### PR TITLE
Add initial migrations and models for shooting log domain

### DIFF
--- a/app/Enums/Deviation.php
+++ b/app/Enums/Deviation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum Deviation: string
+{
+    case LEFT = 'left';
+    case RIGHT = 'right';
+    case HIGH = 'high';
+    case LOW = 'low';
+    case NONE = 'none';
+}

--- a/app/Enums/WeaponType.php
+++ b/app/Enums/WeaponType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum WeaponType: string
+{
+    case PISTOL = 'pistool';
+    case RIFLE = 'geweer';
+    case CARBINE = 'karabijn';
+    case REVOLVER = 'revolver';
+    case SHOTGUN = 'hagelgeweer';
+    case OTHER = 'overig';
+}

--- a/app/Models/AiReflection.php
+++ b/app/Models/AiReflection.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AiReflection extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'session_id',
+        'summary',
+        'positives',
+        'improvements',
+        'next_focus',
+    ];
+
+    protected $casts = [
+        'positives' => 'array',
+        'improvements' => 'array',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(Session::class);
+    }
+}

--- a/app/Models/AiWeaponInsight.php
+++ b/app/Models/AiWeaponInsight.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AiWeaponInsight extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'weapon_id',
+        'summary',
+        'patterns',
+        'suggestions',
+    ];
+
+    protected $casts = [
+        'patterns' => 'array',
+        'suggestions' => 'array',
+    ];
+
+    public function weapon()
+    {
+        return $this->belongsTo(Weapon::class);
+    }
+}

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Attachment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'session_id',
+        'path',
+        'original_name',
+        'mime_type',
+        'size',
+    ];
+
+    protected $casts = [
+        'size' => 'integer',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(Session::class);
+    }
+}

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Session extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'date',
+        'range_name',
+        'location',
+        'notes_raw',
+        'manual_reflection',
+    ];
+
+    protected $casts = [
+        'date' => 'date',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function sessionWeapons()
+    {
+        return $this->hasMany(SessionWeapon::class);
+    }
+
+    public function attachments()
+    {
+        return $this->hasMany(Attachment::class);
+    }
+
+    public function aiReflection()
+    {
+        return $this->hasOne(AiReflection::class);
+    }
+}

--- a/app/Models/SessionWeapon.php
+++ b/app/Models/SessionWeapon.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Deviation;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SessionWeapon extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'session_id',
+        'weapon_id',
+        'distance_m',
+        'rounds_fired',
+        'ammo_type',
+        'group_quality_text',
+        'deviation',
+        'flyers_count',
+    ];
+
+    protected $casts = [
+        'distance_m' => 'integer',
+        'rounds_fired' => 'integer',
+        'flyers_count' => 'integer',
+        'deviation' => Deviation::class,
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(Session::class);
+    }
+
+    public function weapon()
+    {
+        return $this->belongsTo(Weapon::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    use HasFactory;
+    use Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    protected $casts = [
+        'email_verified_at' => 'datetime',
+        'password' => 'hashed',
+    ];
+
+    public function sessions()
+    {
+        return $this->hasMany(Session::class);
+    }
+
+    public function weapons()
+    {
+        return $this->hasMany(Weapon::class);
+    }
+}

--- a/app/Models/Weapon.php
+++ b/app/Models/Weapon.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\WeaponType;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Weapon extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'weapon_type',
+        'caliber',
+        'serial_number',
+        'storage_location',
+        'owned_since',
+        'is_active',
+        'notes',
+    ];
+
+    protected $casts = [
+        'owned_since' => 'date',
+        'is_active' => 'boolean',
+        'weapon_type' => WeaponType::class,
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function sessionWeapons()
+    {
+        return $this->hasMany(SessionWeapon::class);
+    }
+
+    public function aiWeaponInsight()
+    {
+        return $this->hasOne(AiWeaponInsight::class);
+    }
+}

--- a/database/migrations/2024_01_01_000000_create_users_table.php
+++ b/database/migrations/2024_01_01_000000_create_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/migrations/2024_01_01_010000_create_weapons_table.php
+++ b/database/migrations/2024_01_01_010000_create_weapons_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('weapons', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('weapon_type', 50);
+            $table->string('caliber', 50);
+            $table->string('serial_number')->nullable();
+            $table->string('storage_location')->nullable();
+            $table->date('owned_since')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'serial_number']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('weapons');
+    }
+};

--- a/database/migrations/2024_01_01_020000_create_sessions_table.php
+++ b/database/migrations/2024_01_01_020000_create_sessions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->date('date');
+            $table->string('range_name')->nullable();
+            $table->string('location')->nullable();
+            $table->longText('notes_raw')->nullable();
+            $table->text('manual_reflection')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sessions');
+    }
+};

--- a/database/migrations/2024_01_01_030000_create_session_weapons_table.php
+++ b/database/migrations/2024_01_01_030000_create_session_weapons_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('session_weapons', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('session_id')->constrained('sessions')->cascadeOnDelete();
+            $table->foreignId('weapon_id')->constrained('weapons')->cascadeOnDelete();
+            $table->unsignedInteger('distance_m')->nullable();
+            $table->unsignedInteger('rounds_fired')->default(0);
+            $table->string('ammo_type')->nullable();
+            $table->string('group_quality_text')->nullable();
+            $table->string('deviation', 20)->nullable();
+            $table->unsignedInteger('flyers_count')->default(0);
+            $table->timestamps();
+
+            $table->unique(['session_id', 'weapon_id', 'distance_m']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('session_weapons');
+    }
+};

--- a/database/migrations/2024_01_01_040000_create_attachments_table.php
+++ b/database/migrations/2024_01_01_040000_create_attachments_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('attachments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('session_id')->constrained('sessions')->cascadeOnDelete();
+            $table->string('path');
+            $table->string('original_name');
+            $table->string('mime_type', 100);
+            $table->unsignedBigInteger('size');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('attachments');
+    }
+};

--- a/database/migrations/2024_01_01_050000_create_ai_reflections_table.php
+++ b/database/migrations/2024_01_01_050000_create_ai_reflections_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ai_reflections', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('session_id')->unique()->constrained('sessions')->cascadeOnDelete();
+            $table->text('summary');
+            $table->json('positives')->nullable();
+            $table->json('improvements')->nullable();
+            $table->text('next_focus')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_reflections');
+    }
+};

--- a/database/migrations/2024_01_01_060000_create_ai_weapon_insights_table.php
+++ b/database/migrations/2024_01_01_060000_create_ai_weapon_insights_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ai_weapon_insights', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('weapon_id')->unique()->constrained('weapons')->cascadeOnDelete();
+            $table->text('summary');
+            $table->json('patterns')->nullable();
+            $table->json('suggestions')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_weapon_insights');
+    }
+};


### PR DESCRIPTION
## Summary
- add initial Laravel-style migrations for users, weapons, sessions, session_weapons, attachments, ai_reflections, and ai_weapon_insights
- introduce enums for weapon type and deviation values with casts on related models
- create Eloquent models with fillable fields and relationships for the shooting log domain

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922bcbca7fc833387e18d73c62d7675)