### PR TITLE
Update Pest and Dompdf versions for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         "laravel/tinker": "^2.10",
         "livewire/livewire": "^3.0",
         "filament/filament": "^4.0",
-        "barryvdh/laravel-dompdf": "^2.0"
+        "barryvdh/laravel-dompdf": "^3.0"
     },
     "require-dev": {
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-laravel": "^2.4",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
         "laravel/pint": "^1.24",
         "fakerphp/faker": "^1.23",
         "nunomaduro/collision": "^8.6"


### PR DESCRIPTION
## Summary
- bump pestphp/pest and pest-plugin-laravel to v4 for Laravel 12 compatibility
- raise barryvdh/laravel-dompdf to v3 to align with Laravel 12 projects
- keep core stack on Laravel 12 while stabilizing dependency ranges

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922d93ac4ac8333bfc556e2b6c0dd1e)