### PR TITLE
chore: auto-publish filament assets after composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "scripts": {
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover --ansi"
+            "@php artisan package:discover --ansi",
+            "@php artisan filament:assets --ansi"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""


### PR DESCRIPTION
Adds `php artisan filament:assets` to the post-autoload-dump composer hook. Filament publishes its panel CSS/JS into public/ which is gitignored, so a fresh checkout/worktree was missing those files — causing 404s for app.css, livewire.js, actions.js, etc. until the command was run manually. Hooking it into post-autoload-dump means every `composer install` and `composer update` now keeps the assets in sync, so this can't be forgotten on a new worktree or clone.