### PR TITLE
chore: add worktree-setup script and parallel-development guideline

### DIFF
--- a/.ai/guidelines/parallel-worktrees.md
+++ b/.ai/guidelines/parallel-worktrees.md
@@ -1,0 +1,65 @@
+# Parallelle ontwikkeling via Git Worktrees
+
+## Wanneer
+
+Gebruik een aparte worktree zodra je een feature wilt ontwikkelen terwijl een andere stack (`aimtrack_dev` of een andere worktree) actief blijft. Denk aan:
+
+- Parallelle Jira-tickets / feature branches
+- Migratie-trajecten die de hoofd-dev niet mogen blokkeren
+- Browser testen van een nieuwe feature naast een werkende baseline
+
+Niet gebruiken voor: hotfix op de huidige branch, kleine refactor in de huidige stack.
+
+## Hoe — altijd via het setup script
+
+```bash
+./scripts/worktree-setup.sh <feature-naam> [offset]
+```
+
+Het script:
+1. Maakt `../aimtrack-<feature>` aan met branch `feature/<feature>`
+2. Kopieert `.env.local` (Laravel-config) naar de worktree
+3. Maakt een **aparte** `.env` in de worktree project root met de docker-compose overrides (`COMPOSE_PROJECT_NAME`, poorten)
+4. Print de URL's en cleanup-instructies
+
+Vervolgens:
+
+```bash
+cd ../aimtrack-<feature>
+docker compose --env-file .env -f docker/compose.dev.yml up -d
+docker compose --env-file .env -f docker/compose.dev.yml exec app php artisan migrate --seed
+```
+
+**Cruciaal**: gebruik altijd `--env-file .env`. Docker Compose leest `.env.local` niet, en zonder de flag worden alle compose-variabelen genegeerd. Dat heeft als bijwerking dat de containers de hoofd-dev project name (`aimtrack_dev`) en default poorten (8080, 5432, ...) gebruiken — waardoor je hoofd-dev stack wordt overschreven.
+
+## Verboden
+
+- **Niet** de root `docker-compose.yml` gebruiken voor parallelle stacks — heeft hardcoded `container_name` en geeft conflicten. Altijd `-f docker/compose.dev.yml`.
+- **Niet** `--env-file` weglaten in compose commands — zonder die flag mount de worktree per ongeluk de hoofd-dev stack.
+- **Niet** handmatig worktrees aanmaken zonder het script — dan loopt de poort-administratie en `.env`-isolatie uit de pas.
+- **Niet** dezelfde branch in twee worktrees checkouten (Git verbiedt dit, maar zelf opletten).
+
+## Cleanup
+
+```bash
+cd ../aimtrack-<feature>
+docker compose --env-file .env -f docker/compose.dev.yml down -v
+cd -
+git worktree remove ../aimtrack-<feature>
+git branch -d feature/<feature>   # alleen na merge
+```
+
+Vergeet de registry hieronder niet bij te werken.
+
+## Registry van actieve worktrees
+
+| Feature | Branch | Pad | Web | DB | Mailpit | Python | Status |
+|---|---|---|---|---|---|---|---|
+| _hoofd-dev_ | _huidige_ | `aimtrack/` | 8080 | 5432 | 8025 | 8000 | actief |
+| copilot | feature/copilot | `aimtrack-copilot/` | 19080 | 15433 | 19025 | 19000 | actief (Filament Copilot migratie) |
+
+Update deze tabel bij setup en cleanup — zo weet iedereen direct welke poort bij welke stack hoort.
+
+## Cross-machine borging
+
+Dit guideline bestand is in git, dus elke developer en elke Claude sessie volgt dezelfde aanpak. MEMORY.md is **niet** geschikt — die is per-machine en zou niet meereizen.

--- a/.ai/plans/PLAN-filament-copilot-migratie.md
+++ b/.ai/plans/PLAN-filament-copilot-migratie.md
@@ -1,0 +1,105 @@
+---
+status: APPROVED
+created: 2026-04-25
+approved: 2026-04-25
+author: Claude
+jira: n/a
+---
+
+# PLAN: Migratie naar Filament Copilot Plugin
+
+## Status: APPROVED
+
+## Samenvatting
+
+Migreer de bestaande AI-coach chat functionaliteit (`AiCoachPage`, `CoachQuestion`, `CoachSession`) naar de `eslam-reda-div/filament-copilot` plugin. Behoud de bestaande async reflectie- en inzichtengeneratie (`AiReflection`, `AiWeaponInsight`) via de eigen `ShooterCoach` service.
+
+## Motivatie
+
+De huidige `AiCoachPage` is een zelfgebouwde chat-UI zonder streaming, met handmatige history-opslag en beperkte UX. De Copilot plugin biedt:
+- SSE streaming responses (token-voor-token)
+- Ingebouwde conversation persistence en history sidebar
+- Agent memory systeem (feiten onthouden over sessies heen)
+- Configureerbare rate limiting en token budgets
+- Uitbreidbaar via custom tools en `CopilotPage` interface
+
+## Acceptatiecriteria
+
+1. Gebruiker kan AI-coachvragen stellen via Copilot modal in het Filament panel
+2. Schuttercontext (recente sessies, wapen, datumrange) wordt automatisch geïnjecteerd via `CopilotPage`
+3. Conversation history is beschikbaar en laadbaar via Copilot sidebar
+4. Rate limiting is geconfigureerd (minimaal gelijkwaardig aan huidige 3/uur, 10/dag)
+5. Gebruiker kan reflectie voor een sessie triggeren via chat ("genereer reflectie")
+6. `AiReflection` en `AiWeaponInsight` generatie blijft ongewijzigd functioneren
+7. Feature flag `aimtrack-ai` blijft werken via Copilot `authorizeUsing` closure
+8. Alle bestaande tests blijven groen; nieuwe tests dekken Copilot integratie
+
+## Buiten scope
+
+- Migratie van bestaande `CoachQuestion` data naar Copilot conversation history
+- Vervanging van `ShooterCoach` service voor reflectie/insight generatie
+- Verandering van AI provider (blijft OpenAI)
+- Management dashboard van Copilot plugin activeren
+
+## Afhankelijkheden & risico's
+
+| Risico | Impact | Mitigatie |
+|---|---|---|
+| `laravel/ai` is v0 (breaking changes mogelijk) | Hoog | Pin op exacte versie, monitor releases |
+| Temperature (0.3) en MaxTokens (4096) hardcoded in plugin | Medium | Accepteren of fork voor eigen configuratie |
+| Community plugin, geen first-party onderhoud | Medium | 81 tests aanwezig, actieve repo |
+
+## Architectuur
+
+### Wat verdwijnt
+- `app/Filament/Pages/AiCoachPage.php`
+- `resources/views/filament/pages/ai-coach-page.blade.php`
+- `resources/views/filament/modals/ai-coach-question.blade.php`
+- `app/Models/CoachQuestion.php`
+- `app/Models/CoachSession.php`
+- Migratie `create_coach_questions_table` (data archiveren voor verwijdering)
+
+### Wat blijft
+- `app/Services/Ai/ShooterCoach.php` (alleen reflectie/insight methoden)
+- `app/Models/AiReflection.php`
+- `app/Models/AiWeaponInsight.php`
+- `app/Jobs/GenerateSessionReflectionJob.php`
+- `app/Notifications/AiCoachFailureNotification.php`
+- `config/ai.php`
+
+### Wat nieuw wordt gebouwd
+- `app/Filament/Copilot/Tools/ShooterContextTool.php` — injecteert sessie/wapen context
+- `app/Filament/Copilot/Tools/GenerateReflectionTool.php` — triggert `GenerateSessionReflectionJob`
+- Implementatie van `CopilotPage` op de AI-coach pagina (of verwijderd indien overbodig)
+
+## Fasering
+
+### Fase 1 — Installatie & basis chat (MEDIUM)
+- [ ] Voeg `eslam-reda-div/filament-copilot` en `laravel/ai` toe via Composer
+- [ ] Publiceer config, assets en migraties van de plugin
+- [ ] Configureer provider (OpenAI), model en systeem prompt in `FilamentCopilotPlugin`
+- [ ] Koppel feature flag via `authorizeUsing(fn() => AimtrackFeatureToggle::aiEnabled())`
+- [ ] Stel rate limiting in (3/uur, 10/dag)
+- [ ] Verifieer basiswerking van chat modal in panel
+
+### Fase 2 — Schuttercontext & tools (MEDIUM)
+- [ ] Implementeer `ShooterContextTool` met wapen + sessie-data als context
+- [ ] Implementeer `GenerateReflectionTool` als wrapper rond `GenerateSessionReflectionJob`
+- [ ] Voeg `CopilotResource` interface toe aan `SessionResource` (optioneel)
+- [ ] Schrijf systeemprompt specifiek voor schutterscoaching (gebaseerd op huidige `ShooterCoach` prompt)
+
+### Fase 3 — Opruimen (SIMPLE)
+- [ ] Verwijder `AiCoachPage` en bijhorende views
+- [ ] Verwijder `CoachQuestion` en `CoachSession` models (na datamigratie/-archivering)
+- [ ] Vereenvoudig `ShooterCoach` service (verwijder `answerCoachQuestion`)
+- [ ] Update navigatie en feature flag checks
+
+### Fase 4 — Tests & documentatie (verplicht per fase)
+- [ ] Feature tests voor Copilot tool integratie
+- [ ] Verifieer bestaande reflectie/insight tests nog groen
+- [ ] Update `docs/AimTrack/` met nieuwe architectuur
+
+## Goedkeuring
+
+- [ ] Plan reviewed door gebruiker
+- [ ] Status gewijzigd naar APPROVED voor start BUILD MODE

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/worktree-setup.sh
+# Maakt een Git worktree + geïsoleerde Docker stack voor parallelle ontwikkeling.
+#
+# Gebruik: ./scripts/worktree-setup.sh <feature-naam> [offset] [base-branch]
+#   <feature-naam>: lowercase, bv. "copilot" of "auth-rewrite"
+#   [offset]      : optioneel, integer (default: aantal bestaande worktrees)
+#   [base-branch] : optioneel, basis-branch voor de worktree (default: main)
+#
+# Belangrijk:
+# - Docker Compose leest GEEN .env.local. Voor compose-variabelen wordt een
+#   APARTE .env in de worktree project root aangemaakt. Compose moet altijd
+#   draaien met de --env-file flag, anders worden de overrides genegeerd:
+#       docker compose --env-file .env -f docker/compose.dev.yml up -d
+# - Poorten starten op 19000+ om conflicten met andere lokale projecten
+#   (mototrax, openjarvis, etc.) te vermijden.
+
+NAME="${1:-}"
+EXPLICIT_OFFSET="${2:-}"
+BASE_BRANCH="${3:-main}"
+
+if [[ -z "$NAME" ]]; then
+  echo "Gebruik: $0 <feature-naam> [offset] [base-branch]" >&2
+  exit 1
+fi
+
+if [[ ! "$NAME" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+  echo "Feature-naam mag alleen lowercase letters, cijfers, '-' en '_' bevatten." >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+WORKTREE_PATH="$REPO_ROOT/../aimtrack-${NAME}"
+BRANCH="feature/${NAME}"
+PROJECT_NAME="aimtrack_${NAME}"
+
+if [[ -e "$WORKTREE_PATH" ]]; then
+  echo "Pad bestaat al: $WORKTREE_PATH" >&2
+  exit 1
+fi
+
+if [[ -n "$EXPLICIT_OFFSET" ]]; then
+  OFFSET="$EXPLICIT_OFFSET"
+else
+  # Bestaande worktrees tellen (inclusief hoofd-dev). Eerste extra worktree → offset 1.
+  OFFSET="$(git worktree list | wc -l | tr -d ' ')"
+fi
+
+# Poort-range vanaf 19000 om conflicten met andere lokale stacks te vermijden.
+WEB_PORT=$((19080 + OFFSET))
+DB_FORWARD_PORT=$((15432 + OFFSET))
+PYTHON_SERVICE_PORT=$((19000 + OFFSET))
+MAILPIT_HTTP_PORT=$((19025 + OFFSET))
+MAILPIT_SMTP_PORT=$((11025 + OFFSET))
+
+if ! git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null; then
+  echo "Basis-branch '$BASE_BRANCH' bestaat niet lokaal. Run 'git fetch' of geef een geldige branch op als 3e argument." >&2
+  exit 1
+fi
+
+echo "==> Worktree aanmaken: $WORKTREE_PATH (branch: $BRANCH, basis: $BASE_BRANCH)"
+git worktree add -b "$BRANCH" "$WORKTREE_PATH" "$BASE_BRANCH"
+
+# Kopieer .env.local zodat Laravel zelf z'n env heeft (DB_PASSWORD, APP_KEY, etc.)
+for candidate in .env.local .env.example; do
+  if [[ -f "$REPO_ROOT/$candidate" ]]; then
+    cp "$REPO_ROOT/$candidate" "$WORKTREE_PATH/.env.local"
+    echo "==> .env.local gekopieerd uit $candidate"
+    break
+  fi
+done
+
+# Maak .env in de worktree root met ALLEEN docker compose overrides.
+# Deze .env wordt door 'docker compose --env-file .env' gelezen.
+cat > "$WORKTREE_PATH/.env" <<EOF
+# Docker Compose variabele overrides (auto-gegenereerd door scripts/worktree-setup.sh)
+# Lezen via: docker compose --env-file .env -f docker/compose.dev.yml ...
+COMPOSE_PROJECT_NAME=${PROJECT_NAME}
+WEB_PORT=${WEB_PORT}
+DB_FORWARD_PORT=${DB_FORWARD_PORT}
+PYTHON_SERVICE_PORT=${PYTHON_SERVICE_PORT}
+MAILPIT_HTTP_PORT=${MAILPIT_HTTP_PORT}
+MAILPIT_SMTP_PORT=${MAILPIT_SMTP_PORT}
+EOF
+
+cat <<EOF
+
+==> Worktree klaar: $WORKTREE_PATH
+
+LET OP: Gebruik altijd '--env-file .env' bij docker compose commands.
+Zonder die flag worden defaults gebruikt en mounten containers de hoofd-dev stack.
+
+Volgende stappen:
+  cd $WORKTREE_PATH
+  docker compose --env-file .env -f docker/compose.dev.yml up -d
+  docker compose --env-file .env -f docker/compose.dev.yml exec app php artisan migrate --seed
+
+Toegangs-URL's:
+  Web:        http://localhost:${WEB_PORT}
+  Mailpit:    http://localhost:${MAILPIT_HTTP_PORT}
+  Postgres:   localhost:${DB_FORWARD_PORT}
+  Python svc: http://localhost:${PYTHON_SERVICE_PORT}
+
+Project name: ${PROJECT_NAME}
+
+Vergeet niet de registry in .ai/guidelines/parallel-worktrees.md bij te werken.
+
+Cleanup later:
+  cd $WORKTREE_PATH && docker compose --env-file .env -f docker/compose.dev.yml down -v
+  cd $REPO_ROOT && git worktree remove $WORKTREE_PATH
+EOF


### PR DESCRIPTION
Adds tooling for parallel feature development via Git worktrees:
- scripts/worktree-setup.sh creates an isolated worktree with its own Docker stack (separate COMPOSE_PROJECT_NAME, ports, .env), branched from main by default
- .ai/guidelines/parallel-worktrees.md documents the workflow, including the --env-file requirement to prevent the parallel stack from accidentally taking over the main dev containers
- .ai/plans/PLAN-filament-copilot-migratie.md captures the approved migration plan toward the Filament Copilot plugin