### PR TITLE
Add QA smoke plan and initial findings

### DIFF
--- a/docs/QA_FINDINGS.md
+++ b/docs/QA_FINDINGS.md
@@ -1,0 +1,26 @@
+# QA Smoke Findings (lokaal)
+
+## Context
+- Doel: smoke-test van core flows (user → wapen → sessie → AI → export → bijlagen → queue).
+- Status: geblokkeerd vóór UI-tests door dependency issues tijdens setup.
+
+## Bevindingen
+1. **Composer install faalt tegen Laravel 12**  
+   - `pestphp/pest-plugin-laravel` vereist Laravel ^10/^11 en blokkeert install.  
+   - `barryvdh/laravel-dompdf` locked tot Laravel ^11.  
+   - Gevolg: geen vendor map, artisan/Filament niet uitvoerbaar → alle handmatige flows geblokkeerd.  
+   - Log: zie composer update foutmelding (dependency conflict).  
+   - Impact: Blocker voor alle smoke-tests; moet eerst dependency matrix naar Laravel 12 geüpdatet worden (wachten op compat releases of alternatieve pakketten kiezen).
+
+2. **Geen composer.lock aanwezig**  
+   - Install draait als `composer update` en haalt laatste versies; zonder lock is CI niet deterministisch.  
+   - Bij huidige conflicts bemoeilijkt dit debugging; lockfile moet toegevoegd zodra dependency-issues zijn opgelost.
+
+3. **Smoke-scenario's niet uitgevoerd**  
+   - Door bovenstaande install-blocker zijn de gevraagde handmatige testen (user/wapen/sessie/AI/export/bijlagen/queue) niet uitvoerbaar in deze run.  
+   - Zodra dependencies gefikst zijn: QA-plan in `docs/QA_PLAN.md` kan direct gevolgd worden voor een volledige smoke-pass.
+
+## Aanpak na fix
+- Dependencies alignen met Laravel 12 (check beschikbaarheid van Pest Laravel plugin en Dompdf voor 12.x of pin tijdelijk naar Laravel 11 als tussenstap).  
+- Lockfile genereren, `.env` opzetten (SQLite/Pg), `php artisan migrate --seed`, queue worker starten.  
+- Daarna QA-plan uitvoeren en resultaten loggen (verwacht binnen 1 run mogelijk als dependencies staan).

--- a/docs/QA_PLAN.md
+++ b/docs/QA_PLAN.md
@@ -1,0 +1,53 @@
+# QA Smoke Plan – AimTrack
+
+## Doel
+Bevestigen dat de basisflows van AimTrack werken: gebruikers aanmaken, wapens registreren, sessies loggen (met bijlagen), AI-acties triggeren en exports genereren. We toetsen alleen MVP-flows zoals beschreven in docs/PLAN.md.
+
+## Omvang
+- Handmatige UI-checks via Filament admin.
+- Backend-acties via queue-jobs (AI reflectie/inzichten).
+- Export (CSV/PDF) genereren.
+- Bijlagen upload.
+- Queue worker async gedrag.
+
+## Testomgeving
+- Laravel 12 + PHP 8.4/8.5.
+- Database: lokale PostgreSQL (of SQLite fallback voor smoke).
+- Queue: database driver met `queue:work`.
+- AI-service: stub/placeholder; fouten loggen is ok zolang UI netjes feedback geeft.
+
+## Testscenario's
+1. **User onboarding**
+   - Inloggen als bestaande admin of nieuwe user registreren.
+   - Controleer Filament toegang, navigatie NL labels.
+
+2. **Wapenbeheer**
+   - Maak een wapen (type, kaliber, serienummer, opslag, notities).
+   - Controleer tabelweergave, filters en relation manager naar sessies.
+
+3. **Sessielog + bijlagen**
+   - Maak een sessie met datum/locatie/notities/handmatige reflectie.
+   - Voeg minstens één sessiewapen (afstand, schoten, munitie, afwijking, flyers).
+   - Upload foto + PDF als bijlage.
+   - Bekijk detailpagina: tabbladen, bijlagen zichtbaar en downloadbaar.
+
+4. **AI-acties**
+   - Vanuit sessie: actie "Genereer AI-reflectie" → job in queue, status zichtbaar.
+   - Vanuit wapen: actie "Genereer AI-inzichten" → job in queue, status zichtbaar.
+   - Controleer foutafhandeling bij mislukte AI-call (melding, status failed zonder crash).
+
+5. **AI-coach page**
+   - Free-form vraag met optioneel wapen + periode; check antwoord + disclaimer.
+   - Historie van vragen zichtbaar.
+
+6. **Export**
+   - Export page: selecteer periode + meerdere wapens, genereer CSV + PDF.
+   - Valideer content/kolommen + disclaimer.
+
+7. **Queue worker**
+   - Start queue worker (database driver) en bevestig dat jobs async afronden zonder exceptions.
+   - Inspecteer `failed_jobs` blijft leeg.
+
+## Rapportage
+- Noteer per scenario: status (OK/minor/blocked) + observaties/bugs.
+- Verzamel relevante logs/stacktraces of terminal output voor regressies.


### PR DESCRIPTION
## Summary
- Add a QA smoke plan outlining manual test scenarios for the core AimTrack flows
- Document the initial QA findings noting dependency conflicts blocking smoke testing

## Testing
- composer install --no-interaction --prefer-dist *(fails: dependency conflict with Laravel 12 and Pest/Dompdf packages)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d4990f7083339c4f15fdcf461886)