### PR TITLE
chore(docker): enable HTTPS enforcement and add Livewire routing support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./:/var/www/html
     environment:
-      APP_FORCE_HTTPS: "false"
+      APP_FORCE_HTTPS: "true"
       TRUSTED_PROXIES: 172.16.0.0/12,127.0.0.1/32
       MAIL_MAILER: smtp
       MAIL_HOST: mailpit
@@ -69,7 +69,7 @@ services:
     volumes:
       - ./:/var/www/html
     environment:
-      APP_FORCE_HTTPS: "false"
+      APP_FORCE_HTTPS: "true"
       TRUSTED_PROXIES: 172.16.0.0/12,127.0.0.1/32
       MAIL_MAILER: smtp
       MAIL_HOST: mailpit

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -22,6 +22,10 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
 
+    location ^~ /livewire/ {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
     location ~* \.(jpg|jpeg|gif|png|svg|ttf|otf|woff|woff2|css|js)$ {
         expires 30d;
         access_log off;


### PR DESCRIPTION
- Set APP_FORCE_HTTPS to "true" for app and queue services
- Add nginx location block for /livewire/ paths with fallback to index.php