### PR TITLE
chore(docker): enable HTTPS enforcement for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./:/var/www/html
     environment:
-      APP_FORCE_HTTPS: "false"
+      APP_FORCE_HTTPS: "true"
       TRUSTED_PROXIES: 172.16.0.0/12,127.0.0.1/32
       MAIL_MAILER: smtp
       MAIL_HOST: mailpit
@@ -69,7 +69,7 @@ services:
     volumes:
       - ./:/var/www/html
     environment:
-      APP_FORCE_HTTPS: "false"
+      APP_FORCE_HTTPS: "true"
       TRUSTED_PROXIES: 172.16.0.0/12,127.0.0.1/32
       MAIL_MAILER: smtp
       MAIL_HOST: mailpit


### PR DESCRIPTION
- Set APP_FORCE_HTTPS to "true" for app and queue services
- Ensures secure connections in development environment