### PR TITLE
Add final documentation set and repository policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+Dit project volgt de Contributor Covenant versie 2.1.
+
+## Onze belofte
+We willen een open, veilige en gastvrije omgeving bieden, ongeacht leeftijd, lichaam, handicap, etniciteit, geslachtsidentiteit of -expressie, ervaring, opleiding, sociaal-economische status, nationaliteit, uiterlijk, ras, religie of seksuele identiteit en oriëntatie.
+
+## Onze standaarden
+Positief gedrag omvat:
+- Empathische, respectvolle communicatie
+- Constructieve feedback accepteren en geven
+- Focus op wat het project en de community ten goede komt
+
+Onacceptabel gedrag omvat:
+- Beledigend/denigrerend taalgebruik of persoonlijke aanvallen
+- Trolling of het delen van privé-informatie zonder toestemming
+- Andere gedrag dat redelijkerwijs als onprofessioneel kan worden beschouwd
+
+## Verantwoordelijkheden
+Maintainers mogen bijdragen verwijderen, issues sluiten of bans opleggen die niet aansluiten bij deze code.
+
+## Scope
+Dit geldt voor alle projectruimtes en publieke ruimtes wanneer iemand het project vertegenwoordigt.
+
+## Rapporteren
+Meld incidenten via **conduct@aimtrack.local**. Klachten worden vertrouwelijk behandeld. Maintainers beoordelen en communiceren binnen redelijke termijn over vervolgstappen.
+
+## Attribution
+Gebaseerd op de [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+Bedankt voor je interesse in AimTrack! Volg onderstaande richtlijnen om bij te dragen.
+
+## Gedragscode
+Door bij te dragen ga je akkoord met de [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md).
+
+## Issues
+- Gebruik issues voor bugs of feature requests. Beschrijf duidelijk het probleem, verwachte gedrag en stappen om te reproduceren.
+- Voeg relevante logs, screenshots en omgeving (OS, PHP-versie, DB) toe.
+
+## Workflow
+1. Fork de repo en maak een feature branch (`feature/onderwerp` of `fix/bug-xyz`).
+2. Houd je aan het PLAN-FIRST principe: beschrijf kort de aanpak (bijv. update `docs/PLAN.md` of een issue-comment) voordat je code wijzigt.
+3. Schrijf compacte, leesbare code met NL-labels in Filament.
+4. Zorg dat alle tests en linters slagen.
+5. Maak een heldere PR met samenvatting, testresultaten en referentie naar het issue.
+
+## Coding standards
+- Lint met `composer lint` (Laravel Pint). Gebruik `composer lint:fix` voor automatische fixes.
+- Tests draaien met `composer test` (Pest/phpunit).
+- Geen secrets committen; gebruik `.env`/secrets store.
+- AI-calls altijd via de queue (geen directe HTTP-call in request lifecycles) behalve expliciet synchrone coachvragen.
+
+## Commits en PR’s
+- Gebruik betekenisvolle commit messages (imperatief: "Add...", "Fix...").
+- Kleine, gefocuste PR’s zijn makkelijker te reviewen.
+
+## Documentatie
+- Update relevante docs bij nieuwe features (technisch en gebruikersdocumentatie).
+- Voeg NL-disclaimers toe bij AI/exports waar nodig.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # AimTrack
-AimTrack is een moderne AI-gedreven schietlogapp voor sportschutters. Registreer sessies, wapens en munitie, upload kaarten, ontvang automatische AI-reflecties en inzichten, beheer je wapens en genereer exports (CSV/PDF) voor o.a. WM-4. Privacy-first, self-hosted en gebouwd met Laravel + Filament.
+
+AimTrack is een moderne, self-hosted schietlog voor sportschutters. Registreer sessies (met wapens/afstanden), voeg bijlagen toe, krijg AI-reflecties en wapen-trends, stel vragen aan een AI-coach en genereer CSV/PDF-exports voor o.a. WM-4-achtige aanvragen. Gebouwd met Laravel 12, Filament 4 en Livewire 3.
+
+## Kernfeatures
+- **Sessies**: datum, baan/vereniging, locatie, tijden, notities, attachments en meerdere wapen × afstand entries.
+- **Reflectie**: handmatige reflectie + AI-reflectie (samenvatting, went_well, needs_improvement, next_focus).
+- **Wapenbeheer**: wapens met type/kaliber/serienummer/opslag; inzicht in gebruik per sessie.
+- **AI-coach**: vrije vragen op basis van eigen sessies/wapens.
+- **Export**: CSV/PDF per periode + wapenselectie met NL-disclaimer.
+- **Infra**: Docker Compose (nginx, php-fpm, db, queue) en queue-jobs voor AI-taken.
+
+## Stack
+- PHP 8.4/8.5, Laravel 12
+- Filament 4 + Livewire 3
+- Database: PostgreSQL (default) of MySQL
+- Queue: database driver (queue-worker container)
+
+## Snel starten (Docker)
+1. Kopieer `.env.example` naar `.env` en vul waarden in.
+2. Start stack: `docker compose up -d`.
+3. Installeer dependencies: `docker compose exec app composer install`.
+4. Genereer key: `docker compose exec app php artisan key:generate`.
+5. Migreer (en seed): `docker compose exec app php artisan migrate --seed`.
+6. Open `http://localhost:8080` en log in (standaard Laravel-auth). Gebruik Filament om sessies/wapens te beheren.
+
+## AI-configuratie
+- Zet `AI_DRIVER`, `AI_MODEL`, `OPENAI_API_KEY` en `OPENAI_BASE_URL` (of andere provider variabelen) in `.env`.
+- AI-calls verlopen via queue-jobs (`GenerateSessionReflectionJob`, `GenerateWeaponInsightJob`). Zorg dat de `queue` container draait.
+- Prompts bevatten NL-disclaimers; AI-output is adviserend en vervangt geen veiligheidsregels of instructeurs.
+
+## Export
+Gebruik de Filament **Export**-pagina om CSV of PDF te downloaden. Periode is verplicht; wapenselectie optioneel. Download bevat een disclaimer dat de gebruiker zelf verantwoordelijk blijft voor actuele WM-4-eisen.
+
+## Documentatie
+- Techniek: `docs/architecture.md`, `docs/ai.md`, `docs/export.md`, `docs/infra.md`, `docs/operations.md`, `docs/security.md`
+- Gebruiker: `docs/user/quickstart.md`, `docs/user/sessions.md`, `docs/user/weapons.md`, `docs/user/export.md`, `docs/user/ai-coach.md`
+- Overige plannen: `docs/PLAN.md`, `docs/BACKUPS.md`, `docs/PROD_HARDENING.md`
+
+## Ontwikkelen
+- Lint: `composer lint` (Laravel Pint).
+- Tests: `composer test` (Pest/phpunit).
+- Houd NL-labels aan in Filament en gebruik queue voor AI-taken.
+
+## Licentie
+MIT – zie [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+AimTrack volgt de laatste stabiele Laravel 12 releases. Beveiligingsfixes richten zich op de huidige major/minor zolang de codebase wordt onderhouden.
+
+## Kwetsbaarheden melden
+1. Stuur een e-mail naar **security@aimtrack.local** met een duidelijke omschrijving, impact en reproduceerbare stappen.
+2. Vermeld indien mogelijk logs, request samples en versie-informatie (commit hash).
+3. Gebruik geen publieke issues/discussies voor niet-gepatchte kwetsbaarheden.
+
+## Respons
+- We bevestigen ontvangst binnen 5 werkdagen.
+- Kritieke issues krijgen prioriteit; we streven naar een fix of mitigatie binnen 14 dagen.
+- Na release communiceren we, indien gewenst, erkenning aan de melder.
+
+## Richtlijnen voor onderzoekers
+- Geen data-exfiltratie of verstoring van productieomgevingen.
+- Beperk tests tot je eigen account/data (single-tenant).
+- Houd je aan toepasselijke wet- en regelgeving.

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1,0 +1,32 @@
+# AI
+
+Dit document beschrijft hoe de AI-functionaliteit is ingericht en hoe je deze veilig en betrouwbaar gebruikt.
+
+## Componenten
+- **Service:** `App\Services\Ai\ShooterCoach` – centraal entrypoint voor alle LLM-calls.
+- **Config:** `config/ai.php` leest provider/model/base_url/timeout/retries uit `.env` (bijv. `AI_DRIVER`, `AI_MODEL`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`). Geen secrets in code of repo.
+- **Queue-jobs:**
+  - `GenerateSessionReflectionJob` – bouwt prompt met sessiecontext (datum, locatie, wapens, notities) en vraagt om samenvatting/went_well/needs_improvement/next_focus.
+  - `GenerateWeaponInsightJob` – bouwt prompt met historische sessies per wapen en vraagt om trends/typical_issues/recommendations.
+- **AI-coach:** `ShooterCoach::answerCoachQuestion` ondersteunt vrije vragen (optioneel wapen/periode) en bewaart vraag/antwoord in `coach_questions` wanneer geactiveerd.
+
+## Flow per use-case
+1. **Sessie-reflectie**: Filament-actie → queue-job → service-call → resultaat in `ai_reflections` → statuskolom in tabel/detail.
+2. **Wapen-trends**: Filament-actie → queue-job → service-call → resultaat in `ai_weapon_insights` → zichtbaar bij het wapen.
+3. **AI-coach**: Filament page → directe service-call (of queue bij zware context) → antwoord + waarschuwing → optioneel opslag in `coach_questions` voor audit/historie.
+
+## Prompts & guardrails
+- Prompts zijn Nederlandstalig en leggen uit dat de AI **geen vervanging** is voor veiligheidsregels, wetgeving of instructeurs.
+- Output is kort en puntsgewijs (~150 woorden per sectie), met focus op concrete acties.
+- Fouten/timeouts worden gelogd; jobs schrijven status `failed` + `error` veld bij mislukking.
+- Provider/model is configureerbaar zodat self-hosted of cloud LLM’s kunnen worden gebruikt.
+
+## Limits & performance
+- Queue zorgt dat UI niet blokkeert. Job-retries staan aan via queue-config.
+- Timeouts/max tokens via `config/ai.php`; in `.env` kunnen strengere waarden worden gezet voor self-hosting.
+- Bij grote datasets kan coach-vraag worden gequeue’d; structureer context (laatste N sessies) om tokens te beperken.
+
+## Privacy en dataretentie
+- AI krijgt alleen user-eigen data; queries filteren op `user_id`.
+- Geen data wordt gedeeld met derde partijen buiten de gekozen LLM-provider; kies self-hosted/provider met DPA indien nodig.
+- Bewaar AI-output in de database voor audit; verwijder op verzoek via standaard CRUD.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,45 @@
+# Architectuur
+
+Deze sectie beschrijft hoe AimTrack is opgebouwd (Laravel 12, PHP 8.4/8.5, Filament 4, Livewire 3) en hoe de belangrijkste componenten samenwerken. De app is single-tenant (standaard Laravel-auth) en is gecontaineriseerd.
+
+## Domeinmodel
+- **User** – eigenaar van alle data.
+- **Weapon** – naam, type, kaliber, serienummer, opslaglocatie, notities; heeft één `AiWeaponInsight` en meerdere sessie-entries.
+- **Session** – datum, baan/vereniging, locatie, tijden, notities, handmatige reflectie; heeft één `AiReflection` en meerdere `SessionWeaponEntry` records.
+- **SessionWeaponEntry** – koppelrecord per sessie × wapen met afstand, schoten, munitie, optionele score/groepering.
+- **Attachment** – morph naar Session/SessionWeaponEntry/Weapon voor foto’s/kaarten/PDF.
+- **AiReflection** – AI-output per sessie (samenvatting, went_well, needs_improvement, next_focus + status/provider/model/errortext).
+- **AiWeaponInsight** – AI-trends per wapen (trends, typical_issues, recommendations + status/provider/model/errortext).
+- **CoachQuestion** (optioneel) – bewaarde AI-coach vragen/antwoorden per user, met optionele wapen- en periodefilter.
+
+## Belangrijke lagen
+- **HTTP/Filament**: Filament Resources (Sessions, Weapons, AI-resultaten, Attachments) + Pages (AI Coach, Export). Formulieren/tafels zijn NL-gelabeld en filteren op de ingelogde user.
+- **Services**: `App\Services\Ai\ShooterCoach` voor LLM-calls; `App\Services\Export\SessionExportService` voor CSV/PDF.
+- **Jobs**: `GenerateSessionReflectionJob` en `GenerateWeaponInsightJob` draaien in de queue en schrijven AI-resultaten weg.
+- **Config**: `config/ai.php` voor provider/model/base_url/timeout; `.env` plaatst secrets.
+- **Infra**: Docker Compose met nginx, php-fpm (app), Postgres/MySQL, queue-worker. Queue gebruikt database driver als standaard.
+
+## Datastromen
+- **Sessies**: gebruiker maakt sessie + repeater met wapens/afstanden → opslag in `sessions` + `session_weapon_entries` + bijlagen via polymorfe relatie.
+- **AI-reflectie per sessie**: Filament-actie of event dispatcht `GenerateSessionReflectionJob` → job laadt sessiecontext → roept `ShooterCoach::generateSessionReflection` → bewaart `ai_reflections` met status.
+- **AI-trends per wapen**: Filament-actie dispatcht `GenerateWeaponInsightJob` → job haalt gebruiksdata voor wapen op → roept `ShooterCoach::generateWeaponInsight` → bewaart `ai_weapon_insights`.
+- **AI-coach Q&A**: Filament page roept `ShooterCoach::answerCoachQuestion` aan (direct of via queue indien zwaarder) → slaat vraag/antwoord op in `coach_questions` (optioneel) en toont antwoord.
+- **Export**: Filament Export-page valideert filters → roept `SessionExportService` → bouwt dataset → streamt CSV of rendert PDF view met disclaimer.
+
+## Filament resources en pages
+- **SessionResource**: create/edit forms met sessiedata + repeatable session weapon entries + upload voor bijlagen; tabel met datum/baan/locatie/wapens/AI-status; detail toont AI-reflectie + bijlagen; actie voor AI-generatie.
+- **WeaponResource**: beheer wapenstamdata, tabel met sessietelling en AI-status; detail toont AI-trends + relation manager naar sessie-entries; actie voor AI-generatie.
+- **AiReflectionResource / AiWeaponInsightResource**: read-only inzicht in AI-status (audit/controle).
+- **AttachmentResource**: optionele read-only lijst van uploads.
+- **AiCoachPage**: vrije vraag + optionele wapen/periode; toont antwoord + waarschuwing dat AI geen vervanging is voor veiligheidsregels.
+- **ExportSessionsPage**: filters (van/tot, wapenselectie, formaat CSV/PDF) + downloadactie met NL-disclaimer.
+
+## Veiligheid en multi-tenancy
+- Elke query filtert op `user_id` van de ingelogde gebruiker; Filament resources gebruiken scopes/policies om data te isoleren.
+- AI-service gebruikt env-gestuurde provider/model; geen secrets in code. AI-calls verlopen via queue (async) behalve optionele coachvragen.
+- Downloads en uploads gebruiken Laravel storage; file ACL’s via storage driver. Disclaimers in exports en AI-uitvoer vermelden dat gebruiker zelf verantwoordelijk blijft.
+
+## Uitbreidingshaken
+- Extra exportprofielen kunnen via nieuwe services/views worden toegevoegd.
+- Multi-turn coachgesprekken kunnen de `coach_threads/messages` structuur benutten.
+- Horizon of alternatieve queue backends kunnen worden aangesloten via config zonder codewijziging.

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,0 +1,29 @@
+# Export
+
+AimTrack kan sessies exporteren naar CSV of PDF voor o.a. WM-4-achtige rapportage.
+
+## Flow
+1. Gebruiker opent Filament **Export**-pagina.
+2. Formulier valideert periode (van/tot), optionele wapenselectie en formaat (CSV of PDF).
+3. `App\Services\Export\SessionExportService` haalt sessies + `session_weapon_entries` van de ingelogde gebruiker op.
+4. Service bouwt records per sessie × wapen (datum, baan, locatie, wapen, kaliber, afstand, schoten, munitietype, groepering/score, notities).
+5. Service streamt CSV of rendert een Blade-PDF met overzicht + NL-disclaimer.
+
+## CSV
+- Kolommen: `datum, baan, locatie, wapen, kaliber, afstand_m, aantal_schoten, munitie, score/groepering, notities`.
+- Eén regel per `SessionWeaponEntry`.
+- UTF-8 + komma-gescheiden (RFC4180). Decimalen met punt.
+
+## PDF
+- Eenvoudige Blade-view met periodekop, totalen per wapen/kaliber en tabel met sessies.
+- Disclaimer onderaan: "Let op: dit document is een hulpmiddel; controleer altijd zelf of dit voldoet aan de actuele eisen van de politie / korpschef voor een WM-4 aanvraag." (NL).
+- Render via lichte PDF-lib (bijv. Dompdf). Houd styles minimalistisch zodat printbaar is.
+
+## Validatie & beveiliging
+- Queries filteren altijd op `user_id` van de ingelogde gebruiker.
+- Periode is verplicht; wapenselectie is optioneel maar beperkt tot eigen wapens.
+- Downloads zijn transient; geen lange-termijn opslag tenzij gebruiker dat zelf doet.
+
+## Uitbreidbaarheid
+- Nieuwe exportprofielen kunnen als extra service + view worden toegevoegd.
+- Eventueel queue-based exports voor grote datasets (job + notificatie met downloadlink) kunnen later worden toegevoegd zonder de huidige interface te breken.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -1,0 +1,42 @@
+# Infra
+
+Overzicht van de infrastructuur en lokale ontwikkelsetup.
+
+## Containers (Docker Compose)
+- **app**: PHP 8.4/8.5 FPM met Laravel, Composer, extensies (pdo_pgsql/pdo_mysql, gd, mbstring, intl, zip, exif). Mountt repo naar `/var/www/html`.
+- **web**: nginx die `/public/index.php` via FastCGI naar `app:9000` stuurt.
+- **db**: PostgreSQL (default). MySQL-alternatief kan met eigen service worden toegevoegd.
+- **queue**: zelfde image als `app`, draait `php artisan queue:work --tries=3`.
+
+## Netwerk & poorten
+- Web luistert op `:8080` (kan via compose override). DB standaard `5432`. Queue worker is intern.
+
+## Configuratie (.env)
+Belangrijkste variabelen:
+- `APP_ENV`, `APP_DEBUG=false` voor productie.
+- `APP_URL=http://localhost:8080` (dev) / prod-URL.
+- `DB_CONNECTION=pgsql`, `DB_HOST=db`, `DB_PORT=5432`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`.
+- `QUEUE_CONNECTION=database` (default).
+- AI: `AI_DRIVER`, `AI_MODEL`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`.
+- Logging/monitoring: Sentry DSN indien gebruikt.
+
+## Lifecycle
+1. `docker compose up -d` start stack.
+2. `docker compose exec app composer install` (eerste keer) en `php artisan key:generate`.
+3. `docker compose exec app php artisan migrate --seed` om schema op te zetten.
+4. Queue worker draait automatisch; anders handmatig starten met `docker compose exec queue php artisan queue:work`.
+
+## Caching en assets
+- Gebruik `php artisan config:cache`, `route:cache`, `view:cache` voor productie (entrypoint kan dit doen).
+- Vite build (indien front assets) via `npm install && npm run build` buiten scope van Filament-only UI.
+
+## Monitoring & health
+- Health endpoint `/health` controleert DB, queue-config en storage schrijfbaarheid; te gebruiken voor container probes.
+- Logs gaan naar stdout/stderr (container-friendly) en/of Sentry wanneer geconfigureerd.
+
+## Backups
+- Zie `docs/BACKUPS.md` voor strategie (pg_dump + storage sync). Plan cron/automation buiten de app; minimaal dagelijkse DB-dump en storage sync naar object storage.
+
+## Deploy
+- Multi-stage Docker image mogelijk: builder (composer install zonder dev) + runtime (php-fpm + opcache).
+- GitHub Actions workflow kan image naar GHCR pushen; zie CI-notities in `docs/PLAN.md` sectie "Release & productiehardening".

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,39 @@
+# Operations
+
+Runbook voor dagelijks beheer, incidentrespons en onderhoud van AimTrack.
+
+## Dagelijkse checks
+- **Health**: monitor `/health` endpoint (verwacht 200 + JSON). Controleer logs op errors.
+- **Queue**: zorg dat `queue:work` draait (container `queue`). Check `queue:failed` voor mislukte jobs, met name AI-jobs.
+- **Storage**: voldoende schijfruimte voor uploads; controleer schrijfpermissies op `storage/`.
+
+## Incidentrespons
+1. **App down**: controleer containers (`docker compose ps`), bekijk logs van `web` en `app`. Herstart met `docker compose restart app web`.
+2. **DB issues**: check `db` logs. Indien migrations ontbreken, voer `php artisan migrate --force` uit (met backup!).
+3. **Queue stilgevallen**: herstart `queue` service; inspecteer `queue:failed` en gebruik `queue:retry` na het oplossen van de oorzaak.
+4. **AI-fouten**: controleer `.env` voor API-key/base_url, timeouts in `config/ai.php`, en foutmeldingen in `ai_reflections`/`ai_weapon_insights`.
+5. **Exports mislukken**: controleer bestandssysteem en permissies; valideer dat filters geldige data leveren.
+
+## Deploy flow (productie)
+1. Bouw productie-image (multi-stage) met Composer install zonder dev.
+2. Draai database migraties: `php artisan migrate --force`.
+3. Cache config/routes/views: `php artisan optimize`.
+4. Zorg dat queue-worker opnieuw start na deploy (supervisor/systemd of compose restart).
+5. Vul `APP_KEY`, `APP_ENV=production`, `APP_DEBUG=false`, database- en AI-credentials in.
+
+## Backups & herstel
+- Zie `docs/BACKUPS.md` voor gedetailleerde stappen (pg_dump + storage sync + restore flow).
+- Test herstel periodiek: herstel DB-dump in een aparte omgeving en valideer login + sessies/weapons.
+
+## Monitoring & logging
+- Stuur logs naar stdout/Sentry. Configureer alerts op 5xx rate, queue-failures en AI-error spikes.
+- Overweeg database monitoring (pg_stat_activity) en storage usage alerts.
+
+## Beveiliging & compliance
+- Patch base images regelmatig en rebuild. Houd PHP/Laravel security releases bij.
+- Beperk netwerktoegang tot DB; gebruik sterke DB-wachtwoorden en separate gebruikers per omgeving.
+- Secrets uitsluitend via `.env`/secret store; nooit committen.
+- Schakel HTTPS/secure cookies in productie; configureer trusted proxies.
+
+## Rapportage
+- Exporteer CSV/PDF bij verzoeken (bijv. WM-4). Voeg handmatig auditnotities toe indien juridisch vereist.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,35 @@
+# Security
+
+Beveiligingsrichtlijnen voor AimTrack.
+
+## Threat model
+- Single-tenant app: risico’s vooral rond ongeautoriseerde toegang tot de host of database.
+- Gevoelige data: schietsessies, wapeninformatie, AI-output. Geen multi-user delen.
+
+## Basismaatregelen
+- **Auth**: gebruik standaard Laravel-auth met sterke wachtwoorden en HTTPS.
+- **Transport**: forceer HTTPS in productie; stel trusted proxies in.
+- **Secrets**: alleen in `.env` of secretsmanager; nooit committen. Rotatie via CI/secrets store.
+- **Headers**: zorg voor HSTS, X-Frame-Options, X-Content-Type-Options via webserver.
+- **Rate limiting**: gebruik Laravel throttle middleware voor login/APIs indien blootgesteld.
+
+## Data & opslag
+- Alle queries filteren op `user_id`. Gebruik policies/scopes in Filament resources.
+- Bestanden via Laravel storage; configureer private disks of presigned URLs voor downloads indien publiek internet.
+- Backups versleutelen waar mogelijk; beperk toegang tot storage bucket.
+
+## AI-specifiek
+- Provider keuze via config; vermijd het delen van meer data dan nodig.
+- Prompts bevatten veiligheidsdisclaimers; geen wapen- of veiligheidsadvies dat wetgeving schendt.
+- AI-jobs loggen status en fouten; bewaak rate limits en timeouts.
+
+## Dependencies & updates
+- Draai regelmatig `composer update` voor security fixes; gebruik `composer audit` in CI.
+- Base images patchen en rebuilden; controleer PHP/Laravel security advisories.
+
+## Logging & auditing
+- Gebruik Sentry/stack driver; log 5xx, failed jobs, en AI-fouten.
+- Zorg dat logs geen secrets bevatten (mask keys). Bewaar retentie volgens beleid.
+
+## Vulnerability disclosure
+- Zie `SECURITY.md` voor meldingsproces. Reageer snel op gemelde issues en patch/roll-out.

--- a/docs/user/ai-coach.md
+++ b/docs/user/ai-coach.md
@@ -1,0 +1,24 @@
+# AI-coach
+
+Hoe je vragen stelt aan de AI-coach en wat je kunt verwachten.
+
+## Vraag stellen
+1. Open **AI-coach** in het Filament-menu.
+2. Formulier:
+   - **Vraag**: vrije tekst (NL) met je coachvraag.
+   - **Wapen** (optioneel): selecteer een wapen om de context te beperken.
+   - **Periode** (optioneel): kies van/tot om recente sessies te gebruiken.
+3. Klik **Stel vraag aan AI-coach**. Het antwoord verschijnt zodra de service klaar is.
+
+## Output
+- Antwoord is kort en puntsgewijs met focus op concrete verbeteracties.
+- Context komt uit je eigen sessies/wapens; geen externe data.
+- Een disclaimer herinnert je eraan dat AI geen vervanging is voor instructeurs of veiligheidsregels.
+
+## Fouten of timeouts
+- Controleer of de AI-providerkey in `.env` staat en dat de queue (indien gebruikt) draait.
+- Bij mislukking verschijnt een foutmelding; probeer het opnieuw of verkort de vraag/periode.
+
+## Privacy & veiligheid
+- Je data blijft binnen je eigen account; queries filteren op `user_id`.
+- Deel geen gevoelige of illegale vragen; de AI volgt guardrails maar gebruiker blijft verantwoordelijk.

--- a/docs/user/export.md
+++ b/docs/user/export.md
@@ -1,0 +1,25 @@
+# Export
+
+Handleiding voor CSV/PDF-export.
+
+## Export uitvoeren
+1. Open **Export** in het Filament-menu.
+2. Kies een **periode** (verplicht) en selecteer optioneel specifieke wapens.
+3. Kies een formaat: **CSV** of **PDF**.
+4. Klik **Download**. Het bestand wordt direct gedownload.
+
+## CSV
+- Geschikt voor spreadsheets. Bevat één regel per sessie × wapen met datum, baan/locatie, afstand, schoten, munitie en notities.
+
+## PDF
+- Printvriendelijke versie met overzicht per periode, totalen per wapen/kaliber en een tabel met sessies.
+- Ondersteunde disclaimer wordt automatisch toegevoegd: je moet altijd zelf controleren of de export voldoet aan actuele WM-4-eisen.
+
+## Validatie en veiligheid
+- Alleen data van de ingelogde gebruiker wordt geëxporteerd.
+- Periode is verplicht om te voorkomen dat per ongeluk alle data wordt gedownload.
+- Wapenselectie toont alleen eigen wapens.
+
+## Probleemoplossing
+- Lege export? Controleer of er sessies bestaan in de gekozen periode en met de gekozen wapens.
+- Foutmelding bij downloaden? Controleer opslagpermissies en logs van de `app` container.

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -1,0 +1,33 @@
+# Quickstart
+
+Korte gids om AimTrack lokaal te starten en de eerste sessie te registreren.
+
+## Vereisten
+- Docker + Docker Compose
+- (Optioneel) AI-provider key in `.env` (`OPENAI_API_KEY` of ander driver-specific secret)
+
+## Installatie (lokaal)
+1. Clone repo en kopieer `.env.example` naar `.env`. Vul `APP_KEY` later met `php artisan key:generate`.
+2. Start containers: `docker compose up -d`.
+3. Installeer dependencies: `docker compose exec app composer install`.
+4. Genereer app key: `docker compose exec app php artisan key:generate`.
+5. Run migraties (en seeders indien aanwezig): `docker compose exec app php artisan migrate --seed`.
+6. Open de app op `http://localhost:8080` en login met het aangemaakte account (of registreer via standaard Laravel-auth).
+
+## Eerste sessie loggen
+1. Ga in Filament naar **Sessies** → **Nieuwe sessie**.
+2. Vul datum, baan/vereniging, locatie en optioneel notities/handmatige reflectie in.
+3. Voeg één of meer **Wapen × afstand** entries toe (wapen, afstand, aantal schoten, munitietype, score/groepering).
+4. Upload eventuele bijlagen (foto/kaart/PDF).
+5. Opslaan. De sessie verschijnt in het overzicht.
+
+## AI-reflectie starten
+- Open de sessiedetail en klik **Genereer AI-reflectie**. De queue-job wordt gestart; status is zichtbaar in de tabel/detail.
+
+## Export maken
+- Ga naar **Export** in het menu, kies periode en (optioneel) wapens, selecteer CSV of PDF en klik **Download**. Lees de disclaimer in de download.
+
+## Problemen oplossen
+- Controleer `docker compose logs app` bij errors.
+- Queue niet actief? Start `docker compose exec queue php artisan queue:work`.
+- Geen AI-output? Check `.env` voor AI-key/base URL en bekijk `ai_reflections` statusvelden.

--- a/docs/user/sessions.md
+++ b/docs/user/sessions.md
@@ -1,0 +1,36 @@
+# Sessies
+
+Handleiding voor het registreren en beheren van schietsessies.
+
+## Nieuwe sessie aanmaken
+1. Open **Sessies** → **Nieuwe sessie** in Filament.
+2. Vul basisgegevens: datum, baan/vereniging, locatie. Voeg eventueel weersinformatie of tijdstippen toe indien beschikbaar.
+3. Voeg een korte **handmatige reflectie** of ruwe notitie toe (optioneel).
+4. Voeg **Wapen × afstand** entries toe via de repeater:
+   - Kies wapen
+   - Afstand (m)
+   - Aantal schoten
+   - Munitie(type/kaliber)
+   - Optioneel score/groepering/afwijking
+5. Upload bijlagen (foto’s, kaarten, PDF). Deze worden aan de sessie gekoppeld.
+6. Opslaan.
+
+## Bekijken en bewerken
+- In de tabel zie je datum, locatie, gekoppelde wapens, aantal entries en AI-status.
+- Klik op een sessie om details te zien. Je kunt entries/bijlagen toevoegen of aanpassen en opnieuw opslaan.
+
+## AI-reflectie
+- Op de detailpagina: klik **Genereer AI-reflectie**.
+- De queue-job vult `ai_reflections` met vier velden: samenvatting, wat ging goed, wat kan beter, focus.
+- Status (pending/succeeded/failed) en errors zijn zichtbaar; bij mislukking kun je opnieuw genereren.
+
+## Bijlagen
+- Uploads worden opgeslagen via Laravel storage. Downloaden kan vanuit de sessiedetail of attachments-lijst.
+- Bewaar alleen materialen die je zelf mag delen; verwijder bijlagen die niet langer nodig zijn.
+
+## Filters
+- Gebruik periodefilter, locatie/baan filter en wapenfilter om snel sessies terug te vinden.
+
+## Tips
+- Voeg na elke sessie direct een handmatige reflectie toe; AI-uitvoer wordt beter met duidelijke context.
+- Noteer afwijkingen (bijv. “trekkerfout links hoog”) zodat trends zichtbaar worden in AI-trends per wapen.

--- a/docs/user/weapons.md
+++ b/docs/user/weapons.md
@@ -1,0 +1,26 @@
+# Wapens
+
+Handleiding voor het beheren van wapens en AI-trends.
+
+## Wapen toevoegen
+1. Ga naar **Wapens** → **Nieuw wapen**.
+2. Vul naam, type, kaliber, serienummer, opslaglocatie en optioneel aankoopdatum/notities.
+3. Opslaan. Het wapen is nu beschikbaar in sessie-formulieren.
+
+## Wapen bewerken of archiveren
+- Open het wapen en pas velden aan. Je kunt een **retired** datum of actief-toggle gebruiken om het uit sessies te houden.
+- Sessies behouden hun koppeling; historiek blijft intact.
+
+## Relatie met sessies
+- Elke sessie kan meerdere wapens bevatten via `SessionWeaponEntry` records.
+- In de wapen-detail zie je een lijst van gekoppelde sessies (relation manager).
+
+## AI-trends genereren
+1. Open het wapen-detail.
+2. Klik **Genereer AI-trends**.
+3. Queue-job analyseert historische sessies voor dit wapen en vult `ai_weapon_insights` met trends, typische problemen en aanbevelingen.
+4. Status en eventuele foutmelding zijn zichtbaar; je kunt opnieuw genereren bij fouten.
+
+## Tips
+- Houd kaliber en munitietype consistent per sessie-entry voor betere trendanalyse.
+- Gebruik notities om problemen te markeren (bijv. “trekkerfout links”), zodat AI hierop kan rapporteren.


### PR DESCRIPTION
## Summary
- add comprehensive technical architecture, AI, export, infra, operations, and security documentation
- add end-user guides for setup, sessions, weapons, exports, and the AI coach
- refresh repository-level docs including README, contributing guidelines, code of conduct, and security policy

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ee7848f0833396000b104fc21ae1)