### PR TITLE
Tighten user scoping and AI coach wiring

### DIFF
--- a/app/Filament/Resources/AttachmentResource.php
+++ b/app/Filament/Resources/AttachmentResource.php
@@ -64,4 +64,10 @@ class AttachmentResource extends Resource
             'index' => AttachmentResource\Pages\ListAttachments::route('/'),
         ];
     }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereHas('session', fn (Builder $query) => $query->where('user_id', auth()->id()));
+    }
 }

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -49,6 +49,7 @@ class SessionResource extends Resource
             ->schema([
                 Hidden::make('user_id')
                     ->default(fn () => auth()->id())
+                    ->required()
                     ->dehydrated(fn ($state) => filled($state)),
 
                 Section::make('Sessie')
@@ -323,5 +324,11 @@ class SessionResource extends Resource
             'edit' => SessionResource\Pages\EditSession::route('/{record}/edit'),
             'view' => SessionResource\Pages\ViewSession::route('/{record}'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('user_id', auth()->id());
     }
 }

--- a/app/Filament/Resources/WeaponResource.php
+++ b/app/Filament/Resources/WeaponResource.php
@@ -24,6 +24,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Filament\Notifications\Notification;
 use Filament\Tables\Actions\Action;
+use Illuminate\Database\Eloquent\Builder;
 
 class WeaponResource extends Resource
 {
@@ -43,6 +44,7 @@ class WeaponResource extends Resource
             ->schema([
                 Hidden::make('user_id')
                     ->default(fn () => auth()->id())
+                    ->required()
                     ->dehydrated(fn ($state) => filled($state)),
 
                 Section::make('Basisgegevens')
@@ -198,5 +200,11 @@ class WeaponResource extends Resource
             'edit' => WeaponResource\Pages\EditWeapon::route('/{record}/edit'),
             'view' => WeaponResource\Pages\ViewWeapon::route('/{record}'),
         ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('user_id', auth()->id());
     }
 }

--- a/app/Filament/Resources/WeaponResource/RelationManagers/SessionWeaponsRelationManager.php
+++ b/app/Filament/Resources/WeaponResource/RelationManagers/SessionWeaponsRelationManager.php
@@ -2,7 +2,9 @@
 
 namespace App\Filament\Resources\WeaponResource\RelationManagers;
 
+use App\Enums\Deviation;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
@@ -23,6 +25,21 @@ class SessionWeaponsRelationManager extends RelationManager
     {
         return $form
             ->schema([
+                Select::make('session_id')
+                    ->label('Sessie')
+                    ->relationship(
+                        name: 'session',
+                        titleAttribute: 'date',
+                        modifyQueryUsing: fn (Builder $query) => $query->where('user_id', auth()->id()),
+                    )
+                    ->getOptionLabelFromRecordUsing(fn ($record) => sprintf(
+                        '%s - %s (%s)',
+                        optional($record->date)->format('Y-m-d'),
+                        $record->range_name ?? 'onbekend',
+                        $record->location ?? 'locatie n.v.t.',
+                    ))
+                    ->required()
+                    ->searchable(),
                 TextInput::make('distance_m')
                     ->label('Afstand (m)')
                     ->numeric()
@@ -31,6 +48,7 @@ class SessionWeaponsRelationManager extends RelationManager
                     ->label('Patronen')
                     ->numeric()
                     ->minValue(0)
+                    ->default(0)
                     ->required(),
                 TextInput::make('ammo_type')
                     ->label('Munitie')
@@ -39,8 +57,14 @@ class SessionWeaponsRelationManager extends RelationManager
                     ->label('Groepering')
                     ->rows(2)
                     ->columnSpanFull(),
-                TextInput::make('deviation')
-                    ->label('Afwijking'),
+                Select::make('deviation')
+                    ->label('Afwijking')
+                    ->options(
+                        collect(Deviation::cases())
+                            ->mapWithKeys(fn (Deviation $deviation) => [$deviation->value => ucfirst($deviation->value)])
+                            ->all(),
+                    )
+                    ->native(false),
                 TextInput::make('flyers_count')
                     ->label('Flyers')
                     ->numeric()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,13 +2,14 @@
 
 namespace App\Providers;
 
+use App\Services\Ai\ShooterCoach;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        //
+        $this->app->singleton(ShooterCoach::class, fn () => ShooterCoach::make());
     }
 
     public function boot(): void

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -114,3 +114,10 @@ AimTrack is een persoonlijke schietlog-app (Laravel 12 + Filament 4) waarmee een
   - `queue`: hergebruikt het app-image en draait `php artisan queue:work --tries=3`.
 - **Flow:** `docker compose up -d` start stack; daarna `docker compose exec app php artisan key:generate` en `docker compose exec app php artisan migrate` om de app klaar te zetten.
 - **ENV-waarden:** `APP_URL=http://localhost:8080`, `DB_HOST=db`, `DB_PORT=5432`, `QUEUE_CONNECTION=database`, optioneel `VITE_*` voor asset build; AI-variabelen blijven in `.env` staan.
+
+## 14) Stabilisatieplan (eindcontrole)
+- **Relaties en scope:** Sessions, Weapons, SessionWeapons, AiReflection en AiWeaponInsight blijven strikt gekoppeld aan de ingelogde gebruiker; Filament queries filteren op `user_id` of gekoppelde sessies.
+- **AI-flow robuust:** `ShooterCoach` via service container met config uit `config/ai.php`; jobs/pages delen dezelfde service; defensieve foutafhandeling blijft.
+- **Filament polish:** Forms tonen vereiste velden, repeaters werken end-to-end, relation managers bieden filters en CRUD; detailpagina’s tonen AI-output en bijlagen overzichtelijk.
+- **Export afronden:** CSV/PDF gebruiken dezelfde dataset/filtering, tonen disclaimer en aggregaties; Filament exportpagina valideert periode en selectie.
+- **Opschonen:** Geen TODO’s of losse eindjes; labels NL; defaults voor datumfilters (bijv. huidige maand) en statusnotificaties bij async AI-acties.


### PR DESCRIPTION
## Summary
- Bind the ShooterCoach service through the container so pages and jobs share config-driven AI access
- Restrict Filament resources and attachment listings to the signed-in user and improve session-weapon relation inputs
- Extend the stabilization plan document for final codebase verification

## Testing
- composer install --no-interaction --no-progress *(fails: dependency conflicts with Laravel 12 constraints and pest/laravel + dompdf versions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d326ada0833394ee542e3feaee1e)