### PR TITLE
Add AI coach page with question history

### DIFF
--- a/app/Filament/Pages/AiCoachPage.php
+++ b/app/Filament/Pages/AiCoachPage.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\CoachQuestion;
+use App\Models\Weapon;
+use App\Services\Ai\ShooterCoach;
+use Carbon\Carbon;
+use Filament\Actions\Action;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+
+class AiCoachPage extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static ?string $navigationIcon = 'heroicon-o-sparkles';
+
+    protected static ?string $navigationLabel = 'AI-coach';
+
+    protected static ?string $title = 'AI-coach';
+
+    protected static string $view = 'filament.pages.ai-coach-page';
+
+    public ?array $data = [];
+
+    public ?string $answer = null;
+
+    public Collection $history;
+
+    public function mount(): void
+    {
+        $this->form->fill([
+            'question' => '',
+            'weapon_id' => null,
+            'from_date' => null,
+            'to_date' => null,
+        ]);
+
+        $this->loadHistory();
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make('Stel je vraag')
+                    ->description('De AI-coach gebruikt alleen jouw eigen logs als context en geeft geen vervanging voor erkende instructeurs of officiële regels.')
+                    ->schema([
+                        Textarea::make('question')
+                            ->label('Vraag aan AI-coach')
+                            ->placeholder('Bijvoorbeeld: hoe kan ik mijn consistentie op 25m met mijn pistool verbeteren?')
+                            ->rows(5)
+                            ->required(),
+                        Section::make('Context (optioneel)')
+                            ->schema([
+                                Select::make('weapon_id')
+                                    ->label('Specifiek wapen')
+                                    ->native(false)
+                                    ->options(fn () => $this->weaponOptions())
+                                    ->searchable()
+                                    ->placeholder('Alle wapens'),
+                                DatePicker::make('from_date')
+                                    ->label('Vanaf datum')
+                                    ->native(false),
+                                DatePicker::make('to_date')
+                                    ->label('Tot datum')
+                                    ->native(false),
+                            ])
+                            ->columns(3),
+                    ]),
+            ])
+            ->statePath('data');
+    }
+
+    public function submit(ShooterCoach $coach): void
+    {
+        $state = $this->form->getState();
+
+        $from = isset($state['from_date']) && $state['from_date'] ? Carbon::parse($state['from_date']) : null;
+        $to = isset($state['to_date']) && $state['to_date'] ? Carbon::parse($state['to_date']) : null;
+
+        if ($from && $to && $from->greaterThan($to)) {
+            Notification::make()
+                ->title('Ongeldige periode')
+                ->body('De startdatum moet voor of gelijk aan de einddatum zijn.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $user = auth()->user();
+        $question = (string) ($state['question'] ?? '');
+        $weaponId = $state['weapon_id'] ?? null;
+
+        $this->answer = $coach->answerCoachQuestion($user, $question, $weaponId, $from, $to);
+
+        CoachQuestion::create([
+            'user_id' => $user->id,
+            'weapon_id' => $weaponId ?: null,
+            'question' => $question,
+            'answer' => $this->answer,
+            'asked_at' => now(),
+            'period_from' => $from,
+            'period_to' => $to,
+        ]);
+
+        Notification::make()
+            ->title('AI-coach antwoord klaar')
+            ->success()
+            ->send();
+
+        $this->loadHistory();
+    }
+
+    protected function getFormActions(): array
+    {
+        return [
+            Action::make('ask')
+                ->label('Stel vraag aan AI-coach')
+                ->submit('submit')
+                ->icon('heroicon-m-sparkles'),
+        ];
+    }
+
+    protected function weaponOptions(): Collection
+    {
+        return Weapon::query()
+            ->where('user_id', auth()->id())
+            ->orderBy('name')
+            ->pluck('name', 'id');
+    }
+
+    protected function loadHistory(): void
+    {
+        $this->history = CoachQuestion::query()
+            ->with('weapon')
+            ->where('user_id', auth()->id())
+            ->latest('asked_at')
+            ->latest()
+            ->take(10)
+            ->get();
+    }
+}

--- a/app/Models/CoachQuestion.php
+++ b/app/Models/CoachQuestion.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CoachQuestion extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'weapon_id',
+        'question',
+        'answer',
+        'asked_at',
+        'period_from',
+        'period_to',
+    ];
+
+    protected $casts = [
+        'asked_at' => 'datetime',
+        'period_from' => 'date',
+        'period_to' => 'date',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function weapon()
+    {
+        return $this->belongsTo(Weapon::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,4 +36,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Weapon::class);
     }
+
+    public function coachQuestions()
+    {
+        return $this->hasMany(CoachQuestion::class);
+    }
 }

--- a/app/Models/Weapon.php
+++ b/app/Models/Weapon.php
@@ -42,4 +42,9 @@ class Weapon extends Model
     {
         return $this->hasOne(AiWeaponInsight::class);
     }
+
+    public function coachQuestions()
+    {
+        return $this->hasMany(CoachQuestion::class);
+    }
 }

--- a/database/migrations/2024_01_01_090000_create_coach_questions_table.php
+++ b/database/migrations/2024_01_01_090000_create_coach_questions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('coach_questions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('weapon_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('question');
+            $table->longText('answer')->nullable();
+            $table->timestamp('asked_at')->nullable();
+            $table->date('period_from')->nullable();
+            $table->date('period_to')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('coach_questions');
+    }
+};

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -98,3 +98,10 @@ AimTrack is een persoonlijke schietlog-app (Laravel 12 + Filament 4) waarmee een
 - **Config:** nieuw `config/ai.php` met driver/model/base_url; .env.example uitbreiden met `AI_DRIVER`, `AI_MODEL`, `OPENAI_API_KEY`, `OPENAI_BASE_URL` placeholders.
 - **Queue jobs:** `GenerateSessionReflectionJob` en `GenerateWeaponInsightJob` roepen de service aan en verwerken resultaten in respectieve modellen/velden.
 - **Filament actions:** in `SessionResource` en `WeaponResource` extra actions om jobs te dispatchen (AI-calls blijven async).
+
+## 12) Iteratie: AI-Coach vrije vragen page (huidige taak)
+- **Doel:** Filament-pagina `AiCoachPage` waar gebruiker vrije vragen kan stellen over eigen sessies/wapens, met optionele filters (wapen + periode) en veiligheid/disclaimer in UI + prompt.
+- **Datamodel:** nieuwe tabel `coach_questions` met `id, user_id (fk), weapon_id (nullable), question, answer, asked_at (timestamp), period_from/to (nullable), created_at/updated_at`. Relaties: User hasMany CoachQuestions; Weapon hasMany CoachQuestions; CoachQuestion belongsTo User en Weapon.
+- **Service-uitbreiding:** `ShooterCoach::answerCoachQuestion(User $user, string $question, ?int $weaponId = null, ?Carbon $from = null, ?Carbon $to = null)` bouwt context: relevante sessies van user gefilterd op periode/wapen + recente wapen entries; prompt benadrukt veiligheid/geen illegale tips en dat AI geen vervanging is voor instructeurs/regels. Retourneert antwoordstring.
+- **Filament Page:** `AiCoachPage` met textarea vraag, select wapen (optioneel), date range filter, submit-button "Stel vraag aan AI-coach", resultaatkaart met antwoord (en waarschuwing dat AI geen vervanging is). Na submit: roept ShooterCoach aan, slaat vraag/antwoord op in `coach_questions` en toont laatste antwoord. Toon recente historie (bijv. table/list van vorige Q/A van gebruiker) voor context.
+- **Veiligheid:** System prompt + UI bevatten disclaimer over veiligheid, geen illegale/gevaarlijke adviezen; antwoord max ~150 woorden. Geen queue-job nodig (synchrone vraag), maar blijf defensief bij API-fouten (toon melding).

--- a/resources/views/filament/pages/ai-coach-page.blade.php
+++ b/resources/views/filament/pages/ai-coach-page.blade.php
@@ -1,0 +1,52 @@
+@php
+    use Illuminate\Support\Str;
+@endphp
+
+<x-filament::page>
+    <div class="grid gap-6 lg:grid-cols-3">
+        <div class="space-y-4 lg:col-span-2">
+            <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+                <p><strong>Let op:</strong> de AI-coach geeft geen vervanging voor een erkende instructeur of officiële instanties. Volg altijd baanregels, wetgeving en veiligheidsprotocollen.</p>
+            </div>
+
+            <div class="space-y-4">
+                {{ $this->form }}
+            </div>
+
+            @if ($answer)
+                <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                    <div class="flex items-center justify-between">
+                        <h2 class="text-lg font-semibold">Antwoord van de AI-coach</h2>
+                        <span class="text-xs text-gray-500">Context: eigen sessiedata, geen officiële adviezen</span>
+                    </div>
+                    <p class="mt-3 whitespace-pre-line text-gray-800">{{ $answer }}</p>
+                </div>
+            @endif
+        </div>
+
+        <div class="space-y-3">
+            <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                <h3 class="text-md font-semibold">Recente vragen</h3>
+                <p class="text-sm text-gray-600">Alleen jouw eigen vragen en AI-antwoorden worden getoond.</p>
+                <div class="mt-3 space-y-3">
+                    @forelse ($history as $item)
+                        <div class="rounded-md border border-gray-100 bg-gray-50 p-3">
+                            <div class="flex items-center justify-between text-xs text-gray-500">
+                                <span>{{ optional($item->asked_at)->format('d-m-Y H:i') }}</span>
+                                @if ($item->weapon)
+                                    <span class="rounded bg-indigo-50 px-2 py-0.5 text-indigo-700">{{ $item->weapon->name }}</span>
+                                @else
+                                    <span class="text-gray-500">Alle wapens</span>
+                                @endif
+                            </div>
+                            <p class="mt-2 text-sm font-medium text-gray-800">Vraag: {{ Str::limit($item->question, 120) }}</p>
+                            <p class="mt-1 text-sm text-gray-700">Antwoord: {{ Str::limit($item->answer, 180) }}</p>
+                        </div>
+                    @empty
+                        <p class="text-sm text-gray-600">Nog geen vragen gesteld.</p>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+    </div>
+</x-filament::page>


### PR DESCRIPTION
## Summary
- add a Filament AI-coach page with question form, filters, answer panel, and recent history
- extend ShooterCoach to build filtered context for coach answers with safety disclaimers
- introduce coach_questions table/model to persist user AI-coach interactions

## Testing
- php artisan test *(fails: vendor directory not installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c94e480c8333b710351ac36c1989)