### PR TITLE
feat(backup): add automated database backup service with cron schedul…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        cron \
         git \
         unzip \
         libpq-dev \
@@ -18,6 +19,7 @@ RUN apt-get update \
         libicu-dev \
         locales \
         libonig-dev \
+        postgresql-client \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
     && docker-php-ext-install -j"$(nproc)" gd intl mbstring pdo pdo_pgsql pdo_mysql zip exif \
     && docker-php-ext-enable opcache \
@@ -64,6 +66,7 @@ WORKDIR /var/www/html
 
 COPY --from=vendor /var/www/html/vendor ./vendor
 COPY . .
+RUN chmod +x docker/backup/*.sh scripts/backup-dev-db.sh
 COPY --from=frontend /opt/artifacts/public-build ./public/build
 
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint

--- a/docker/backup/entrypoint.sh
+++ b/docker/backup/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+CRON_SCHEDULE="${BACKUP_SCHEDULE:-0 3 * * *}"
+CRON_LOG="${BACKUP_LOG:-/backups/cron.log}"
+BACKUP_RUNNER_SOURCE="${BACKUP_RUNNER_SOURCE:-/var/www/html/docker/backup/run-backup.sh}"
+BACKUP_RUNNER_TARGET="/usr/local/bin/run-backup"
+
+if [ ! -f "${BACKUP_RUNNER_SOURCE}" ]; then
+  echo "[backup-entrypoint] Runner script ontbreekt op ${BACKUP_RUNNER_SOURCE}" >&2
+  exit 1
+fi
+
+cp "${BACKUP_RUNNER_SOURCE}" "${BACKUP_RUNNER_TARGET}"
+chmod +x "${BACKUP_RUNNER_TARGET}"
+
+mkdir -p "$(dirname "${CRON_LOG}")"
+touch "${CRON_LOG}"
+
+cat <<EOF >/etc/crontabs/root
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+${CRON_SCHEDULE} ${BACKUP_RUNNER_TARGET} >> ${CRON_LOG} 2>&1
+EOF
+
+exec crond -f -l 2

--- a/docker/backup/run-backup.sh
+++ b/docker/backup/run-backup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+SCRIPT_PATH="${BACKUP_SCRIPT:-/app/scripts/backup-dev-db.sh}"
+
+if [ ! -f "${SCRIPT_PATH}" ]; then
+  echo "[backup-runner] Script not found at ${SCRIPT_PATH}" >&2
+  exit 1
+fi
+
+exec env BACKUP_MODE="${BACKUP_MODE:-direct}" "${SCRIPT_PATH}"

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -17,6 +17,33 @@ services:
       - app_storage:/var/www/html/storage
       - app_bootstrap_cache:/var/www/html/bootstrap/cache
 
+  backup:
+    image: ${REGISTRY_IMAGE}:${IMAGE_TAG}
+    env_file:
+      - ../.env
+    environment:
+      APP_ENV: production
+      BACKUP_MODE: direct
+      BACKUP_DIR: /backups
+      BACKUP_PREFIX: ${BACKUP_PREFIX_PROD:-prod-db}
+      RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+      BACKUP_SCHEDULE: "${BACKUP_SCHEDULE:-0 3 * * *}"
+      BACKUP_LOG: /backups/cron.log
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_DATABASE: ${DB_DATABASE:-aimtrack}
+      DB_USERNAME: ${DB_USERNAME:-aimtrack}
+      DB_PASSWORD: ${DB_PASSWORD:-aimtrack}
+    entrypoint: ["/var/www/html/docker/backup/entrypoint.sh"]
+    command: []
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - app_code:/var/www/html:ro
+      - db_backups_prod:/backups
+
   queue:
     image: ${REGISTRY_IMAGE}:${IMAGE_TAG}
     env_file:
@@ -70,3 +97,4 @@ volumes:
   app_storage:
   app_bootstrap_cache:
   db_data_prod:
+  db_backups_prod:

--- a/docker/compose.staging.yml
+++ b/docker/compose.staging.yml
@@ -17,6 +17,33 @@ services:
       - app_storage:/var/www/html/storage
       - app_bootstrap_cache:/var/www/html/bootstrap/cache
 
+  backup:
+    image: ${REGISTRY_IMAGE}:${IMAGE_TAG}
+    env_file:
+      - ../.env
+    environment:
+      APP_ENV: staging
+      BACKUP_MODE: direct
+      BACKUP_DIR: /backups
+      BACKUP_PREFIX: ${BACKUP_PREFIX_STAGING:-staging-db}
+      RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
+      BACKUP_SCHEDULE: "${BACKUP_SCHEDULE:-0 3 * * *}"
+      BACKUP_LOG: /backups/cron.log
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_DATABASE: ${DB_DATABASE:-aimtrack}
+      DB_USERNAME: ${DB_USERNAME:-aimtrack}
+      DB_PASSWORD: ${DB_PASSWORD:-aimtrack}
+    entrypoint: ["/var/www/html/docker/backup/entrypoint.sh"]
+    command: []
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - app_code:/var/www/html:ro
+      - db_backups_staging:/backups
+
   queue:
     image: ${REGISTRY_IMAGE}:${IMAGE_TAG}
     env_file:
@@ -70,3 +97,4 @@ volumes:
   app_storage:
   app_bootstrap_cache:
   db_data_staging:
+  db_backups_staging:

--- a/docs/AimTrack/index.md
+++ b/docs/AimTrack/index.md
@@ -4,6 +4,7 @@
 Deze map bevat alle documentatie voor het AimTrack-project volgens het PLAN-FIRST proces. Zie `docs/plans/` voor lopende plannen en `docs/AimTrack/tech/` voor technische referenties.
 
 ## Recent
+- 2026-01-26 — GH-38 Backup services + cron jobs toegevoegd (staging/prod compose, runbook)
 - 2026-01-24 — GH-42 Laravel logrotatie ingericht (daily channel, tests, runbook)
 - 2026-01-24 — Filament logout flow gefixed (signed GET fallback + melding) — GH-33
 - 2026-01-24 — GH-41 Pennant fallback helper + Filament aanpassingen (features-table resilience)

--- a/docs/AimTrack/tech/backups.md
+++ b/docs/AimTrack/tech/backups.md
@@ -1,0 +1,44 @@
+# Database Backup Runbook
+
+## Overzicht
+Staging en productie draaien dagelijkse PostgreSQL-back-ups via een dedicated `backup`-service in de respectieve Docker Compose stacks. De service gebruikt `scripts/backup-dev-db.sh` (in `direct` mode) met cron (`BACKUP_SCHEDULE`, standaard 03:00) en bewaart gzipte dumps op een persistent volume (`db_backups_<env>`).
+
+## Architectuur
+- **Container:** dezelfde applicatie-image met `cron` en `postgresql-client` (zie `Dockerfile`).
+- **EntryPoint:** `docker/backup/entrypoint.sh` configureert cron en logt naar `/backups/cron.log`.
+- **Runner:** `docker/backup/run-backup.sh` roept `scripts/backup-dev-db.sh` aan met `BACKUP_MODE=direct`.
+- **Volumes:** `db_backups_staging` / `db_backups_prod` worden op `/backups` gemount en bevatten dumps + `cron.log`.
+- **Database connectie:** environment variabelen (`DB_HOST=db`, `DB_PORT=5432`, …) verwijzen naar de interne `db`-service.
+
+## Configuratie & Variabelen
+| Variabele | Beschrijving | Default |
+|-----------|--------------|---------|
+| `BACKUP_PREFIX_STAGING` / `BACKUP_PREFIX_PROD` | Prefix voor bestandsnamen | `staging-db` / `prod-db` |
+| `BACKUP_RETENTION_DAYS` | Aantal dagen dat dumps bewaard blijven (`find ... -mtime`) | `14` |
+| `BACKUP_SCHEDULE` | Cron-expressie voor `crond` | `0 3 * * *` |
+| `BACKUP_DIR` | Binnen-container pad voor dumps | `/backups` |
+| `BACKUP_LOG` | Logbestand met joboutput | `/backups/cron.log` |
+| `BACKUP_DRY_RUN` | Zet op `1` voor tests (geen pg_dump) | `0` |
+
+Env placeholders zijn toegevoegd aan `.env.example`; pas ze aan in `.env` voor staging/prod.
+
+## Operaties
+1. **Handmatig draaien:**
+   ```bash
+   docker compose -f docker/compose.staging.yml run --rm \
+     -e BACKUP_DRY_RUN=1 backup /usr/local/bin/run-backup
+   ```
+   Laat `BACKUP_DRY_RUN=0` om een echte dump te maken.
+2. **Log controleren:** `docker compose -f docker/compose.staging.yml logs -f backup` of lees `/backups/cron.log` op het gedeelde volume.
+3. **Retentie aanpassen:** wijzig `BACKUP_RETENTION_DAYS` in `.env` en herstart de `backup`-service.
+4. **Hersteltest:**
+   ```bash
+   docker compose -f docker/compose.staging.yml exec db \
+     pg_restore -d aimtrack_restore /backups/staging-db-YYYYMMDD-HHMMSS.sql.gz
+   ```
+   (Pak eerst uit met `gunzip` indien nodig.)
+
+## Monitoring & Alerts
+- Controleer dat `cron.log` dagelijks een "Done"-regel bevat.
+- Voeg infra-monitoring toe voor volumegebruik en cron failures (bijv. tail `cron.log` of health endpoint).
+- In lijn met C-PII-Logging blijven dumps lokaal op het backups-volume; offsite replicatie is optioneel en niet geautomatiseerd.

--- a/docs/plans/aimtrack-issue-0038-plan.md
+++ b/docs/plans/aimtrack-issue-0038-plan.md
@@ -1,0 +1,57 @@
+# AimTrack Issue 0038 – Backup Workflow Plan
+Status: APPROVED (2026-01-25)
+Auteur: Cascade AI
+Datum: 2026-01-25
+Issue: GH-38 — "Backups voorkomen dataverlies"
+
+## 1. Context & Aanleiding
+- Staging- en productieomgevingen draaien PostgreSQL binnen Docker composities zonder ingebouwde backupstrategie.
+- Huidige `scripts/backup-dev-db.sh` voorziet in lokale dumps, maar is niet aangesloten op cron/volume-setup binnen remote composities.
+- Organisatie wil dataderving voorkomen door geautomatiseerde back-ups met retentie en duidelijke runbooks.
+
+## 2. Doelen
+1. Creëer herhaalbaar backupmechanisme voor staging en production dat in containers draait.
+2. Zorg voor retentie/cleanup zodat schijfruimte beperkt blijft en off-host verplaatsing mogelijk blijft.
+3. Documenteer runbook + configuratie zodat DevOps-team het kan beheren en auditen.
+
+## 3. Scope & Grenzen
+**In scope**
+- Aanpassingen aan `docker/compose.staging.yml` en `docker/compose.production.yml` (of equivalente bestanden) om backupcontainers/cron toe te voegen.
+- Re-usable script/config (bijv. parametriseren van `backup-dev-db.sh` of nieuwe variant) voor niet-dev omgevingen.
+- Logging, retentie en volume mounts nodig voor automatische backupjob.
+- Documentatie van installatie/operationele stappen in relevante `docs/` secties.
+
+**Out of scope**
+- Volledige offsite replicatie (S3, rsync) buiten basis dump + opschoning.
+- Migratie naar managed database services.
+- Realtime replication/failover (enkel batch back-ups).
+
+## 4. Constraints & Assumpties
+- Bestaande constraints blijven gelden (C-PII-Logging, C-API-Timeouts).
+- Backups mogen geen secrets lekken; gebruik `.env` placeholders en zorg dat wachtwoorden via env variabelen komen.
+- Cronjobs moeten idempotent draaien: geen overlappende runs (gebruik `flock` of container scheduling).
+- Retentie ≥7 dagen tenzij anders afgesproken.
+
+## 5. Aanpak (Stappen)
+1. **Analyse Compose Files**
+   - Inventariseer staging/prod compose bestanden, check bestaande volumes/services.
+   - Bepaal beste plek voor backupjob (dedicated utility container vs. host cron + `docker exec`).
+2. **Ontwerp Backup Service**
+   - Parametriseer script (env-vars) voor omgevingsspecifieke credentials en paden.
+   - Definieer cron schedule (bijv. dagelijks 03:00) en volume mounts (`/app`, `/backups`).
+3. **Implementatie**
+   - Update compose-bestanden met backup-service/cron, volume mounts, en secrets.
+   - Voeg eventuele nieuwe env-variabelen toe aan `.env.example` + document constraints.
+4. **Validatie & Documentatie**
+   - Schrijf/aanpassen tests of scripts indien nodig (dry-run, `docker compose run backup`).
+   - Documenteer runbook (starten, monitoren, loglocaties) in `docs/AimTrack/tech/` en update `docs/AimTrack/index.md` Recent.
+
+## 6. Acceptatiecriteria
+1. Staging- en productiecompose bevatten een geconfigureerde backupjob die minimaal dagelijks een gzipte dump + retentie uitvoert zonder handmatige stappen.
+2. Backupconfig is gedocumenteerd (runbook + env vars) en logt naar een gedeeld volume zodat operators status kunnen verifiëren.
+3. Nieuwe/gewijzigde scripts draaien succesvol in CI/local test (bijv. `docker compose run backup --dry-run`) en voldoen aan lint/test vereisten.
+
+## 7. Afhankelijkheden & Open Vragen
+- Welke exacte compose-bestandsnamen voor staging/prod? (te bevestigen)
+- Opslaglocatie voor langdurige retentie (blijft voorlopig op host?).
+- Is encryptie vereist voor dumpbestanden?

--- a/scripts/backup-dev-db.sh
+++ b/scripts/backup-dev-db.sh
@@ -5,35 +5,65 @@ set -euo pipefail
 # prunes backups older than RETENTION_DAYS (default: 7).
 #
 # Optional environment overrides:
+#   BACKUP_MODE    (compose|direct, default: compose)
 #   COMPOSE_FILE   (default: docker/compose.dev.yml)
 #   ENV_FILE       (default: .env.local)
 #   DB_SERVICE     (default: db)
 #   BACKUP_DIR     (default: <repo>/backups)
 #   BACKUP_PREFIX  (default: db)
 #   RETENTION_DAYS (default: 7)
+#   DB_HOST        (direct mode default: localhost)
+#   DB_PORT        (default: 5432)
+#   DB_DATABASE    (default: aimtrack)
+#   DB_USERNAME    (default: aimtrack)
+#   DB_PASSWORD    (default: aimtrack)
+#   BACKUP_DRY_RUN (set to 1 to skip pg_dump and create placeholder output)
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
+BACKUP_MODE="${BACKUP_MODE:-compose}"
 COMPOSE_FILE="${COMPOSE_FILE:-docker/compose.dev.yml}"
 ENV_FILE="${ENV_FILE:-.env.local}"
 DB_SERVICE="${DB_SERVICE:-db}"
 BACKUP_DIR="${BACKUP_DIR:-${PROJECT_ROOT}/backups}"
 BACKUP_PREFIX="${BACKUP_PREFIX:-db}"
 RETENTION_DAYS="${RETENTION_DAYS:-7}"
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_USERNAME="${DB_USERNAME:-aimtrack}"
+DB_DATABASE="${DB_DATABASE:-aimtrack}"
+DB_PASSWORD="${DB_PASSWORD:-aimtrack}"
+BACKUP_DRY_RUN="${BACKUP_DRY_RUN:-0}"
 
 timestamp="$(date +%Y%m%d-%H%M%S)"
 backup_path="${BACKUP_DIR}/${BACKUP_PREFIX}-${timestamp}.sql"
 
 mkdir -p "${BACKUP_DIR}"
 
-echo "[backup] Dumping database to ${backup_path}"
-docker compose \
-  -f "${PROJECT_ROOT}/${COMPOSE_FILE}" \
-  --env-file "${PROJECT_ROOT}/${ENV_FILE}" \
-  exec -T "${DB_SERVICE}" \
-  sh -c 'pg_dump --no-owner --no-privileges -U "${DB_USERNAME:-aimtrack}" -d "${DB_DATABASE:-aimtrack}"' \
-  > "${backup_path}"
+if [ "${BACKUP_DRY_RUN}" = "1" ]; then
+  echo "[backup] DRY-RUN enabled; writing placeholder dump to ${backup_path}"
+  echo "dry-run placeholder $(date --iso-8601=seconds)" > "${backup_path}"
+elif [ "${BACKUP_MODE}" = "compose" ]; then
+  echo "[backup] Dumping database via docker compose to ${backup_path}"
+  docker compose \
+    -f "${PROJECT_ROOT}/${COMPOSE_FILE}" \
+    --env-file "${PROJECT_ROOT}/${ENV_FILE}" \
+    exec -T "${DB_SERVICE}" \
+    sh -c 'pg_dump --no-owner --no-privileges -U "${DB_USERNAME:-aimtrack}" -d "${DB_DATABASE:-aimtrack}"' \
+    > "${backup_path}"
+else
+  echo "[backup] Dumping database via direct pg_dump (${DB_HOST}:${DB_PORT}/${DB_DATABASE})"
+  export PGPASSWORD="${DB_PASSWORD}"
+  pg_dump \
+    --no-owner \
+    --no-privileges \
+    --host "${DB_HOST}" \
+    --port "${DB_PORT}" \
+    --username "${DB_USERNAME}" \
+    --dbname "${DB_DATABASE}" \
+    > "${backup_path}"
+fi
 
 echo "[backup] Compressing ${backup_path}"
 gzip -f "${backup_path}"


### PR DESCRIPTION
…ing for staging and production

- Add backup service to compose.staging.yml and compose.prod.yml with dedicated volumes (db_backups_staging/prod)
- Add docker/backup/entrypoint.sh to configure cron with BACKUP_SCHEDULE (default: 0 3 * * *)
- Add docker/backup/run-backup.sh wrapper to invoke backup script in direct mode
- Extend scripts/backup-dev-db.sh with BACKUP_MODE (compose|direct), direct pg_dump support, and BACKUP_DRY_RUN