### PR TITLE
```

### DIFF
--- a/docs/local-dev-wsl.md
+++ b/docs/local-dev-wsl.md
@@ -92,5 +92,21 @@ Zie ook de Troubleshooting-sectie in `README.md` voor aanvullende tips.
 - Tests: `docker compose ... exec app composer test`
 - Vite build (optioneel): `docker compose ... exec app npm install && npm run build`
 - Artisan vanuit host: `docker compose ... exec app php artisan <command>`
+- Backup dev database:
+  ```bash
+  ./scripts/backup-dev-db.sh                      # eenmalige dump + gzip + 7d retention
+  COMPOSE_FILE=docker/compose.dev.yml \
+  ENV_FILE=.env.local \
+  BACKUP_DIR=backups \
+  ./scripts/backup-dev-db.sh                      # override voorbeelden
+  ```
+  Voeg voor dagelijks cron-job op WSL toe (`crontab -e`):
+  ```
+  0 3 * * * cd /home/<user>/CascadeProjects/AimTrack && ./scripts/backup-dev-db.sh >> backups/cron.log 2>&1
+  ```
+  Restoren:
+  ```bash
+  zcat backups/db-YYYYMMDD-HHMMSS.sql.gz | docker compose -f docker/compose.dev.yml --env-file .env.local exec -T db psql -U aimtrack -d aimtrack
+  ```
 
 Volg altijd de PLAN-FIRST richtlijnen: pas je `.env.local` aan vóórdat je containers start, en houd documentatie synchroon bij wijzigingen.

--- a/scripts/backup-dev-db.sh
+++ b/scripts/backup-dev-db.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates a timestamped PostgreSQL dump from the local dev stack and
+# prunes backups older than RETENTION_DAYS (default: 7).
+#
+# Optional environment overrides:
+#   COMPOSE_FILE   (default: docker/compose.dev.yml)
+#   ENV_FILE       (default: .env.local)
+#   DB_SERVICE     (default: db)
+#   BACKUP_DIR     (default: <repo>/backups)
+#   BACKUP_PREFIX  (default: db)
+#   RETENTION_DAYS (default: 7)
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker/compose.dev.yml}"
+ENV_FILE="${ENV_FILE:-.env.local}"
+DB_SERVICE="${DB_SERVICE:-db}"
+BACKUP_DIR="${BACKUP_DIR:-${PROJECT_ROOT}/backups}"
+BACKUP_PREFIX="${BACKUP_PREFIX:-db}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+
+timestamp="$(date +%Y%m%d-%H%M%S)"
+backup_path="${BACKUP_DIR}/${BACKUP_PREFIX}-${timestamp}.sql"
+
+mkdir -p "${BACKUP_DIR}"
+
+echo "[backup] Dumping database to ${backup_path}"
+docker compose \
+  -f "${PROJECT_ROOT}/${COMPOSE_FILE}" \
+  --env-file "${PROJECT_ROOT}/${ENV_FILE}" \
+  exec -T "${DB_SERVICE}" \
+  sh -c 'pg_dump --no-owner --no-privileges -U "${DB_USERNAME:-aimtrack}" -d "${DB_DATABASE:-aimtrack}"' \
+  > "${backup_path}"
+
+echo "[backup] Compressing ${backup_path}"
+gzip -f "${backup_path}"
+backup_path="${backup_path}.gz"
+
+echo "[backup] Retaining files newer than ${RETENTION_DAYS} day(s)"
+find "${BACKUP_DIR}" -maxdepth 1 -type f -name "${BACKUP_PREFIX}-*.sql.gz" -mtime +$((RETENTION_DAYS - 1)) -print -delete || true
+
+echo "[backup] Done -> ${backup_path}"


### PR DESCRIPTION
chore(dev): add PostgreSQL backup script with automatic retention for local development

- Add scripts/backup-dev-db.sh for timestamped pg_dump with gzip compression
- Support configurable COMPOSE_FILE, ENV_FILE, DB_SERVICE, BACKUP_DIR, and RETENTION_DAYS
- Implement automatic cleanup of backups older than 7 days (configurable)
- Update docs/local-dev-wsl.md with backup/restore examples and cron setup instructions
- Include restore command using zcat and docker compose exec
```