### PR TITLE
feat(auth): add password reset, profile management, and file upload i…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
+COPY docker/php/uploads.ini $PHP_INI_DIR/conf.d/uploads.ini
+
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/html

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -146,13 +146,20 @@ class SessionResource extends Resource
                                 FileUpload::make('path')
                                     ->label('Bestand')
                                     ->required()
+                                    ->maxSize(20480)
                                     ->directory('attachments')
                                     ->preserveFilenames()
                                     ->downloadable()
                                     ->openable()
                                     ->getUploadedFileNameForStorageUsing(fn (TemporaryUploadedFile $file): string => $file->getClientOriginalName())
-                                    ->afterStateUpdated(function ($state, callable $set, ?TemporaryUploadedFile $file): void {
-                                        if (! $file) {
+                                    ->afterStateUpdated(function ($state, callable $set): void {
+                                        if (! $state) {
+                                            return;
+                                        }
+
+                                        $file = is_array($state) ? end($state) : $state;
+
+                                        if (! $file instanceof TemporaryUploadedFile) {
                                             return;
                                         }
 
@@ -160,15 +167,14 @@ class SessionResource extends Resource
                                         $set('mime_type', $file->getMimeType());
                                         $set('size', $file->getSize());
                                     }),
-                                TextInput::make('original_name')
-                                    ->label('Bestandsnaam')
+                                Hidden::make('original_name')
+                                    ->dehydrated()
                                     ->required(),
-                                TextInput::make('mime_type')
-                                    ->label('MIME-type')
+                                Hidden::make('mime_type')
+                                    ->dehydrated()
                                     ->required(),
-                                TextInput::make('size')
-                                    ->label('Grootte (bytes)')
-                                    ->numeric()
+                                Hidden::make('size')
+                                    ->dehydrated()
                                     ->required(),
                             ])
                             ->columns(2)

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -16,7 +16,9 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
+            ->passwordReset()
             ->registration()
+            ->profile()
             ->colors([
                 'primary' => Color::Indigo,
             ])

--- a/app/Services/Ai/ShooterCoach.php
+++ b/app/Services/Ai/ShooterCoach.php
@@ -117,7 +117,9 @@ class ShooterCoach
 
             $content = data_get($response->json(), 'choices.0.message.content');
 
-            return is_string($content) ? $content : json_encode($content) ?: '';
+            return is_string($content)
+                ? $content
+                : (json_encode($content) ?: '');
         } catch (Throwable $exception) {
             Log::error('AI: exception tijdens API-call', [
                 'message' => $exception->getMessage(),

--- a/database/migrations/2025_11_30_000000_create_password_reset_tokens_table.php
+++ b/database/migrations/2025_11_30_000000_create_password_reset_tokens_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('password_reset_tokens', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('password_reset_tokens');
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       APP_URL: http://localhost:8080
       APP_FORCE_HTTPS: "false"
       TRUSTED_PROXIES: 172.16.0.0/12,127.0.0.1/32
+      MAIL_MAILER: smtp
+      MAIL_HOST: mailpit
+      MAIL_PORT: 1025
       DB_CONNECTION: pgsql
       DB_HOST: db
       DB_PORT: 5432
@@ -23,7 +26,8 @@ services:
       DB_PASSWORD: postgres
       QUEUE_CONNECTION: database
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   web:
     image: nginx:stable-alpine
@@ -49,6 +53,11 @@ services:
       - "5432:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d aimtrack"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   queue:
     build:
@@ -65,6 +74,9 @@ services:
       APP_URL: http://localhost:8080
       APP_FORCE_HTTPS: "false"
       TRUSTED_PROXIES: 172.16.0.0/12,127.0.0.1/32
+      MAIL_MAILER: smtp
+      MAIL_HOST: mailpit
+      MAIL_PORT: 1025
       DB_CONNECTION: pgsql
       DB_HOST: db
       DB_PORT: 5432
@@ -74,6 +86,14 @@ services:
       QUEUE_CONNECTION: database
     depends_on:
       - db
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: aimtrack_mailpit
+    restart: unless-stopped
+    ports:
+      - "8025:8025"   # Web UI
+      - "1025:1025"   # SMTP
 
 volumes:
   db_data:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -2,14 +2,13 @@ server {
     listen 80;
     server_name localhost;
 
+    client_max_body_size 20M;
+
     root /var/www/html/public;
     index index.php index.html;
 
     real_ip_header X-Forwarded-For;
     real_ip_recursive on;
-
-    set $forwarded_proto $http_x_forwarded_proto;
-    if ($forwarded_proto = '') { set $forwarded_proto $scheme; }
 
     access_log /var/log/nginx/access.log;
     error_log /var/log/nginx/error.log;
@@ -23,14 +22,10 @@ server {
         fastcgi_pass app:9000;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
-        fastcgi_param HTTPS $forwarded_proto;
-        fastcgi_param HTTP_X_FORWARDED_PROTO $forwarded_proto;
-        fastcgi_param HTTP_X_FORWARDED_HOST $host;
-        fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
         fastcgi_index index.php;
     }
 
-    location ~* \.(jpg|jpeg|gif|png|css|js|ico|svg|ttf|otf|woff|woff2)$ {
+    location ~* \.(jpg|jpeg|gif|png|svg|ttf|otf|woff|woff2)$ {
         expires max;
         log_not_found off;
     }

--- a/docker/php/uploads.ini
+++ b/docker/php/uploads.ini
@@ -1,0 +1,9 @@
+; Upload limits for AimTrack (dev/prod)
+; Keep in sync with Nginx client_max_body_size (currently 20M).
+
+upload_max_filesize = 20M
+post_max_size = 24M
+max_file_uploads = 20
+
+; Optional safety: limit very large requests overall
+; (memory_limit stays at php.ini-production default unless overridden elsewhere)

--- a/resources/views/filament/pages/export-sessions-page.blade.php
+++ b/resources/views/filament/pages/export-sessions-page.blade.php
@@ -1,6 +1,6 @@
 <x-filament::page>
     <div class="max-w-3xl space-y-4">
         <p class="text-sm text-gray-600">Kies de periode en (optioneel) specifieke wapens voor je export. Formaat: CSV of PDF.</p>
-        {{ $this->form }}
+        {{ $this->content }}
     </div>
 </x-filament::page>


### PR DESCRIPTION
…mprovements

- Add password reset functionality with migration for tokens table
- Enable profile management and password reset in admin panel
- Configure Mailpit for local email testing in docker-compose
- Increase file upload limits to 20MB (PHP, Nginx, Filament)
- Add PHP uploads.ini configuration for consistent upload limits
- Refactor ExportSessionsPage to use route-based download with redirect
- Hide attachment metadata fields