### PR TITLE
feat(ops): borg productie backup-strategie in repo (#83)

### DIFF
--- a/.ai/guidelines/parallel-worktrees.md
+++ b/.ai/guidelines/parallel-worktrees.md
@@ -78,6 +78,7 @@ Vergeet de registry hieronder niet bij te werken.
 |---|---|---|---|---|---|---|---|
 | _hoofd-dev_ | _huidige_ | `aimtrack/` | 8080 | 5432 | 8025 | 8000 | actief |
 | copilot | feature/copilot | `aimtrack-copilot/` | 19080 | 15433 | 19025 | 19000 | actief (Filament Copilot migratie) |
+| prod-backups | feature/prod-backups | `aimtrack-prod-backups/` | 19085 | 15437 | 19030 | 19005 | actief (issue #83 — prod backup-strategie in repo) |
 
 Update deze tabel bij setup en cleanup — zo weet iedereen direct welke poort bij welke stack hoort.
 

--- a/.ai/plans/PLAN-prod-backup-strategie.md
+++ b/.ai/plans/PLAN-prod-backup-strategie.md
@@ -1,0 +1,128 @@
+---
+status: APPROVED
+created: 2026-05-14
+approved: 2026-05-14
+author: Claude (Opus 4.7)
+github_issue: Marcvdc/AimTrack#83
+labels: enhancement, devops
+---
+
+# PLAN: Productie backup-strategie borgen in repo (#83)
+
+## Status: APPROVED
+
+## Samenvatting
+
+De productie-backupinfrastructuur (DB-dump + storage-rsync + maandelijkse hersteltest) draait nu vanuit handmatig aangemaakte scripts in `/home/madmin/` op de prod-host. Deze scripts staan niet in git en gaan verloren bij een server-rebuild. Dit PLAN borgt de scripts in de repo, fixt een padbug in de bestaande dev-backup-runner, documenteert de productie-crontab en eigenaarschap, en splitst offsite-backup (rclone → Backblaze B2) af naar een follow-up issue.
+
+## Motivatie
+
+- **Risico:** server-rebuild of disk-failure → backup-strategie weg, herstel onmogelijk te reproduceren.
+- **Bewezen werkend:** hersteltest 2026-05-14 → 22 tabellen, 1 user, 7 sessies, 142 schoten, 3 wapens — GESLAAGD. We borgen wat al draait, geen nieuw ontwerp.
+- **Bugfix:** `docker/backup/run-backup.sh` verwijst naar `/app/scripts/...` maar de container mount op `/var/www/html` — runner zou nooit werken in de huidige image.
+
+## Acceptatiecriteria (AC)
+
+1. `scripts/backup-aimtrack.sh` bestaat in de repo, identiek aan de prod-versie uit het issue, executable (`chmod +x`).
+2. `scripts/restore-test-aimtrack.sh` bestaat in de repo, identiek aan de prod-versie uit het issue, executable.
+3. `docker/backup/run-backup.sh` verwijst naar `/var/www/html/scripts/backup-dev-db.sh` (was `/app/scripts/...`) en de sudo-vereiste bij `app_aimtrack` eigenaarschap is gedocumenteerd.
+4. `docs/BACKUPS.md` bevat de productie-procedure: crontab-regels (03:00 dagelijks backup, 04:00 op 1e v/d maand hersteltest), eigenaarschap (`madmin`), rechten (`chmod +x`), log-locatie (`/home/madmin/aimtrack-backups/logs/cron.log`), sudo-note voor `run-backup.sh`, hersteltest-bewijs (datum + counts).
+5. `docs/BACKUPS.md` bevat een check dat productie `.env` `APP_ENV=production` heeft (niet `local`). `.env.example` blijft staan op `production`.
+6. Offsite-backup (rclone → Backblaze B2) is afgesplitst naar een nieuw GitHub-issue, gelabeld `enhancement`/`devops`/`backlog`, met de drie sub-tasks uit issue #83 sectie 4.
+7. Pint loopt schoon (`vendor/bin/pint --dirty` na de wijzigingen).
+8. `php artisan test --compact` blijft groen (geen functionele code-paden gewijzigd; we voegen bash-scripts en docs toe).
+
+## Buiten scope
+
+- Daadwerkelijk uitvoeren van offsite-config (rclone install, B2 keys) — dat hoort op de prod-server en in een follow-up ticket.
+- Wijzigingen aan `scripts/backup-dev-db.sh` zelf — die werkt en wordt door de runner aangeroepen; alleen het pad in de runner is fout.
+- Migratie van crontab van host naar een container/systemd-timer — keep what works.
+- Een ADR — dit is een ops-borging van bestaande, werkende infra, geen nieuwe architectuurkeuze.
+
+## Afhankelijkheden & risico's
+
+| Risico | Impact | Mitigatie |
+|---|---|---|
+| Script-inhoud wijkt af van wat op prod draait | Hoog | 1-op-1 overnemen uit issue #83 (door eigenaar bevestigd op 2026-05-14). |
+| Iemand kopieert script naar prod zonder rechten te zetten | Medium | `chmod +x` in repo + docs-sectie "Installatie op prod-host". |
+| `run-backup.sh` padfix breekt dev-backup voor mensen die de oude image draaien | Laag | Image mount-pad is `/var/www/html` (zie `docker/compose.dev.yml`). Oude `/app/` werkt nu al niet, dus geen regressie. |
+| Toegevoegde scripts vragen om Pest-coverage (STOP-conditie 9) | Medium | Scripts zijn bash, geen PHP. Pest dekt geen bash. We documenteren dat dekking via runtime (cron-log + maandelijkse hersteltest) plaatsvindt. Vragen aan reviewer of dit OK is. |
+
+## Architectuur
+
+### Wat verdwijnt
+
+- `/app/scripts/backup-dev-db.sh` als pad-string in `docker/backup/run-backup.sh` (was bug).
+
+### Wat blijft
+
+- `scripts/backup-dev-db.sh` (dev backup, werkt al).
+- `docker/backup/run-backup.sh` (alleen pad-string vervangen).
+
+### Wat nieuw wordt toegevoegd
+
+- `scripts/backup-aimtrack.sh` (prod DB-dump + storage-rsync + rotatie).
+- `scripts/restore-test-aimtrack.sh` (maandelijkse hersteltest).
+- Uitbreiding van `docs/BACKUPS.md` met sectie "Productie installatie & crontab".
+- Update van `.ai/guidelines/parallel-worktrees.md` registry (al gedaan in deze worktree-setup).
+
+## Fasering
+
+### Fase 1 — Scripts in repo (SIMPLE)
+1. `scripts/backup-aimtrack.sh` — exact zoals in issue, `chmod +x`.
+2. `scripts/restore-test-aimtrack.sh` — exact zoals in issue, `chmod +x`.
+
+**Klaar wanneer:** beide bestanden bestaan, executable zijn, `bash -n` valideert syntax zonder fouten.
+
+### Fase 2 — Bugfix runner (SIMPLE)
+3. `docker/backup/run-backup.sh`: default voor `BACKUP_SCRIPT` van `/app/scripts/backup-dev-db.sh` → `/var/www/html/scripts/backup-dev-db.sh`.
+
+**Klaar wanneer:** runner verwijst naar correct mount-pad. Geen container nodig om dit te testen — `grep` volstaat.
+
+### Fase 3 — Documentatie (SIMPLE)
+4. `docs/BACKUPS.md` uitbreiden met:
+   - "Productie installatie" sectie (pad `/home/madmin/`, ownership, `chmod +x`).
+   - Crontab-regels (verbatim uit issue).
+   - Sudo-note voor `run-backup.sh` wanneer `app_aimtrack` eigenaar van het dev-bestand is.
+   - `APP_ENV=production` check.
+   - Hersteltest-bewijs 2026-05-14 (1 regel, traceerbaar).
+
+**Klaar wanneer:** alle 5 sub-bullets staan in het bestand, sectie-anchor `## Productie installatie` bestaat.
+
+### Fase 4 — Follow-up issue (SIMPLE)
+5. Nieuw GitHub-issue aanmaken voor offsite (rclone+B2) met:
+   - Title: `feat: offsite backup naar Backblaze B2 via rclone (follow-up #83)`.
+   - Body: 3 sub-tasks uit issue #83 sectie 4 + verwijzing naar dit ticket.
+   - Labels: `enhancement`, `devops`, `backlog`.
+
+**Klaar wanneer:** issue staat in GitHub, URL is bekend.
+
+### Fase 5 — Lint + test + commit (SIMPLE)
+6. `vendor/bin/pint --dirty`.
+7. `php artisan test --compact` (sanity check; geen nieuwe PHP-tests omdat geen PHP raakt aangepast).
+8. Commit per fase (script, bugfix, docs, follow-up-link) — wacht expliciet op approval per commit volgens core-workflow.
+9. PR openen die issue #83 sluit (Fases 1-3-5 sluiten 4 van de 5 sub-tasks; Fase 4 sluit AC 6).
+
+## Open vragen aan reviewer (Marc)
+
+1. **Coverage-STOP (regel 9):** scripts zijn bash, geen Pest-coverage mogelijk. Akkoord om runtime-bewijs (cron-log + maandelijkse hersteltest) als equivalent te tellen, of moeten we een Pest browser/smoke-test bedenken die het `scripts/`-pad valideert?
+2. **`docs/BACKUPS.md` of nieuwe `docs/operations/backups-prod.md`?** `BACKUPS.md` bestaat al, ik stel voor om uit te breiden. OK?
+3. **Commit-strategie:** één commit per fase (4 commits) of één gebundelde commit voor issue #83? Issue raakt 4 onafhankelijke artefacten — ik leun naar gebundeld omdat ze samen sluiten.
+
+## STOP-condities (uit core-workflow)
+
+| # | Conditie | Status |
+|---|---|---|
+| 1 | PLAN bestaat | OK (dit document) |
+| 2 | ≥3 AC's + verplichte secties | OK (8 AC's, alle secties) |
+| 4 | MCP/JIRA actief | n.v.t. (GitHub-issue, geen Jira) |
+| 5 | Linter schoon | uit te voeren in Fase 5 |
+| 6 | Code zonder tests/docs | bash-scripts → zie open vraag 1 |
+| 7 | Secrets in ENV | geen — scripts bevatten alleen container-/user-namen |
+| 9 | Coverage 90% gewijzigd | zie open vraag 1 |
+| 10 | PLAN vs JIRA divergent | n.v.t. |
+| 11-17 | Architectuur-regels | n.v.t. (alleen bash + docs) |
+
+## Sign-off
+
+- [ ] Marc — review AC's en open vragen, geef APPROVED voor BUILD MODE.

--- a/docker/backup/run-backup.sh
+++ b/docker/backup/run-backup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -euo pipefail
 
-SCRIPT_PATH="${BACKUP_SCRIPT:-/app/scripts/backup-dev-db.sh}"
+SCRIPT_PATH="${BACKUP_SCRIPT:-/var/www/html/scripts/backup-dev-db.sh}"
 
 if [ ! -f "${SCRIPT_PATH}" ]; then
   echo "[backup-runner] Script not found at ${SCRIPT_PATH}" >&2

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -37,3 +37,57 @@ Doel: eenvoudige, herstelbare back-ups voor database (PostgreSQL) en uploads (st
 - **Healthcheck:** `/health` endpoint monitort DB/queue/storage toegankelijkheid.
 - **Logboek:** documenteer uitgevoerde back-ups (tijdstip, resultaat, locatie) en hersteltesten.
 - **Alerting:** configureer alerts op mislukte back-ups en healthcheck failures via Sentry/monitoring.
+
+## Productie installatie
+
+De repo bevat twee scripts die op de productie-host (`madmin`) draaien:
+
+- `scripts/backup-aimtrack.sh` — dagelijkse `pg_dump` van container `aimtrack_db` + `rsync` van `storage/app` + rotatie (7 dagelijks, 4 wekelijks, 3 maandelijks).
+- `scripts/restore-test-aimtrack.sh` — maandelijkse hersteltest naar tijdelijke database `aimtrack_restore_test`, controleert tabel- en rijcounts.
+
+### Installatie
+
+```bash
+# als madmin op de prod-host
+cp /var/www/AimTrack/scripts/backup-aimtrack.sh       /home/madmin/backup-aimtrack.sh
+cp /var/www/AimTrack/scripts/restore-test-aimtrack.sh /home/madmin/restore-test-aimtrack.sh
+chmod +x /home/madmin/backup-aimtrack.sh /home/madmin/restore-test-aimtrack.sh
+mkdir -p /home/madmin/aimtrack-backups/{db,storage,logs}
+```
+
+**Eigenaarschap:** beide scripts horen bij gebruiker `madmin` (de cron-eigenaar) en hebben `chmod +x`. De backup-doelmap (`/home/madmin/aimtrack-backups`) is alleen leesbaar voor `madmin`.
+
+### Crontab (madmin)
+
+```cron
+0 3 * * *   /home/madmin/backup-aimtrack.sh        >> /home/madmin/aimtrack-backups/logs/cron.log 2>&1
+0 4 1 * *   /home/madmin/restore-test-aimtrack.sh  >> /home/madmin/aimtrack-backups/logs/cron.log 2>&1
+```
+
+- 03:00 dagelijks → backup.
+- 04:00 op de 1e van de maand → hersteltest.
+- Beide scripts schrijven hun eigen dagrotatie-logbestand in `/home/madmin/aimtrack-backups/logs/`, plus naar de gecombineerde `cron.log`.
+
+### Productie `.env`
+
+Controleer dat productie `.env` `APP_ENV=production` heeft staan (niet `local`). `.env.example` in de repo gebruikt al `production` als default.
+
+### Coverage / verificatie
+
+Bash-scripts zijn niet via Pest gedekt. De runtime-verificatie verloopt via:
+
+1. De maandelijkse hersteltest (cron-regel 2) — exitcode 0 = restore werkt; >0 = pager.
+2. Het dagelijkse cron-log (`/home/madmin/aimtrack-backups/logs/cron.log`) — niet-lege regels = success.
+3. Visuele check `ls -lh /home/madmin/aimtrack-backups/db/` — verwacht 7 daily + tot 4 weekly + tot 3 monthly.
+
+Laatst geslaagde hersteltest: **2026-05-14** → 22 tabellen · 1 user · 7 sessies · 142 schoten · 3 wapens.
+
+## Dev-backup runner (`docker/backup/run-backup.sh`)
+
+Voor lokale dev draait er een aparte runner-container die `scripts/backup-dev-db.sh` aanroept. Het mount-pad in de runner is `/var/www/html/scripts/backup-dev-db.sh` (gelijk aan de andere services in `docker/compose.dev.yml`).
+
+> **Let op:** wanneer `scripts/backup-dev-db.sh` op de host als `app_aimtrack` (of een andere niet-`madmin`/root) eigenaar staat, moet de runner via `sudo` worden gestart — anders kan de container het script niet executable lezen. Zet desnoods `chmod 755 scripts/backup-dev-db.sh` voor brede leesbaarheid.
+
+## Offsite backup
+
+Offsite-replicatie naar Backblaze B2 (rclone install + bucket + appkey + `rclone sync` append) is afgesplitst naar follow-up issue [#84](https://github.com/Marcvdc/AimTrack/issues/84).

--- a/scripts/backup-aimtrack.sh
+++ b/scripts/backup-aimtrack.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# AimTrack production backup — database (pg_dump) + storage (rsync)
+# Rotatie: 7 dagelijks, 4 wekelijks, 3 maandelijks
+# Gebruik: ./backup-aimtrack.sh [--dry-run]
+set -euo pipefail
+
+BACKUP_ROOT="/home/madmin/aimtrack-backups"
+DB_DIR="${BACKUP_ROOT}/db"
+STORAGE_DIR="${BACKUP_ROOT}/storage"
+LOG_DIR="${BACKUP_ROOT}/logs"
+LOG_FILE="${LOG_DIR}/backup-$(date +%Y%m%d).log"
+
+APP_STORAGE_SRC="/var/www/AimTrack/storage/app"
+DB_CONTAINER="aimtrack_db"
+DB_USER="postgres"
+DB_NAME="aimtrack"
+
+RETAIN_DAILY=7
+RETAIN_WEEKLY=4
+RETAIN_MONTHLY=3
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=1
+fi
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "${LOG_FILE}"; }
+die() { log "FOUT: $*"; exit 1; }
+
+run() {
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+        log "[DRY-RUN] $*"
+    else
+        "$@"
+    fi
+}
+
+rotate_old() {
+    local dir="$1" pattern="$2" keep="$3"
+    local count
+    count=$(find "${dir}" -maxdepth 1 -name "${pattern}" -type f | wc -l)
+    if (( count > keep )); then
+        find "${dir}" -maxdepth 1 -name "${pattern}" -type f \
+            | sort | head -n $(( count - keep )) \
+            | while IFS= read -r f; do
+                log "  Verwijder oud: ${f}"
+                run rm -f "${f}"
+            done
+    fi
+}
+
+docker inspect "${DB_CONTAINER}" --format '{{.State.Running}}' 2>/dev/null | grep -q true \
+    || die "Container ${DB_CONTAINER} draait niet."
+
+mkdir -p "${DB_DIR}" "${STORAGE_DIR}" "${LOG_DIR}"
+
+log "=== AimTrack backup gestart ==="
+[[ "${DRY_RUN}" -eq 1 ]] && log "*** DRY-RUN modus — geen bestanden worden aangemaakt ***"
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+DAY_OF_WEEK="$(date +%u)"
+DAY_OF_MONTH="$(date +%d)"
+
+DAILY_FILE="${DB_DIR}/daily-${TIMESTAMP}.sql.gz"
+log "Database dump → ${DAILY_FILE}"
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+    docker exec "${DB_CONTAINER}" \
+        pg_dump -U "${DB_USER}" --no-owner --no-privileges "${DB_NAME}" \
+        | gzip -9 > "${DAILY_FILE}"
+    log "  Grootte: $(du -sh "${DAILY_FILE}" | cut -f1)"
+fi
+
+if [[ "${DAY_OF_WEEK}" == "1" ]]; then
+    WEEKLY_FILE="${DB_DIR}/weekly-$(date +%Y-W%V).sql.gz"
+    log "Wekelijkse kopie → ${WEEKLY_FILE}"
+    run cp "${DAILY_FILE}" "${WEEKLY_FILE}"
+    rotate_old "${DB_DIR}" "weekly-*.sql.gz" "${RETAIN_WEEKLY}"
+fi
+
+if [[ "${DAY_OF_MONTH}" == "01" ]]; then
+    MONTHLY_FILE="${DB_DIR}/monthly-$(date +%Y-%m).sql.gz"
+    log "Maandelijkse kopie → ${MONTHLY_FILE}"
+    run cp "${DAILY_FILE}" "${MONTHLY_FILE}"
+    rotate_old "${DB_DIR}" "monthly-*.sql.gz" "${RETAIN_MONTHLY}"
+fi
+
+rotate_old "${DB_DIR}" "daily-*.sql.gz" "${RETAIN_DAILY}"
+
+log "Storage rsync: ${APP_STORAGE_SRC} → ${STORAGE_DIR}"
+if [[ -d "${APP_STORAGE_SRC}" ]]; then
+    if [[ "${DRY_RUN}" -eq 0 ]]; then
+        rsync -a --delete "${APP_STORAGE_SRC}/" "${STORAGE_DIR}/"
+        log "  Rsync klaar ($(du -sh "${STORAGE_DIR}" | cut -f1) totaal)"
+    else
+        log "[DRY-RUN] rsync -a --delete ${APP_STORAGE_SRC}/ ${STORAGE_DIR}/"
+    fi
+else
+    log "  WAARSCHUWING: ${APP_STORAGE_SRC} niet gevonden, storage backup overgeslagen."
+fi
+
+log "=== Backup succesvol afgerond ==="
+log "DB bestanden:"
+ls -lh "${DB_DIR}"/*.sql.gz 2>/dev/null | awk '{print "  " $5 "  " $9}' | tee -a "${LOG_FILE}" || true

--- a/scripts/restore-test-aimtrack.sh
+++ b/scripts/restore-test-aimtrack.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# AimTrack maandelijkse hersteltest
+# Gebruik: ./restore-test-aimtrack.sh [--keep]
+set -euo pipefail
+
+BACKUP_ROOT="/home/madmin/aimtrack-backups"
+DB_DIR="${BACKUP_ROOT}/db"
+LOG_DIR="${BACKUP_ROOT}/logs"
+LOG_FILE="${LOG_DIR}/restore-test-$(date +%Y%m%d).log"
+
+DB_CONTAINER="aimtrack_db"
+DB_USER="postgres"
+RESTORE_DB="aimtrack_restore_test"
+
+KEEP_DB=0
+[[ "${1:-}" == "--keep" ]] && KEEP_DB=1
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "${LOG_FILE}"; }
+die() { log "FOUT: $*"; exit 1; }
+
+log "=== AimTrack hersteltest gestart ==="
+
+DUMP_FILE="$(find "${DB_DIR}" -maxdepth 1 -name "daily-*.sql.gz" -type f | sort | tail -n1)"
+[[ -z "${DUMP_FILE}" ]] && die "Geen dagelijkse dump gevonden in ${DB_DIR}"
+log "Dump: ${DUMP_FILE} ($(du -sh "${DUMP_FILE}" | cut -f1))"
+
+docker exec "${DB_CONTAINER}" \
+    psql -U "${DB_USER}" -c "DROP DATABASE IF EXISTS ${RESTORE_DB};" postgres \
+    >> "${LOG_FILE}" 2>&1
+
+log "Aanmaken testdatabase: ${RESTORE_DB}"
+docker exec "${DB_CONTAINER}" \
+    psql -U "${DB_USER}" -c "CREATE DATABASE ${RESTORE_DB};" postgres \
+    >> "${LOG_FILE}" 2>&1
+
+log "Herstellen dump..."
+gunzip -c "${DUMP_FILE}" \
+    | docker exec -i "${DB_CONTAINER}" \
+        psql -U "${DB_USER}" -d "${RESTORE_DB}" -q \
+    >> "${LOG_FILE}" 2>&1
+
+TABLE_COUNT=$(docker exec "${DB_CONTAINER}" \
+    psql -U "${DB_USER}" -d "${RESTORE_DB}" -tAc \
+    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';")
+log "Aantal tabellen in herstelde DB: ${TABLE_COUNT}"
+
+for table in users sessions session_shots weapons; do
+    ROW_COUNT=$(docker exec "${DB_CONTAINER}" \
+        psql -U "${DB_USER}" -d "${RESTORE_DB}" -tAc \
+        "SELECT count(*) FROM ${table};" 2>/dev/null || echo "ONTBREEKT")
+    log "  ${table}: ${ROW_COUNT} rijen"
+done
+
+if [[ "${TABLE_COUNT}" -lt 5 ]]; then
+    log "WAARSCHUWING: Minder dan 5 tabellen gevonden — controleer dump!"
+    EXIT_CODE=1
+else
+    log "Hersteltest GESLAAGD (${TABLE_COUNT} tabellen)"
+    EXIT_CODE=0
+fi
+
+if [[ "${KEEP_DB}" -eq 0 ]]; then
+    log "Verwijderen testdatabase..."
+    docker exec "${DB_CONTAINER}" \
+        psql -U "${DB_USER}" -c "DROP DATABASE ${RESTORE_DB};" postgres \
+        >> "${LOG_FILE}" 2>&1
+else
+    log "Testdatabase bewaard als: ${RESTORE_DB}"
+fi
+
+log "=== Hersteltest afgerond (exitcode: ${EXIT_CODE}) ==="
+exit "${EXIT_CODE}"


### PR DESCRIPTION
## Summary

- Plaatst de prod-backup scripts (`backup-aimtrack.sh`, `restore-test-aimtrack.sh`) in de repo zodat ze een server-rebuild overleven.
- Fixt het pad-bug in `docker/backup/run-backup.sh` (`/app/scripts/...` → `/var/www/html/scripts/...`) zodat de dev-backup runner überhaupt kan starten.
- Documenteert in `docs/BACKUPS.md` de productie-installatie, crontab (`madmin`), eigenaarschap, sudo-note voor de dev-runner, `APP_ENV=production` check en hersteltest-bewijs (2026-05-14: 22 tabellen, 142 schoten — GESLAAGD).

Volledige planning + open vragen + AC's staan in `.ai/plans/PLAN-prod-backup-strategie.md` (status APPROVED).

## Closes

- Closes #83

## Refs

- #84 — offsite backup (rclone + Backblaze B2) is afgesplitst naar een follow-up issue.

## Test plan

- [ ] `bash -n scripts/backup-aimtrack.sh && bash -n scripts/restore-test-aimtrack.sh` (geverifieerd lokaal).
- [ ] `sh -n docker/backup/run-backup.sh` (geverifieerd lokaal).
- [ ] Geen PHP gewijzigd, dus Pest/Pint hebben geen targets; CI hoort daarom gewoon groen te zijn.
- [ ] Op de prod-host: scripts kopiëren naar `/home/madmin/`, `chmod +x`, crontab updaten volgens `docs/BACKUPS.md` — zelfde state als nu, maar nu reproduceerbaar vanuit git.
- [ ] Optioneel: dev-runner één keer aanroepen om te bevestigen dat het pad-fix werkt (`docker compose --env-file .env -f docker/compose.dev.yml run --rm backup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)