### PR TITLE
Add AI shooter coach service integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+APP_NAME=AimTrack
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+AI_DRIVER=openai
+AI_MODEL=gpt-4.1-mini
+OPENAI_API_KEY=your-openai-api-key
+OPENAI_BASE_URL=https://api.openai.com/v1

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -3,7 +3,9 @@
 namespace App\Filament\Resources;
 
 use App\Enums\Deviation;
+use App\Jobs\GenerateSessionReflectionJob;
 use App\Models\Session;
+use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
@@ -26,6 +28,7 @@ use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Filament\Notifications\Notification;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class SessionResource extends Resource
@@ -225,6 +228,19 @@ class SessionResource extends Resource
             ->actions([
                 Actions\ViewAction::make(),
                 Actions\EditAction::make(),
+                Action::make('generateAiReflection')
+                    ->label('Genereer AI-reflectie nu')
+                    ->icon('heroicon-m-sparkles')
+                    ->requiresConfirmation()
+                    ->action(function (Session $record): void {
+                        GenerateSessionReflectionJob::dispatch($record);
+
+                        Notification::make()
+                            ->title('AI-reflectie ingepland')
+                            ->body('De job is toegevoegd aan de wachtrij.')
+                            ->success()
+                            ->send();
+                    }),
             ])
             ->bulkActions([
                 Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/SessionResource/Pages/ViewSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/ViewSession.php
@@ -18,7 +18,7 @@ class ViewSession extends ViewRecord
             Actions\EditAction::make()
                 ->label('Bewerken'),
             Actions\Action::make('regenerateAi')
-                ->label('AI-reflectie opnieuw genereren')
+                ->label('Genereer AI-reflectie nu')
                 ->icon('heroicon-m-sparkles')
                 ->color('primary')
                 ->requiresConfirmation()

--- a/app/Filament/Resources/WeaponResource.php
+++ b/app/Filament/Resources/WeaponResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Enums\WeaponType;
+use App\Jobs\GenerateWeaponInsightJob;
 use App\Models\Weapon;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Hidden;
@@ -21,6 +22,8 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Filament\Notifications\Notification;
+use Filament\Tables\Actions\Action;
 
 class WeaponResource extends Resource
 {
@@ -126,6 +129,19 @@ class WeaponResource extends Resource
             ->actions([
                 Actions\ViewAction::make(),
                 Actions\EditAction::make(),
+                Action::make('generateAiWeaponInsight')
+                    ->label('Genereer AI-inzichten nu')
+                    ->icon('heroicon-m-sparkles')
+                    ->requiresConfirmation()
+                    ->action(function (Weapon $record): void {
+                        GenerateWeaponInsightJob::dispatch($record);
+
+                        Notification::make()
+                            ->title('AI-inzichten ingepland')
+                            ->body('De job is toegevoegd aan de wachtrij.')
+                            ->success()
+                            ->send();
+                    }),
             ])
             ->bulkActions([
                 Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/WeaponResource/Pages/ViewWeapon.php
+++ b/app/Filament/Resources/WeaponResource/Pages/ViewWeapon.php
@@ -18,7 +18,7 @@ class ViewWeapon extends ViewRecord
             Actions\EditAction::make()
                 ->label('Bewerken'),
             Actions\Action::make('generateAi')
-                ->label('AI-inzichten genereren')
+                ->label('Genereer AI-inzichten nu')
                 ->icon('heroicon-m-sparkles')
                 ->color('primary')
                 ->requiresConfirmation()

--- a/app/Jobs/GenerateSessionReflectionJob.php
+++ b/app/Jobs/GenerateSessionReflectionJob.php
@@ -3,11 +3,14 @@
 namespace App\Jobs;
 
 use App\Models\Session;
+use App\Services\Ai\ShooterCoach;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class GenerateSessionReflectionJob implements ShouldQueue
 {
@@ -22,6 +25,13 @@ class GenerateSessionReflectionJob implements ShouldQueue
 
     public function handle(): void
     {
-        // TODO: invullen met AI-call via ShooterCoach service.
+        try {
+            ShooterCoach::make()->generateSessionReflection($this->session->fresh(['sessionWeapons.weapon']));
+        } catch (Throwable $exception) {
+            Log::error('AI: genereren sessiereflectie mislukt', [
+                'session_id' => $this->session->id,
+                'error' => $exception->getMessage(),
+            ]);
+        }
     }
 }

--- a/app/Jobs/GenerateWeaponInsightJob.php
+++ b/app/Jobs/GenerateWeaponInsightJob.php
@@ -3,11 +3,14 @@
 namespace App\Jobs;
 
 use App\Models\Weapon;
+use App\Services\Ai\ShooterCoach;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class GenerateWeaponInsightJob implements ShouldQueue
 {
@@ -22,6 +25,13 @@ class GenerateWeaponInsightJob implements ShouldQueue
 
     public function handle(): void
     {
-        // TODO: invullen met AI-call via ShooterCoach service.
+        try {
+            ShooterCoach::make()->generateWeaponInsight($this->weapon->fresh(['sessionWeapons.session']));
+        } catch (Throwable $exception) {
+            Log::error('AI: genereren wapeninzichten mislukt', [
+                'weapon_id' => $this->weapon->id,
+                'error' => $exception->getMessage(),
+            ]);
+        }
     }
 }

--- a/app/Services/Ai/ShooterCoach.php
+++ b/app/Services/Ai/ShooterCoach.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace App\Services\Ai;
+
+use App\Models\AiReflection;
+use App\Models\AiWeaponInsight;
+use App\Models\Session;
+use App\Models\SessionWeapon;
+use App\Models\Weapon;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+class ShooterCoach
+{
+    public function __construct(
+        private readonly string $driver = '',
+        private readonly string $model = '',
+        private readonly ?string $baseUrl = null,
+        private readonly ?string $apiKey = null,
+    ) {
+    }
+
+    public static function make(): self
+    {
+        $config = config('ai');
+
+        return new self(
+            driver: $config['driver'] ?? 'openai',
+            model: $config['model'] ?? 'gpt-4.1-mini',
+            baseUrl: $config['base_url'] ?? null,
+            apiKey: $config['api_key'] ?? env('OPENAI_API_KEY'),
+        );
+    }
+
+    public function generateSessionReflection(Session $session): AiReflection
+    {
+        $prompt = $this->buildSessionPrompt($session);
+        $rawContent = $this->callModel($prompt);
+        $parsed = $this->parseReflectionPayload($rawContent);
+
+        return $session->aiReflection()->updateOrCreate([], $parsed);
+    }
+
+    public function generateWeaponInsight(Weapon $weapon): AiWeaponInsight
+    {
+        $prompt = $this->buildWeaponPrompt($weapon);
+        $rawContent = $this->callModel($prompt);
+        $parsed = $this->parseWeaponPayload($rawContent);
+
+        return $weapon->aiWeaponInsight()->updateOrCreate([], $parsed);
+    }
+
+    public function answerCoachQuestion($user, string $question): string
+    {
+        $prompt = $this->buildCoachPrompt((string) $question);
+
+        return $this->callModel($prompt);
+    }
+
+    private function callModel(string $prompt): string
+    {
+        if (blank($this->apiKey)) {
+            Log::error('AI: geen API key geconfigureerd.');
+
+            return 'AI-configuratie ontbreekt. Voeg een API key toe om antwoorden te genereren.';
+        }
+
+        $payload = [
+            'model' => $this->model,
+            'messages' => [
+                [
+                    'role' => 'system',
+                    'content' => $this->systemContext(),
+                ],
+                [
+                    'role' => 'user',
+                    'content' => $prompt,
+                ],
+            ],
+            'response_format' => ['type' => 'json_object'],
+        ];
+
+        try {
+            $response = Http::baseUrl($this->baseUrl ?: 'https://api.openai.com/v1')
+                ->timeout(30)
+                ->withToken($this->apiKey)
+                ->acceptJson()
+                ->post('/chat/completions', $payload);
+
+            if (! $response->successful()) {
+                Log::error('AI: fout bij API-call', ['status' => $response->status(), 'body' => $response->body()]);
+
+                return 'Geen AI-antwoord beschikbaar (API-fout).';
+            }
+
+            $content = data_get($response->json(), 'choices.0.message.content');
+
+            return is_string($content) ? $content : json_encode($content) ?: '';
+        } catch (Throwable $exception) {
+            Log::error('AI: exception tijdens API-call', [
+                'message' => $exception->getMessage(),
+            ]);
+
+            return 'Geen AI-antwoord beschikbaar (technical error).';
+        }
+    }
+
+    private function buildSessionPrompt(Session $session): string
+    {
+        $weaponLines = $session->sessionWeapons
+            ->map(fn (SessionWeapon $entry) => sprintf(
+                '- %s | afstand: %sm | patronen: %s | munitie: %s | afwijking: %s | groepering: %s',
+                $entry->weapon?->name ?? 'Onbekend wapen',
+                $entry->distance_m ?? 'n.v.t.',
+                $entry->rounds_fired ?? '0',
+                $entry->ammo_type ?? 'onbekend',
+                $entry->deviation ?? 'n.v.t.',
+                Str::limit($entry->group_quality_text ?? '-', 120)
+            ))
+            ->filter()
+            ->values()
+            ->join("\n");
+
+        $manualReflection = $session->manual_reflection ? "Handmatige reflectie gebruiker: {$session->manual_reflection}" : 'Geen handmatige reflectie ingevoerd.';
+
+        return trim(<<<PROMPT
+Je bent een AI-coach voor sportschutters. Geef veilige, constructieve adviezen, geen illegale of gevaarlijke tips.
+
+Context sessie:
+- Datum: {$session->date?->format('Y-m-d')}
+- Locatie/baan: {$session->range_name} ({$session->location})
+- Ruwe notities: {$session->notes_raw}
+- Wapenregels:
+{$weaponLines}
+- {$manualReflection}
+
+Gevraagde output: JSON met velden summary (string), positives (array van strings), improvements (array van strings), next_focus (string).
+PROMPT);
+    }
+
+    private function buildWeaponPrompt(Weapon $weapon): string
+    {
+        $recentEntries = $weapon->sessionWeapons()->latest('created_at')->take(5)->get();
+        $entriesText = $recentEntries
+            ->map(fn (SessionWeapon $entry) => sprintf(
+                '- %s op %s m, %s schoten, afwijking: %s, notitie: %s',
+                $entry->session?->date?->format('Y-m-d') ?? 'onbekende datum',
+                $entry->distance_m ?? 'n.v.t.',
+                $entry->rounds_fired ?? '0',
+                $entry->deviation ?? 'n.v.t.',
+                Str::limit($entry->group_quality_text ?? '-', 120)
+            ))
+            ->filter()
+            ->values()
+            ->join("\n");
+
+        return trim(<<<PROMPT
+Je bent een AI-coach voor sportschutters. Analyseer trends per wapen en geef veilige aanbevelingen.
+
+Wapen:
+- Naam: {$weapon->name}
+- Type: {$weapon->weapon_type?->value}
+- Kaliber: {$weapon->caliber}
+- Serienummer: {$weapon->serial_number}
+- Opslaglocatie: {$weapon->storage_location}
+
+Recente sessies (max 5):
+{$entriesText}
+
+Gevraagde output: JSON met velden summary (string), patterns (array van strings), suggestions (array van strings).
+PROMPT);
+    }
+
+    private function buildCoachPrompt(string $question): string
+    {
+        return trim(<<<PROMPT
+Je bent een persoonlijke AI-schietcoach. Antwoord beknopt in het Nederlands, focus op veiligheid en legaal handelen.
+Vraag: {$question}
+
+Antwoord in maximaal 120 woorden.
+PROMPT);
+    }
+
+    private function parseReflectionPayload(string $raw): array
+    {
+        $data = json_decode($raw, true);
+
+        if (! is_array($data)) {
+            return [
+                'summary' => $raw,
+                'positives' => [],
+                'improvements' => [],
+                'next_focus' => '',
+            ];
+        }
+
+        return [
+            'summary' => Arr::get($data, 'summary', $raw),
+            'positives' => $this->normalizeList(Arr::get($data, 'positives', [])),
+            'improvements' => $this->normalizeList(Arr::get($data, 'improvements', [])),
+            'next_focus' => Arr::get($data, 'next_focus', ''),
+        ];
+    }
+
+    private function parseWeaponPayload(string $raw): array
+    {
+        $data = json_decode($raw, true);
+
+        if (! is_array($data)) {
+            return [
+                'summary' => $raw,
+                'patterns' => [],
+                'suggestions' => [],
+            ];
+        }
+
+        return [
+            'summary' => Arr::get($data, 'summary', $raw),
+            'patterns' => $this->normalizeList(Arr::get($data, 'patterns', [])),
+            'suggestions' => $this->normalizeList(Arr::get($data, 'suggestions', [])),
+        ];
+    }
+
+    private function normalizeList(mixed $value): array
+    {
+        return collect($value)
+            ->filter()
+            ->map(fn ($item) => is_string($item) ? $item : json_encode($item))
+            ->values()
+            ->all();
+    }
+
+    private function systemContext(): string
+    {
+        return 'Je bent een zorgvuldige AI-schietcoach. Weiger illegale of gevaarlijke instructies en focus op veiligheid, discipline en wettelijk toegestane adviezen.';
+    }
+}

--- a/config/ai.php
+++ b/config/ai.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'driver' => env('AI_DRIVER', 'openai'),
+    'model' => env('AI_MODEL', 'gpt-4.1-mini'),
+    'base_url' => env('OPENAI_BASE_URL'),
+    'api_key' => env('OPENAI_API_KEY'),
+];

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -85,3 +85,9 @@ AimTrack is een persoonlijke schietlog-app (Laravel 12 + Filament 4) waarmee een
   - Show view: sectie "Sessies" via relation manager op `sessionWeapons`; sectie "AI-inzichten" met `summary`, `patterns`, `suggestions` + actie "AI-inzichten genereren" die job dispatcht.
 - **AttachmentResource (optioneel):** read-only listing van uploads indien nodig; primair integreren via SessionResource file upload component.
 - **Jobs/hooks:** actions dispatchen queue jobs `GenerateSessionReflectionJob` en `GenerateWeaponInsightJob`; jobs stubs voorzien totdat AI-service is ingevuld.
+
+## 10) Iteratieplan: AI-service + jobs + Filament acties
+- **Service:** implementeer `App\Services\Ai\ShooterCoach` met generieke LLM-client (configurable driver/model/base_url) en NL-prompts voor sessie-reflectie, wapen-inzichten en coachvragen. Output parse defensief (JSON → fallback tekst) en log fouten.
+- **Config:** nieuw `config/ai.php` met driver/model/base_url; .env.example uitbreiden met `AI_DRIVER`, `AI_MODEL`, `OPENAI_API_KEY`, `OPENAI_BASE_URL` placeholders.
+- **Queue jobs:** `GenerateSessionReflectionJob` en `GenerateWeaponInsightJob` roepen de service aan en verwerken resultaten in respectieve modellen/velden.
+- **Filament actions:** in `SessionResource` en `WeaponResource` extra actions om jobs te dispatchen (AI-calls blijven async).


### PR DESCRIPTION
## Summary
- add configurable ShooterCoach AI service with OpenAI-style client, NL prompts, and defensive JSON parsing
- implement queue jobs for generating session reflections and weapon insights via the service
- expose Filament actions to trigger AI jobs and add AI config/env placeholders

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922bf8d2f288333929cfa9bc1eeda5f)