### PR TITLE
docs(workflow): hoofdrepo-discipline + main-sync precondition voor worktrees

### DIFF
--- a/.ai/guidelines/core-workflow.md
+++ b/.ai/guidelines/core-workflow.md
@@ -51,6 +51,8 @@ Je levert geen ontwerp, code of tests voordat het PLAN de status APPROVED heeft.
 15. API Model zonder timeout configuratie → STOP + timeout toevoegen
 16. API Model zonder retry logic voor mutaties → STOP + retry implementatie
 17. Nieuwe code in legacy style zonder @legacy tag en ADR → STOP + architectuur compliance
+18. Werk (plan-files, code, scratch) in de hoofdrepo (`aimtrack/`, branch `main`) → STOP + verplaats naar de juiste worktree. Hoofdrepo is alleen voor main-sync. Zie [`.ai/guidelines/parallel-worktrees.md`](parallel-worktrees.md).
+19. `worktree-setup.sh` aangeroepen met achterlopende lokale `main` → STOP + `git pull --ff-only` in hoofdrepo, dan opnieuw. Anders splitst de worktree van een verouderde basis en mist gemergde dependencies.
 
 ## PHASE 0 – TASK ASSESSMENT (altijd eerst uitvoeren)
 1. Classificeer de input:

--- a/.ai/guidelines/parallel-worktrees.md
+++ b/.ai/guidelines/parallel-worktrees.md
@@ -10,6 +10,25 @@ Gebruik een aparte worktree zodra je een feature wilt ontwikkelen terwijl een an
 
 Niet gebruiken voor: hotfix op de huidige branch, kleine refactor in de huidige stack.
 
+## Hoofdrepo-discipline
+
+De hoofd-clone (`/home/brandnetel/projects/aimtrack`, branch `main`) is **alleen voor main-sync**. Geen feature-werk, geen scratch-files, geen plan-bestanden in `.ai/plans/`. Reden:
+
+- Untracked files in de hoofdrepo blokkeren `git pull --ff-only` zodra origin een file met dezelfde naam introduceert ("would be overwritten by merge"). Dit is precies hoe een gemergde feature-PR (die het bijbehorende plan tracked maakt) een schijnbaar onschuldige lokale plan-file in een blocker verandert.
+- De hoofdrepo werkt als sync-knooppunt voor alle worktrees: vies werk kruipt door op elke nieuwe worktree die je vanaf `main` afsplitst.
+
+## Vóór je `worktree-setup.sh` aanroept
+
+1. **Lokale `main` fast-forwarden:** `git -C /home/brandnetel/projects/aimtrack pull --ff-only`. Het script splitst de nieuwe branch af van **lokale** `main`; staat die achter, dan mist je nieuwe worktree net-gemergde features (incl. de migraties/services waar je plan op leunt).
+2. **Hoofdrepo schoon:** `git status` in de hoofdrepo moet leeg zijn. Verplaats lopende plan-files of scratch-werk eerst naar de worktree waar ze bij horen.
+3. **Bevestig de afhankelijkheden:** als je nieuwe feature op een nog niet-gemergde branch leunt, splits dan vanaf die branch (`git worktree add -b <naam> ../aimtrack-<naam> <basis-branch>`) en niet via het script — het script forceert `main` als basis.
+
+## Plan-files horen in de worktree
+
+Schrijf `.ai/plans/<TICKET>.md` **in de worktree** (`../aimtrack-<naam>/.ai/plans/<TICKET>.md`), niet in de hoofdrepo. Het plan reist dan mee op de feature-branch, wordt onderdeel van de PR-diff, en blokkeert geen pulls op main.
+
+Als je tijdens het scopen al een DRAFT plan in de hoofdrepo hebt geschreven (bijv. omdat de worktree er nog niet was): verplaats hem naar de juiste worktree zodra die bestaat, vóór de eerste commit. Laat de hoofdrepo daarna leeg achter (`git status` clean).
+
 ## Hoe — altijd via het setup script
 
 ```bash
@@ -38,6 +57,8 @@ docker compose --env-file .env -f docker/compose.dev.yml exec app php artisan mi
 - **Niet** `--env-file` weglaten in compose commands — zonder die flag mount de worktree per ongeluk de hoofd-dev stack.
 - **Niet** handmatig worktrees aanmaken zonder het script — dan loopt de poort-administratie en `.env`-isolatie uit de pas.
 - **Niet** dezelfde branch in twee worktrees checkouten (Git verbiedt dit, maar zelf opletten).
+- **Niet** plan-files of feature-werk in de hoofdrepo plaatsen — zie "Hoofdrepo-discipline" en "Plan-files horen in de worktree".
+- **Niet** `worktree-setup.sh` aanroepen met een achterlopende lokale `main` — pull eerst, anders splits je van een verouderde basis en mis je gemergde dependencies.
 
 ## Cleanup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ Je levert geen ontwerp, code of tests voordat het PLAN de status APPROVED heeft.
 15. API Model zonder timeout configuratie → STOP + timeout toevoegen
 16. API Model zonder retry logic voor mutaties → STOP + retry implementatie
 17. Nieuwe code in legacy style zonder @legacy tag en ADR → STOP + architectuur compliance
+18. Werk (plan-files, code, scratch) in de hoofdrepo (`aimtrack/`, branch `main`) → STOP + verplaats naar de juiste worktree. Hoofdrepo is alleen voor main-sync. Zie [`.ai/guidelines/parallel-worktrees.md`](.ai/guidelines/parallel-worktrees.md).
+19. `worktree-setup.sh` aangeroepen met achterlopende lokale `main` → STOP + `git pull --ff-only` in hoofdrepo, dan opnieuw. Anders splitst de worktree van een verouderde basis en mist gemergde dependencies.
 
 ## PHASE 0 – TASK ASSESSMENT (altijd eerst uitvoeren)
 1. Classificeer de input:


### PR DESCRIPTION
Voegt twee BLOCKING RULES (#18 en #19) toe en drie secties aan parallel-worktrees.md om twee terugkerende worktree-problemen te voorkomen:

1. Untracked plan-files in de hoofdrepo blokkeren `git pull --ff-only` zodra origin een file met dezelfde naam introduceert (bijv. via een gemergde feature-PR die het plan tracked maakt).
2. Een nieuwe worktree die wordt afgesplitst van een achterlopende lokale `main` mist gemergde dependencies (migraties, services waarop het nieuwe plan leunt) en breekt op subtiele wijzes.

De nieuwe regels eisen daarom expliciet:
- De hoofdrepo blijft schoon en is alleen voor main-sync; plan-files, scratch-werk en feature-code horen in de worktree.
- `worktree-setup.sh` wordt pas aangeroepen na een succesvolle `git pull --ff-only` op de hoofdrepo's `main`.

Mirror van Marcvdc/mototrax#3, geadapteerd voor aimtrack-paden, `main` als default branch en de `.ai/guidelines/` map-indeling. CLAUDE.md krijgt rules 18 & 19 erbij omdat de core-workflow rules daar embedded zijn voor Claude's context.