### PR TITLE
feat(auth): add signed GET logout fallback with status flash message (#41)

### DIFF
--- a/app/Http/Controllers/Auth/AdminLogoutController.php
+++ b/app/Http/Controllers/Auth/AdminLogoutController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Filament\Auth\Http\Responses\Contracts\LogoutResponse as LogoutResponseContract;
+use Filament\Facades\Filament;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\URL;
+
+class AdminLogoutController extends Controller
+{
+    public function __invoke(Request $request): RedirectResponse
+    {
+        if (! $request->hasValidSignature()) {
+            return redirect()->to(
+                URL::temporarySignedRoute(
+                    'filament.admin.auth.logout.get',
+                    now()->addSeconds(5),
+                ),
+            );
+        }
+
+        Filament::auth()->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return app(LogoutResponseContract::class)->toResponse($request);
+    }
+}

--- a/app/Http/Responses/Auth/AdminLogoutResponse.php
+++ b/app/Http/Responses/Auth/AdminLogoutResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Responses\Auth;
+
+use Filament\Auth\Http\Responses\Contracts\LogoutResponse as LogoutResponseContract;
+use Filament\Facades\Filament;
+use Illuminate\Http\RedirectResponse;
+use Livewire\Features\SupportRedirects\Redirector;
+
+class AdminLogoutResponse implements LogoutResponseContract
+{
+    public function toResponse($request): RedirectResponse|Redirector
+    {
+        $request->session()->flash('status', 'Je bent uitgelogd.');
+
+        $redirectUrl = Filament::hasLogin()
+            ? Filament::getLoginUrl()
+            : Filament::getUrl();
+
+        return redirect()->to($redirectUrl);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use App\Http\Responses\Auth\AdminLogoutResponse;
 use App\Services\Ai\ShooterCoach;
+use App\Support\Features\AimtrackFeatureToggle;
+use Filament\Auth\Http\Responses\Contracts\LogoutResponse as LogoutResponseContract;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
@@ -15,6 +18,9 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(ShooterCoach::class, fn () => ShooterCoach::make());
+        $this->app->singleton(AimtrackFeatureToggle::class);
+
+        $this->app->bind(LogoutResponseContract::class, AdminLogoutResponse::class);
     }
 
     public function boot(): void

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -6,6 +6,7 @@ use App\Filament\Widgets\FailedJobsWidget;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\View\PanelsRenderHook;
 use Illuminate\Support\HtmlString;
 
 class AdminPanelProvider extends PanelProvider
@@ -34,6 +35,10 @@ class AdminPanelProvider extends PanelProvider
             ->widgets([
                 FailedJobsWidget::class,
             ])
+            ->renderHook(
+                PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
+                fn () => view('filament.auth.logout-status'),
+            )
             ->middleware([
                 // Core Laravel stack; uitbreidbaar met locale middleware.
                 \Illuminate\Cookie\Middleware\EncryptCookies::class,

--- a/docs/AimTrack/index.md
+++ b/docs/AimTrack/index.md
@@ -4,6 +4,9 @@
 Deze map bevat alle documentatie voor het AimTrack-project volgens het PLAN-FIRST proces. Zie `docs/plans/` voor lopende plannen en `docs/AimTrack/tech/` voor technische referenties.
 
 ## Recent
+- 2026-01-24 — Filament logout flow gefixed (signed GET fallback + melding) — GH-33
+- 2026-01-24 — GH-41 Pennant fallback helper + Filament aanpassingen (features-table resilience)
+- 2026-01-24 — Laravel Boost tooling geïnstalleerd en geconfigureerd voor dev (GitHub #34)
 - 2026-01-07 — Bootstrap structuur aangemaakt door Cascade (sessie aimtrack-8)
 - 2026-01-08 — Security contactadressen geünificeerd naar security@aimrack.nl (sessie aimtrack-8)
 - 2026-01-08 — Landing hub plan + design spec en nieuwe welcome page geïmplementeerd (AIMTRACK-landing-hub)

--- a/resources/views/filament/auth/logout-status.blade.php
+++ b/resources/views/filament/auth/logout-status.blade.php
@@ -1,0 +1,25 @@
+@if (session('status'))
+    <div class="fi-logout-status" style="margin-top: 1.5rem;">
+        <div
+            class="fi-logout-status__flash"
+            style="display:flex;gap:0.75rem;align-items:flex-start;padding:1rem 1.25rem;border-radius:0.75rem;background:rgba(76,175,80,0.12);border:1px solid rgba(76,175,80,0.3);color:#1b4332;font-size:0.95rem;flex-wrap:wrap;"
+        >
+            <span
+                class="fi-logout-status__icon"
+                aria-hidden="true"
+                style="width:2rem;height:2rem;display:inline-flex;align-items:center;justify-content:center;border-radius:999px;background:#1b4332;color:#fff;font-weight:600;font-size:1rem;"
+            >
+                ✓
+            </span>
+
+            <div>
+                <p class="fi-logout-status__title" style="margin:0;font-weight:600;">
+                    {{ session('status') }}
+                </p>
+                <p class="fi-logout-status__body" style="margin:0.25rem 0 0;font-size:0.9rem;color:#1b4332cc;">
+                    Je bent veilig uitgelogd. Log opnieuw in om verder te gaan.
+                </p>
+            </div>
+        </div>
+    </div>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,14 +1,19 @@
 <?php
 
+use App\Http\Controllers\Auth\AdminLogoutController;
 use App\Http\Controllers\HealthController;
+use App\Http\Controllers\LandingPageController;
 use App\Services\Export\SessionExportService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::view('/', 'welcome')->name('welcome');
+Route::get('/', LandingPageController::class)->name('welcome');
 
 Route::redirect('/login', '/admin/login')->name('login');
+
+Route::get('/admin/logout', AdminLogoutController::class)
+    ->name('filament.admin.auth.logout.get');
 
 Route::get('/exports/sessions/download', function (Request $request, SessionExportService $exportService) {
     $from = Carbon::parse($request->query('from'));

--- a/tests/Feature/LogoutTest.php
+++ b/tests/Feature/LogoutTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\URL;
+
+beforeEach(function (): void {
+    $this->withoutExceptionHandling();
+});
+
+it('logs out via POST and flashes a status message', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post(route('filament.admin.auth.logout'));
+
+    $response->assertRedirect('/admin/login');
+    $response->assertSessionHas('status', 'Je bent uitgelogd.');
+    $this->assertGuest();
+});
+
+it('redirects unsigned GET logout requests to a signed URL', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/admin/logout');
+
+    $response->assertRedirect();
+    $this->assertStringContainsString('signature=', $response->headers->get('Location'));
+    // User should still be authenticated because logout did not run yet.
+    $this->assertAuthenticated();
+});
+
+it('logs out via the signed GET fallback route', function (): void {
+    $user = User::factory()->create();
+
+    $signedUrl = URL::temporarySignedRoute('filament.admin.auth.logout.get', now()->addMinute());
+
+    $response = $this->actingAs($user)->get($signedUrl);
+
+    $response->assertRedirect('/admin/login');
+    $response->assertSessionHas('status', 'Je bent uitgelogd.');
+    $this->assertGuest();
+});

--- a/tests/Unit/AimtrackFeatureToggleTest.php
+++ b/tests/Unit/AimtrackFeatureToggleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Support\Features\AimtrackFeatureToggle;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Pennant\Feature as FeatureFacade;
+use Mockery;
+
+it('uses Laravel Pennant when the features table exists', function (): void {
+    Schema::shouldReceive('hasTable')
+        ->once()
+        ->with('features')
+        ->andReturnTrue();
+
+    FeatureFacade::shouldReceive('active')
+        ->once()
+        ->with('aimtrack-ai')
+        ->andReturnTrue();
+
+    $toggle = new AimtrackFeatureToggle;
+
+    expect($toggle->aiEnabled())->toBeTrue();
+});
+
+it('falls back to the configured default and logs once when the table is missing', function (): void {
+    config()->set('features.defaults.aimtrack-ai', false);
+
+    Schema::shouldReceive('hasTable')
+        ->once()
+        ->with('features')
+        ->andReturnFalse();
+
+    FeatureFacade::shouldReceive('active')->never();
+
+    Log::shouldReceive('warning')
+        ->once()
+        ->with(
+            'Pennant features table ontbreekt; val terug op env default.',
+            Mockery::on(function (array $context): bool {
+                return $context['feature'] === 'aimtrack-ai'
+                    && $context['default'] === false;
+            })
+        );
+
+    $toggle = new AimtrackFeatureToggle;
+
+    expect($toggle->aiEnabled())->toBeFalse();
+    expect($toggle->aiDisabled())->toBeTrue();
+});
+
+it('only checks for the features table once per instance', function (): void {
+    Schema::shouldReceive('hasTable')
+        ->once()
+        ->with('features')
+        ->andReturnTrue();
+
+    FeatureFacade::shouldReceive('active')
+        ->twice()
+        ->with('aimtrack-ai')
+        ->andReturnFalse();
+
+    $toggle = new AimtrackFeatureToggle;
+
+    expect($toggle->aiEnabled())->toBeFalse();
+    expect($toggle->aiEnabled())->toBeFalse();
+});


### PR DESCRIPTION
- Add AdminLogoutController with signed URL fallback for GET logout requests
- Add AdminLogoutResponse with Dutch status flash ('Je bent uitgelogd.')
- Add logout-status.blade.php view with styled success message on login page
- Register AdminLogoutResponse as LogoutResponseContract in AppServiceProvider
- Add PanelsRenderHook to display logout status after login form
- Add /admin/logout GET route with signature validation


https://github.com/Marcvdc/AimTrack/issues/41