### PR TITLE
Add session export service and Filament export page

### DIFF
--- a/app/Filament/Pages/ExportSessionsPage.php
+++ b/app/Filament/Pages/ExportSessionsPage.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\Weapon;
+use App\Services\Export\SessionExportService;
+use Carbon\Carbon;
+use Filament\Actions\Action;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Form;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+
+class ExportSessionsPage extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-arrow-down-tray';
+
+    protected static ?string $navigationLabel = 'Export sessies';
+
+    protected static ?string $title = 'Export sessies';
+
+    protected static string $view = 'filament.pages.export-sessions-page';
+
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'from_date' => now()->startOfMonth(),
+            'to_date' => now(),
+            'format' => 'csv',
+        ]);
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make('Parameters')
+                    ->schema([
+                        DatePicker::make('from_date')
+                            ->label('Vanaf datum')
+                            ->native(false)
+                            ->required(),
+                        DatePicker::make('to_date')
+                            ->label('Tot datum')
+                            ->native(false)
+                            ->required(),
+                        Select::make('weapon_ids')
+                            ->label('Wapens (optioneel)')
+                            ->multiple()
+                            ->searchable()
+                            ->options(fn () => $this->weaponOptions())
+                            ->helperText('Laat leeg om alle wapens op te nemen.'),
+                        Select::make('format')
+                            ->label('Formaat')
+                            ->options([
+                                'csv' => 'CSV',
+                                'pdf' => 'PDF',
+                            ])
+                            ->required(),
+                    ])
+                    ->columns(2),
+            ])
+            ->statePath('data');
+    }
+
+    public function submit(SessionExportService $service)
+    {
+        $state = $this->form->getState();
+
+        $from = Carbon::parse($state['from_date']);
+        $to = Carbon::parse($state['to_date']);
+
+        if ($from->greaterThan($to)) {
+            Notification::make()
+                ->title('Ongeldige periode')
+                ->body('De startdatum moet voor of gelijk aan de einddatum zijn.')
+                ->danger()
+                ->send();
+
+            return null;
+        }
+
+        return $service->exportSessions(
+            auth()->user(),
+            $from,
+            $to,
+            $state['weapon_ids'] ?? null,
+            $state['format'] ?? 'csv'
+        );
+    }
+
+    protected function getFormActions(): array
+    {
+        return [
+            Action::make('export')
+                ->label('Exporteren')
+                ->submit('submit')
+                ->icon('heroicon-m-arrow-down-tray'),
+        ];
+    }
+
+    protected function weaponOptions(): Collection
+    {
+        return Weapon::query()
+            ->where('user_id', auth()->id())
+            ->orderBy('name')
+            ->pluck('name', 'id');
+    }
+}

--- a/app/Services/Export/SessionExportService.php
+++ b/app/Services/Export/SessionExportService.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Services\Export;
+
+use App\Models\Session;
+use App\Models\User;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Carbon\Carbon;
+use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class SessionExportService
+{
+    /**
+     * Exporteer sessies van een gebruiker binnen een periode en optionele wapenfilter.
+     */
+    public function exportSessions(User $user, Carbon $from, Carbon $to, ?array $weaponIds, string $format): Response|StreamedResponse
+    {
+        $sessions = Session::query()
+            ->with(['sessionWeapons.weapon'])
+            ->where('user_id', $user->getKey())
+            ->whereBetween('date', [$from->toDateString(), $to->toDateString()])
+            ->when($weaponIds, fn ($query) => $query->whereHas(
+                'sessionWeapons',
+                fn ($subQuery) => $subQuery->whereIn('weapon_id', $weaponIds)
+            ))
+            ->orderBy('date')
+            ->get();
+
+        return $format === 'pdf'
+            ? $this->exportPdf($sessions, $from, $to)
+            : $this->exportCsv($sessions, $from, $to);
+    }
+
+    protected function exportCsv(Collection $sessions, Carbon $from, Carbon $to): StreamedResponse
+    {
+        $filename = sprintf('sessions_%s_%s.csv', $from->format('Ymd'), $to->format('Ymd'));
+        $headers = [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+        ];
+
+        $columns = [
+            'Datum',
+            'Baan',
+            'Locatie',
+            'Wapen',
+            'Kaliber',
+            'Afstand (m)',
+            'Rondes',
+            'Munitietype',
+            'Groepering',
+            'Afwijking',
+            'Flyers',
+            'Notities',
+        ];
+
+        return response()->streamDownload(function () use ($sessions, $columns): void {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, $columns);
+
+            foreach ($sessions as $session) {
+                $entries = $session->sessionWeapons;
+
+                if ($entries->isEmpty()) {
+                    fputcsv($handle, [
+                        $session->date?->format('Y-m-d'),
+                        $session->range_name,
+                        $session->location,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        $session->notes_raw,
+                    ]);
+                    continue;
+                }
+
+                foreach ($entries as $entry) {
+                    $weapon = $entry->weapon;
+
+                    fputcsv($handle, [
+                        $session->date?->format('Y-m-d'),
+                        $session->range_name,
+                        $session->location,
+                        $weapon?->name,
+                        $weapon?->caliber,
+                        $entry->distance_m,
+                        $entry->rounds_fired,
+                        $entry->ammo_type,
+                        $entry->group_quality_text,
+                        $entry->deviation?->value ?? $entry->deviation,
+                        $entry->flyers_count,
+                        $session->notes_raw,
+                    ]);
+                }
+            }
+
+            fclose($handle);
+        }, $filename, $headers);
+    }
+
+    protected function exportPdf(Collection $sessions, Carbon $from, Carbon $to): Response
+    {
+        $totals = $this->aggregateTotals($sessions);
+
+        $pdf = Pdf::loadView('exports.sessions', [
+            'sessions' => $sessions,
+            'from' => $from,
+            'to' => $to,
+            'totals' => $totals,
+            'disclaimer' => 'Let op: dit document is een hulpmiddel; controleer altijd zelf of dit voldoet aan de actuele eisen van de politie / korpschef voor een WM-4 aanvraag.',
+        ]);
+
+        $filename = sprintf('sessions_%s_%s.pdf', $from->format('Ymd'), $to->format('Ymd'));
+
+        return $pdf->download($filename);
+    }
+
+    protected function aggregateTotals(Collection $sessions): Collection
+    {
+        return $sessions
+            ->flatMap(fn ($session) => $session->sessionWeapons)
+            ->groupBy(function ($entry) {
+                $weapon = $entry->weapon;
+
+                return $weapon?->name . '|' . ($weapon?->caliber ?? 'onbekend');
+            })
+            ->map(function ($entries, $key) {
+                [$weaponName, $caliber] = explode('|', $key);
+
+                return [
+                    'weapon' => $weaponName ?: 'Onbekend wapen',
+                    'caliber' => $caliber,
+                    'sessions' => $entries->unique('session_id')->count(),
+                    'rounds' => $entries->sum('rounds_fired'),
+                ];
+            })
+            ->values();
+    }
+}

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -86,6 +86,13 @@ AimTrack is een persoonlijke schietlog-app (Laravel 12 + Filament 4) waarmee een
 - **AttachmentResource (optioneel):** read-only listing van uploads indien nodig; primair integreren via SessionResource file upload component.
 - **Jobs/hooks:** actions dispatchen queue jobs `GenerateSessionReflectionJob` en `GenerateWeaponInsightJob`; jobs stubs voorzien totdat AI-service is ingevuld.
 
+## 11) Export-scope voor WM-4 (huidige iteratie)
+- **Service:** `App\Services\Export\SessionExportService` met methode `exportSessions(User $user, Carbon $from, Carbon $to, ?array $weaponIds, string $format)` die sessies binnen periode ophaalt (optionele wapenfilter) en een downloadresponse teruggeeft.
+- **CSV-output:** kolommen `datum, baan, locatie, wapen, kaliber, afstand (m), rondes, munitietype, groepering, afwijking, flyers, notities`; per sessiewapen een regel.
+- **PDF-output:** eenvoudige Blade-view (`resources/views/exports/sessions.blade.php`) met periode-overzicht, totalen per wapen/kaliber, lijst van sessies en NL-disclaimer: "Let op: dit document is een hulpmiddel; controleer altijd zelf of dit voldoet aan de actuele eisen van de politie / korpschef voor een WM-4 aanvraag." PDF-rendering via een lichte lib (bijv. Dompdf) zonder zware styling.
+- **Filament Page:** `App\Filament\Pages\ExportSessionsPage` met formulier (van/tot, multi-select wapens, formaatkeuze CSV/PDF) en actie die service aanroept en download terugstuurt.
+- **Uitbreidbaarheid:** structuur laten voor extra exportprofielen (aparte view/logica), en rekening houden met single-tenant (alle queries gefilterd op ingelogde gebruiker).
+
 ## 10) Iteratieplan: AI-service + jobs + Filament acties
 - **Service:** implementeer `App\Services\Ai\ShooterCoach` met generieke LLM-client (configurable driver/model/base_url) en NL-prompts voor sessie-reflectie, wapen-inzichten en coachvragen. Output parse defensief (JSON → fallback tekst) en log fouten.
 - **Config:** nieuw `config/ai.php` met driver/model/base_url; .env.example uitbreiden met `AI_DRIVER`, `AI_MODEL`, `OPENAI_API_KEY`, `OPENAI_BASE_URL` placeholders.

--- a/resources/views/exports/sessions.blade.php
+++ b/resources/views/exports/sessions.blade.php
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>Schietsessies export</title>
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; color: #111; }
+        h1, h2 { margin-bottom: 0; }
+        .small { font-size: 11px; color: #444; }
+        table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+        th, td { border: 1px solid #ccc; padding: 6px; text-align: left; }
+        th { background: #f7f7f7; }
+        .muted { color: #555; }
+    </style>
+</head>
+<body>
+    <h1>Overzicht schietsessies</h1>
+    <p class="small">Periode: {{ $from->toFormattedDateString() }} t/m {{ $to->toFormattedDateString() }}</p>
+
+    <h2>Samenvatting per wapen/kaliber</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Wapen</th>
+                <th>Kaliber</th>
+                <th>Aantal sessies</th>
+                <th>Afgevuurde rondes</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($totals as $total)
+                <tr>
+                    <td>{{ $total['weapon'] }}</td>
+                    <td>{{ $total['caliber'] }}</td>
+                    <td>{{ $total['sessions'] }}</td>
+                    <td>{{ $total['rounds'] }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4">Geen sessies in deze periode.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <h2>Sessies</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Datum</th>
+                <th>Baan</th>
+                <th>Locatie</th>
+                <th>Wapen</th>
+                <th>Kaliber</th>
+                <th>Afstand (m)</th>
+                <th>Rondes</th>
+                <th>Munitietype</th>
+                <th>Groepering</th>
+                <th>Afwijking</th>
+                <th>Flyers</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($sessions as $session)
+                @php $entries = $session->sessionWeapons; @endphp
+                @if ($entries->isEmpty())
+                    <tr>
+                        <td>{{ $session->date?->format('Y-m-d') }}</td>
+                        <td>{{ $session->range_name }}</td>
+                        <td>{{ $session->location }}</td>
+                        <td colspan="8" class="muted">Geen wapens geregistreerd</td>
+                    </tr>
+                @else
+                    @foreach ($entries as $entry)
+                        <tr>
+                            <td>{{ $session->date?->format('Y-m-d') }}</td>
+                            <td>{{ $session->range_name }}</td>
+                            <td>{{ $session->location }}</td>
+                            <td>{{ $entry->weapon?->name }}</td>
+                            <td>{{ $entry->weapon?->caliber }}</td>
+                            <td>{{ $entry->distance_m }}</td>
+                            <td>{{ $entry->rounds_fired }}</td>
+                            <td>{{ $entry->ammo_type }}</td>
+                            <td>{{ $entry->group_quality_text }}</td>
+                            <td>{{ $entry->deviation?->value ?? $entry->deviation }}</td>
+                            <td>{{ $entry->flyers_count }}</td>
+                        </tr>
+                    @endforeach
+                @endif
+            @empty
+                <tr>
+                    <td colspan="11">Geen sessies gevonden.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <p class="small" style="margin-top: 14px;">{{ $disclaimer }}</p>
+</body>
+</html>

--- a/resources/views/filament/pages/export-sessions-page.blade.php
+++ b/resources/views/filament/pages/export-sessions-page.blade.php
@@ -1,0 +1,6 @@
+<x-filament::page>
+    <div class="max-w-3xl space-y-4">
+        <p class="text-sm text-gray-600">Kies de periode en (optioneel) specifieke wapens voor je export. Formaat: CSV of PDF.</p>
+        {{ $this->form }}
+    </div>
+</x-filament::page>


### PR DESCRIPTION
## Summary
- document export scope and structure in the PLAN for WM-4 style reports
- add SessionExportService to stream CSV or PDF exports with weapon totals and disclaimer
- add Filament ExportSessionsPage with filters and views for CSV/PDF download plus PDF layout template

## Testing
- not run (environment only contains stubs)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c160389c8333875e335a16ad0b30)