### PR TITLE
feat(range-console): 5 core screens (#82 fase 1)

### DIFF
--- a/.ai/guidelines/parallel-worktrees.md
+++ b/.ai/guidelines/parallel-worktrees.md
@@ -80,6 +80,8 @@ Vergeet de registry hieronder niet bij te werken.
 | copilot | feature/copilot | `aimtrack-copilot/` | 19080 | 15433 | 19025 | 19000 | actief (Filament Copilot migratie) |
 | design-foundation | feature/design-foundation | `aimtrack-design-foundation/` | 19084 | 15436 | 19029 | 19004 | actief (issue #82 · Fase 0 foundation) |
 | prod-backups | feature/prod-backups | `aimtrack-prod-backups/` | 19085 | 15437 | 19030 | 19005 | actief (issue #83 — prod backup-strategie in repo) |
+| empty-states | feature/empty-states | `aimtrack-empty-states/` | 19086 | 15438 | 19031 | 19006 | actief (issue #82 · Fase 2 empty-states) |
+| range-console | feature/range-console | `aimtrack-range-console/` | 19087 | 15439 | 19032 | 19007 | actief (issue #82 · Fase 1 Range Console — 5 kernschermen) |
 
 Update deze tabel bij setup en cleanup — zo weet iedereen direct welke poort bij welke stack hoort.
 

--- a/.ai/plans/PLAN-issue-82-fase-1-range-console.md
+++ b/.ai/plans/PLAN-issue-82-fase-1-range-console.md
@@ -1,0 +1,414 @@
+---
+status: APPROVED
+created: 2026-05-15
+updated: 2026-05-15
+approved: 2026-05-15 (Marcvdc)
+author: Claude (Opus 4.7)
+jira: GH#82
+worktree: aimtrack-range-console (feature/range-console)
+basis: e809582 (main, post-PR #86 merge)
+---
+
+# PLAN: Issue #82 · Fase 1 — Range Console (5 kernschermen)
+
+## Status: APPROVED
+
+BUILD-mode actief vanaf 2026-05-15. Per stap commit + sign-off; pas door
+naar volgende stap na expliciete OK van gebruiker.
+
+## Beslissingen na review (2026-05-15)
+
+1. **Scope per scherm** → **pixel-close**: alles uit design tonen,
+   ontbrekende data = placeholder `—`. Veld-pollutie geaccepteerd; design-
+   balans is leidend.
+2. **Series-card** → **dynamisch**: aantal series afgeleid van
+   `session.discipline` (LP10 = 6×10, vrije sessies = `total_shots / 10`).
+   `SessionStatsService::seriesScores($session)` rekent dit zelf uit.
+3. **Kalibratie-velden** → **migratie + form-velden** voor
+   `korrel_correction`, `vizier_correction`, `trigger_weight_g`,
+   `grip_size` op `weapons`-tabel. Volledige feature, niet alleen visueel.
+4. **AI-coach chat** → **hybride**: FilamentCopilot levert message-state +
+   tool-execution, eigen Blade-DOM rendert de 3-koloms layout. Vereist
+   exposure van Copilot's chat-state via een Livewire-property of
+   render-hook — onderzocht in stap 5.
+5. **Nieuwe-sessie wizard** → **Filament Wizard component (in-page)** met
+   custom CSS om dichter bij het design te komen. Geen modal-overlay.
+6. **Live AI-tip wizard-stap 3** → **hard-coded mock-tekst**. Geen
+   Copilot-call. Box toont design-voorbeeld; functionaliteit voor latere
+   iteratie.
+7. **Sessies-overzicht zoekbalk** → **Filament global search skin**:
+   bestaande search-bar via custom CSS dichter bij design (search-icon,
+   monospace placeholder, ⌘K-chip).
+8. **PR-strategie** → **1 PR met alle 5 schermen**. Per stap commit +
+   sign-off (zoals afgesproken in Fase 2 PLAN).
+
+## Samenvatting
+
+Vijf kernschermen van het Filament-panel herontwerpen in het Signal Mint
+dark design uit Fase 0, op basis van de Range Console-richting (variation
+A) uit `.ai/design-handoff/project/`:
+
+1. **Sessies-overzicht** — `SessionResource` index-pagina krijgt KPI-strip,
+   page-header met T1 watermark, geherontworpen tabel en een rechter-rail
+   met "Laatste sessie" target-rings + AI-reflectie (T3 BracketFrame) +
+   30d trend-spark. (`range-console.jsx`)
+2. **Sessie-detail** — `SessionResource` view-pagina met header-card
+   (T1 watermark + T4 "WM-4 OK" stamp), 5-cell stats-strip, series-card
+   (6×10), shot-strip (60 bars), hit-pattern target-rings, T3
+   AI-reflectie en eigen-notitie. (`a-screens.jsx · SessionDetail`)
+3. **Wapen-detail** — `WeaponResource` view-pagina met links een
+   identiteits-card (wapen-silhouet, status-rijen, kalibratie-blok) en
+   rechts 4 KPI's + lange score-trend + sessies-met-dit-wapen tabel.
+   (`a-screens.jsx · WeaponDetail`)
+4. **AI-coach view** — `CoachPage` blade-view krijgt 3-koloms layout:
+   gesprekken-rail links, chat-thread centraal met composer + quick-reply
+   chips, context-rail rechts (actieve sessies/wapens/doelen).
+   (`a-screens.jsx · AICoachView`)
+5. **Nieuwe-sessie wizard** — Stap-voor-stap flow voor `CreateSession`:
+   Wapen → Sessie → Schoten → Notities. Live "VOORTGANG / LOPENDE SCORE /
+   GEM. PER SCHOT" readout, score-numpad of handmatige invoer, context-rail
+   met sessie/wapen/opties. (`new-session-wizard.jsx`)
+
+Alle 5 hergebruiken de Fase 0 Blade-componenten (`<x-aimtrack.reticle>`,
+`<x-aimtrack.watermark-bg>`, `<x-aimtrack.bracket-frame>`,
+`<x-aimtrack.monogram-stamp>`, `<x-aimtrack.wordmark>`) en de
+`aimtrack-tokens.css` variabelen.
+
+**Niet in scope:** Empty states (Fase 2), mobile companion (Fase 4),
+marketing landing (Fase 3), Tactical-HUD en Field-Journal varianten
+(alternatieve richtingen, expliciet uit issue gehaald).
+
+## Motivatie
+
+- De 5 kernschermen vormen samen 80% van de gebruikerstijd in de app —
+  herontwerp hier levert de meeste perceived-quality lift.
+- Fase 0 heeft alle tokens + logo-componenten geland zonder afnemers; deze
+  fase activeert ze in echte UI.
+- AC3 uit issue #82 stelt expliciet: "Sessie-detail toont schot-voor-schot
+  strip, hit-pattern target-rings en T3-bracketed AI-reflectie panel;
+  pixel-close aan `range-console.jsx` SessionDetail."
+- De nieuwe-sessie wizard maakt de hoofdactie (sessie loggen) sneller dan
+  de huidige lange InfoSection-form — en is de plek waar gebruikers
+  vandaag de meeste friction ervaren.
+
+## Acceptatiecriteria
+
+1. **AC1** — `<x-aimtrack.page-header>` Blade-component met slot voor
+   `title`, `subtitle`, `actions` + ingebouwde T1 watermark (positie en
+   opacity configureerbaar). Wordt gebruikt door AC2, AC4 en AC6.
+2. **AC2** — `ListSessions` rendert: page-header, 4 KPI-widgets
+   (Sessies/mnd, Schoten totaal, Beste serie, AI-reflecties), de bestaande
+   tabel met aangepaste kolommen + statusbadges (AI ⇢ groen, open ⇢ amber),
+   en een rechter-rail met `LastSessionPreviewWidget` (target-rings + score
+   readouts) + `LatestReflectionWidget` (T3 BracketFrame) +
+   `Trend30dWidget` (sparkline). Visueel pixel-close aan
+   `range-console.jsx`.
+3. **AC3** — `ViewSession` toont: header-card (T1 watermark + T4
+   monogram-stamp "WM-4 OK") met datum/discipline/score; 5-cell stats-row
+   (Beste schot, Tienen, Negens, Groep, Gem. cadans); series-card
+   (6 × 10-schoten balken met `accent` als ≥95); shot-strip met 60 bars
+   (groen ≥10, amber bij concentratie-dip, grijs normaal); hit-pattern
+   target-rings; T3 AI-reflectie-panel met STERK/VERBETER/VOLGENDE rijen;
+   eigen-notitie kaart. **Vereist `SessionShot`-data** (al beschikbaar).
+   Kolommen `tienen`, `negens`, `groep_mm`, `cadans_sec` kunnen on-the-fly
+   afgeleid worden uit shots — geen migratie nodig.
+4. **AC4** — `ViewWeapon` toont: links een ID-kaart (foto-placeholder
+   SVG-silhouet, naam, type, kaliber, serial, KALIBRATIE-blok met
+   korrel/vizier/trekker/handgreep); rechts 4-cell KPI's + score-trend
+   spark + tabel "Sessies met dit wapen". **Open punt 3** beslist of de
+   kalibratie-velden in DB worden opgeslagen of read-only zonder
+   persistence (uit `notes` parsing of helemaal weggelaten).
+5. **AC5** — `CoachPage` rendert in een 3-koloms layout: chat-list rail
+   (recente gesprekken), centrale chat-thread met Copilot-integratie en
+   composer + quick-reply chips, context-rail (actieve sessies/wapens +
+   voorgestelde doelen + privacy-notice). **Open punt 4** beslist of we
+   FilamentCopilot's chat-widget integreren of een eigen Livewire-chat
+   bouwen.
+6. **AC6** — `CreateSession` route gebruikt een Filament Wizard met 4
+   stappen (Wapen, Sessie, Schoten, Notities). Stap "Schoten" toont een
+   live VOORTGANG/LOPENDE SCORE/GEM-readout, een 60-slot shot-strip
+   (filled/placeholder), een score-numpad (10.9 … 8 … 0) of handmatige
+   invoer, en een context-rail met sessie/wapen + AI-tijdens-sessie tip.
+   **Open punt 5** beslist of dit een modal-overlay (zoals design) of een
+   in-page wizard (Filament-default) wordt.
+7. **AC7** — De AI-reflectie card in AC2 en AC3 hergebruikt dezelfde
+   `<x-aimtrack.ai-reflection-card>` component met props
+   `reflection`, `compact?` en `actions[]`.
+8. **AC8** — Target-rings (`<x-aimtrack.target-rings>`) en shot-strip
+   (`<x-aimtrack.shot-strip>`) zijn herbruikbare Blade-componenten met
+   geconfigureerde grootte, kleuren via tokens, hits-array prop.
+9. **AC9** — Per scherm minimaal 3 Pest-tests:
+   - Smoke: pagina rendert zonder errors voor user met data
+   - Empty: pagina rendert ook zonder data (voor sessie-detail: stub)
+   - Assertief op aanwezigheid van design-elementen (`assertSee('LP10')`,
+     `assertSeeBlade('x-aimtrack.bracket-frame')`)
+
+   Plus component-tests per nieuwe `<x-aimtrack.*>` component.
+   Totaal: ≥20 nieuwe tests.
+10. **AC10** — `vendor/bin/pint --dirty` clean, `php artisan test --compact`
+    groen. Coverage op nieuwe code ≥90%.
+11. **AC11** — Manuele rondgang in dev-stack (`http://localhost:19087`)
+    door alle 5 schermen zonder JS-errors of console-warnings.
+12. **AC12** — Architectuur: nieuwe afgeleide stats voor SessionShot
+    (Tienen/Negens/Groep/Cadans) gaan via een dedicated
+    `SessionStatsService` of Eloquent-accessor — **geen** business-logica
+    in Blade-views of Filament Resources (CLAUDE.md rule 11/12).
+
+## Buiten scope
+
+- Migraties voor nieuwe kolommen (kalibratie, etc.) tenzij **open punt 3**
+  zegt anders.
+- Empty-states voor de 5 nieuwe schermen — Fase 2.
+- AI-coach prompt-engineering of nieuwe Copilot-tools — gebruik wat er is.
+- Onderhouds-loggen op WeaponDetail (CTA-button uit design) — alleen
+  visueel, geen functie. Toekomstige iteratie.
+- Match-routine planner / trainingsdoelen-tabel uit AI-coach
+  context-rail — UI placeholder, geen achterliggende tabel.
+
+## Afhankelijkheden & risico's
+
+| Risico | Impact | Mitigatie |
+|---|---|---|
+| Wizard-overlay (modal) past niet binnen Filament v5 page-structure | Hoog | **Open punt 5** — keuze tussen in-page Wizard (Filament-default, makkelijk) of custom Livewire modal (matched design beter, meer werk). PLAN biedt beide paden. |
+| FilamentCopilot's chat-widget niet hergebruikbaar als 3-koloms-embed | Medium | **Open punt 4** — fallback is custom Livewire chat. CoachPage werkt vandaag, dus we kunnen 3-koloms layout om de bestaande widget heen bouwen. |
+| SessionShot-data niet betrouwbaar genoeg voor afgeleide stats | Medium | Stats die niet berekenbaar zijn tonen `—` placeholder. Smoke-test asserts dat de stats-cells altijd renderen. |
+| Kalibratie-velden ontbreken op `Weapon`-model | Laag | **Open punt 3** — keuze tussen migratie of read-only weergeven. PLAN geeft drie paden. |
+| Range Console list-view "Wapens-gebruik" card vergt aggregate query per request | Laag | Cache per-user voor 5 min via `Cache::remember()` keyed op `weapons-usage:{user_id}`. Invalidate via SessionShot-observer. |
+| Performance van page-header T1 watermark op elke pagina | Laag | T1 is inline SVG, geen runtime cost. Al gebenchmarked in Fase 0. |
+| 5 schermen in 1 PR = grote diff, slechte reviewbaar | Hoog | **Open punt 8** — keuze: alles in 1 PR óf split in 2-3 sub-PR's per scherm-cluster (zie fasering). |
+
+## Architectuur
+
+### Bestandsboom (na BUILD)
+
+```
+resources/views/components/aimtrack/                # bestaand (Fase 0)
+├── page-header.blade.php                           # NIEUW · AC1
+├── target-rings.blade.php                          # NIEUW · AC8
+├── shot-strip.blade.php                            # NIEUW · AC8
+├── series-card.blade.php                           # NIEUW · 6×10 balken
+├── stat-card.blade.php                             # NIEUW · KPI-cel
+├── ai-reflection-card.blade.php                    # NIEUW · AC7 (T3 wrap)
+└── (bestaande Fase 0 componenten — ongewijzigd)
+
+resources/views/filament/
+├── pages/coach-page.blade.php                      # WIJZIG · 3-koloms layout
+├── resources/sessions/
+│   ├── view-session.blade.php                      # NIEUW · custom view
+│   └── session-shot-board-panel.blade.php          # ONGEWIJZIGD
+└── resources/weapons/
+    └── view-weapon.blade.php                       # NIEUW · custom view
+
+app/Filament/
+├── Pages/CoachPage.php                             # WIJZIG · context bindings
+├── Resources/SessionResource.php                   # WIJZIG · table tweaks
+├── Resources/SessionResource/Pages/
+│   ├── ListSessions.php                            # WIJZIG · widgets + header
+│   ├── ViewSession.php                             # WIJZIG · custom view
+│   └── CreateSession.php                           # WIJZIG · Wizard wrap
+├── Resources/WeaponResource.php                    # WIJZIG · table tweaks
+├── Resources/WeaponResource/Pages/
+│   └── ViewWeapon.php                              # WIJZIG · custom view
+└── Widgets/
+    ├── LastSessionPreviewWidget.php                # NIEUW · target-rings
+    ├── LatestReflectionWidget.php                  # NIEUW · T3 card
+    ├── Trend30dWidget.php                          # NIEUW · sparkline
+    └── SessionsKpiWidget.php                       # NIEUW · 4 KPI's
+
+app/Services/                                       # nieuw (architectuur-rule)
+├── SessionStatsService.php                         # NIEUW · tienen/negens/groep/cadans
+└── WeaponInsightsService.php                       # NIEUW · 4 KPI's + trend-data
+
+tests/Feature/RangeConsole/
+├── ListSessionsScreenTest.php                      # NIEUW · AC2 + AC9
+├── ViewSessionScreenTest.php                       # NIEUW · AC3 + AC9
+├── ViewWeaponScreenTest.php                        # NIEUW · AC4 + AC9
+├── AiCoachScreenTest.php                           # NIEUW · AC5 + AC9
+└── NewSessionWizardTest.php                        # NIEUW · AC6 + AC9
+tests/Unit/Aimtrack/
+├── PageHeaderComponentTest.php                     # NIEUW · AC1
+├── TargetRingsComponentTest.php                    # NIEUW · AC8
+├── ShotStripComponentTest.php                      # NIEUW · AC8
+└── AiReflectionCardComponentTest.php               # NIEUW · AC7
+tests/Unit/Services/
+├── SessionStatsServiceTest.php                     # NIEUW · AC12
+└── WeaponInsightsServiceTest.php                   # NIEUW · AC12
+```
+
+### Architectuur-lagen (CLAUDE.md rules 11/12)
+
+```
+[Filament Page]  ──reads──>  [Service]  ──reads──>  [Model::query()]
+   (view binding)              (stats logica)         (Eloquent only)
+        │
+        └──renders──> [Blade component <x-aimtrack.*>]
+                         (presentation only,
+                          props in / DOM out)
+```
+
+Geen `DB::`, geen business-logica in Resources of Blade.
+
+### Component-API (3 voorbeelden)
+
+```blade
+{{-- AC1 --}}
+<x-aimtrack.page-header
+    :reticle-opacity="0.07"
+    :reticle-size="180"
+    title="Sessies"
+    subtitle="Overzicht van je trainingen · 247 totaal"
+>
+    <x-slot:actions>
+        <a href="…" class="at-btn">Filter</a>
+        <a href="…" class="at-btn-prim">Nieuwe sessie</a>
+    </x-slot:actions>
+</x-aimtrack.page-header>
+
+{{-- AC8 --}}
+<x-aimtrack.shot-strip
+    :shots="$session->shots->pluck('score')"
+    :total-slots="60"
+    :dip-range="[33, 42]"  {{-- optioneel, auto-detect via stats-service --}}
+/>
+
+{{-- AC7 --}}
+<x-aimtrack.ai-reflection-card :reflection="$session->aiReflection" :session-id="$session->id">
+    <x-slot:actions>
+        <button class="at-btn-ghost">Vraag coach</button>
+        <button class="at-btn">Markeer</button>
+    </x-slot:actions>
+</x-aimtrack.ai-reflection-card>
+```
+
+### SessionStatsService (architectuur-voorbeeld)
+
+```php
+final class SessionStatsService
+{
+    public function __construct(private readonly Session $session) {}
+
+    public function tienen(): int { /* count shots ≥10.0 */ }
+    public function negens(): int { /* count 9.0–9.9 */ }
+    public function groupMm(): ?float { /* SD-based group calc */ }
+    public function avgCadansSec(): ?float { /* time-delta between shots */ }
+    public function seriesScores(int $perSerie = 10): array { /* 6×10 sums */ }
+    public function dipRange(): ?array { /* [from, to] van laagste reeks */ }
+}
+```
+
+## Fasering
+
+Voorgestelde fasering — gefaseerd commits + sign-off per stap (per
+afspraak in Fase 2 PLAN).
+
+### Stap 1 — Shared components + services
+- [ ] `<x-aimtrack.page-header>` + test
+- [ ] `<x-aimtrack.target-rings>` + test
+- [ ] `<x-aimtrack.shot-strip>` + test
+- [ ] `<x-aimtrack.series-card>` + test
+- [ ] `<x-aimtrack.stat-card>` + test
+- [ ] `<x-aimtrack.ai-reflection-card>` + test
+- [ ] `SessionStatsService` + test
+- [ ] `WeaponInsightsService` + test
+- [ ] Pint clean
+
+### Stap 2 — Sessies-overzicht (ListSessions)
+- [ ] 4 KPI-widgets
+- [ ] Page-header met T1
+- [ ] Tabel-tweaks (statusbadges, kolom-volgorde)
+- [ ] Rechter-rail widgets (LastSession + LatestReflection + Trend30d)
+- [ ] AC2 + AC9 tests
+
+### Stap 3 — Sessie-detail (ViewSession)
+- [ ] Custom view-template
+- [ ] Header-card (T1 + T4)
+- [ ] Stats-row, series-card, shot-strip
+- [ ] Hit-pattern target-rings
+- [ ] T3 AI-reflectie + eigen-notitie
+- [ ] AC3 + AC9 tests
+
+### Stap 4 — Wapen-detail (ViewWeapon)
+- [ ] Custom view-template
+- [ ] ID-kaart links (foto-silhouet + status-rijen + kalibratie)
+- [ ] KPI's + lange trend + sessies-tabel rechts
+- [ ] AC4 + AC9 tests
+
+### Stap 5 — AI-coach view (CoachPage)
+- [ ] 3-koloms layout
+- [ ] Chat-list rail
+- [ ] Copilot-chat-embed of custom Livewire-chat (per **open punt 4**)
+- [ ] Context-rail rechts
+- [ ] AC5 + AC9 tests
+
+### Stap 6 — Nieuwe-sessie wizard (CreateSession)
+- [ ] Filament Wizard óf custom modal (per **open punt 5**)
+- [ ] 4 stappen: Wapen / Sessie / Schoten / Notities
+- [ ] Live VOORTGANG/LOPENDE SCORE readout op stap 3
+- [ ] Score-numpad of handmatige invoer
+- [ ] AC6 + AC9 tests
+
+### Stap 7 — Smoke + Pint + PR
+- [ ] `vendor/bin/pint --dirty`
+- [ ] `php artisan test --compact` → groen
+- [ ] Manuele browser-check op http://localhost:19087
+- [ ] `gh pr create` per **open punt 8** (1 PR of 3 sub-PR's)
+
+### Commits-cadans
+Per stap één commit + sign-off. Voorgestelde commit-titels:
+1. `feat(range-console): shared components + stats/insights services`
+2. `feat(range-console): ListSessions redesign with KPIs + right rail`
+3. `feat(range-console): ViewSession deep-dive with shot-strip + hit pattern`
+4. `feat(range-console): ViewWeapon identity card + trend + sessions`
+5. `feat(range-console): AI-coach 3-column view with context rail`
+6. `feat(range-console): new-session wizard with live shot logging`
+7. `test(range-console): feature + component coverage`
+
+PR-titel (single-PR optie): `feat(range-console): 5 core screens (#82 fase 1)`
+
+## Open punten
+
+Alle 8 punten beantwoord — zie "Beslissingen na review" bovenaan. De
+oorspronkelijke vragen blijven hieronder voor traceability.
+
+### Oorspronkelijke vragen (afgesloten)
+
+1. **Scope per scherm: pixel-close of pragmatic?** Het design toont
+   "Walther LP500 4.5 mm", "WM-4 OK", "32 minuten · 17 °C · vlak" en
+   meer detail-velden die niet allemaal in het huidige Session/Weapon-model
+   bestaan. Optie A: alles tonen, ontbrekende velden = placeholder `—`.
+   Optie B: alleen design-elementen tonen waarvoor data bestaat.
+2. **Series-card: hard-coded 6×10 of dynamisch?** Discipline LP10 doet
+   60 schoten in 6 series van 10. Vrije sessies hebben willekeurige aantallen.
+   Optie A: hard 6×10. Optie B: afgeleid van `session.discipline` of
+   `total_shots / 10`. Optie C: weglaten bij sessies zonder structuur.
+3. **Kalibratie-velden Walther** (korrel/vizier/trekker/handgreep). Opties:
+   (a) Migratie + form-velden in CreateWeapon (echte feature),
+   (b) JSON-blob in `weapon.notes` (geen migratie, parse op render),
+   (c) Read-only placeholders zonder persistence (visueel correct, geen data).
+4. **AI-coach chat-implementatie**:
+   (a) FilamentCopilot's eigen chat-widget embedded in 3-koloms layout
+       (snelste, maar widget-styling beperkt te overriden),
+   (b) Custom Livewire-chat met Copilot-API als backend (volle controle,
+       meer code), (c) Hybride: Copilot voor messages-state, eigen Blade-DOM
+       voor rendering.
+5. **Nieuwe-sessie wizard layout**:
+   (a) Filament Wizard component op standaard `CreateSession` page
+       (in-page stepper, geen modal-overlay), (b) Custom Livewire-modal
+       die over het dim-bare panel laadt (matches design pixel-close,
+       meer werk), (c) Filament v5's built-in Wizard met custom CSS om de
+       header/footer te stijlen tot dichtbij het design.
+6. **Live AI-tijdens-sessie tip** op wizard-stap 3 (groene rand-box rechts
+   onderin). Optie A: hard-coded mock-tekst (visueel). Optie B: real-time
+   Copilot-call na elke 10 schoten (kost geld + latency). C: weglaten.
+7. **Sessies-overzicht zoekbalk + ⌘K** uit design — Filament heeft eigen
+   global search. Hergebruiken of UI-only nabouwen?
+8. **PR-split**: alles in 1 PR (groot maar coherent) of split in:
+   - PR-A: shared components + ListSessions + ViewSession
+   - PR-B: ViewWeapon + AI-coach
+   - PR-C: New-session wizard
+   PR-B en PR-C kunnen parallel als shared components in PR-A landen.
+
+---
+
+**Verzoek**: beantwoord de 8 open punten. Daarna zet ik status op
+`READY_FOR_APPROVAL`. Pas na expliciete "approved" begin ik met BUILD-stap 1.

--- a/.ai/plans/PLAN-issue-82-fase-1-range-console.md
+++ b/.ai/plans/PLAN-issue-82-fase-1-range-console.md
@@ -11,10 +11,48 @@ basis: e809582 (main, post-PR #86 merge)
 
 # PLAN: Issue #82 · Fase 1 — Range Console (5 kernschermen)
 
-## Status: APPROVED
+## Status: COMPLETED
 
-BUILD-mode actief vanaf 2026-05-15. Per stap commit + sign-off; pas door
-naar volgende stap na expliciete OK van gebruiker.
+BUILD afgerond. Alle 5 kernschermen geland op `feature/range-console`,
+163 tests groen (3× stabiel), Pint clean.
+
+### Geland (commits op feature/range-console)
+1. `f4a77d1` — shared components (page-header, stat-card, target-rings,
+   shot-strip, series-card, ai-reflection-card) + SessionStatsService +
+   WeaponInsightsService.
+2. `4ee2db7` — ListSessions redesign: KPI-strip + right-rail (target-rings,
+   AI-reflectie, trend-sparkline) + RangeConsoleSummaryService + sparkline.
+3. `b747e29` — ViewSession deep-dive: header (T1 + T4 stamp), 5 stats,
+   series-card, shot-strip met dip-highlight, hit-pattern, AI-reflectie.
+4. `a83d54f` — ViewWeapon: ID-kaart + kalibratie (migratie 4 velden) +
+   KPI's + score-trend + sessies-tabel.
+5. `b1b22ee` — AI-coach 3-koloms view (hybride: Copilot-state + eigen Blade)
+   + CoachContextService.
+6. `a0000a4` — nieuwe-sessie wizard (4-staps Filament v5 Wizard) +
+   form-refactor naar herbruikbare static field-groups.
+7. `c22c2bb` — fixes uit adversariële branch-review (N+1, scoping, stats).
+
+### Afwijkingen / beslissingen tijdens BUILD
+- **Schoten-stap wizard** is een preview (numpad/readout read-only) i.p.v.
+  live loggen: het echte SessionShotBoard vereist een opgeslagen sessie en
+  logt via target-click → ring/score (niet de decimaal-numpad uit het
+  ontwerp). `getRedirectUrl()` stuurt na afronden naar het schotenbord.
+- **AI-coach** is hybride (decision 4): de bestaande FilamentCopilot-widget
+  blijft de chat-engine; de 3-koloms layout is eigen Blade.
+- **Theme-switch (AC4 uit issue)** blijft uit scope — Signal Mint dark enige
+  palet (afgesproken in Fase 0).
+- Twee adversariële review-workflows (wizard + branch-breed) uitgevoerd;
+  16 findings bevestigd en opgelost, incl. een latente Carbon-3 bug in
+  avgCadansSec (gaf altijd null in productie).
+
+### Niet in deze fase
+- Empty states (Fase 2 · aparte worktree), mobile (Fase 4), marketing (Fase 3).
+
+---
+
+## (oorspronkelijk PLAN — APPROVED 2026-05-15)
+
+Per stap commit + sign-off; pas door naar volgende stap na expliciete OK.
 
 ## Beslissingen na review (2026-05-15)
 

--- a/app/Filament/Pages/CoachPage.php
+++ b/app/Filament/Pages/CoachPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Pages;
 
 use App\Filament\Copilot\Tools\ShooterContextTool;
+use App\Services\CoachContextService;
 use App\Support\Features\AimtrackFeatureToggle;
 use BackedEnum;
 use EslamRedaDiv\FilamentCopilot\Contracts\CopilotPage as CopilotPageContract;
@@ -26,6 +27,11 @@ class CoachPage extends Page implements CopilotPageContract
     public static function shouldRegisterNavigation(): bool
     {
         return static::features()->aiEnabled() && parent::shouldRegisterNavigation();
+    }
+
+    public function getCoachContext(): CoachContextService
+    {
+        return new CoachContextService(auth()->user());
     }
 
     public static function copilotPageDescription(): ?string

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -62,197 +62,234 @@ class SessionResource extends Resource implements CopilotResourceContract
         return $schema
             ->columns(1)
             ->components([
-                Hidden::make('user_id')
-                    ->default(fn () => auth()->id())
-                    ->required()
-                    ->dehydrated(fn ($state) => filled($state)),
+                static::userIdField(),
 
                 InfoSection::make('Sessie')
                     ->description('Basisgegevens van de sessie')
                     ->columns(2)
                     ->schema([
-                        DatePicker::make('date')
-                            ->label('Datum')
-                            ->native(false)
-                            ->required(),
-                        Select::make('range_location_id')
-                            ->label('Baan/vereniging')
-                            ->options(fn () => Location::query()
-                                ->where('user_id', auth()->id())
-                                ->where('is_range', true)
-                                ->orderBy('name')
-                                ->pluck('name', 'id'))
-                            ->searchable()
-                            ->preload()
-                            ->nullable()
-                            ->afterStateUpdated(function ($state, callable $set): void {
-                                if (! $state) {
-                                    return;
-                                }
-
-                                $location = Location::query()->find($state);
-
-                                if ($location) {
-                                    $set('range_name', $location->name);
-                                }
-                            }),
-                        Select::make('location_id')
-                            ->label('Locatie')
-                            ->options(fn () => Location::query()
-                                ->where('user_id', auth()->id())
-                                ->orderBy('name')
-                                ->pluck('name', 'id'))
-                            ->searchable()
-                            ->preload()
-                            ->nullable()
-                            ->afterStateUpdated(function ($state, callable $set): void {
-                                if (! $state) {
-                                    return;
-                                }
-
-                                $location = Location::query()->find($state);
-
-                                if ($location) {
-                                    $set('location', $location->name);
-                                }
-                            }),
-                        Hidden::make('range_name')
-                            ->dehydrated(),
-                        Hidden::make('location')
-                            ->dehydrated(),
-                        Textarea::make('notes_raw')
-                            ->label('Notities (ruw)')
-                            ->rows(4)
-                            ->columnSpanFull(),
-                        Textarea::make('manual_reflection')
-                            ->label('Handmatige reflectie')
-                            ->rows(3)
-                            ->columnSpanFull(),
+                        ...static::sessionDetailFields(),
+                        ...static::notesFields(),
                     ]),
 
                 InfoSection::make('Wapens in deze sessie')
                     ->description('Voeg per wapen de afstand en schoten toe')
                     ->schema([
-                        Repeater::make('sessionWeapons')
-                            ->label('Sessiewapens')
-                            ->relationship()
-                            ->schema([
-                                Select::make('weapon_id')
-                                    ->label('Wapen')
-                                    ->relationship(
-                                        name: 'weapon',
-                                        titleAttribute: 'name',
-                                        modifyQueryUsing: fn (Builder $query) => $query->where('user_id', auth()->id()),
-                                    )
-                                    ->required()
-                                    ->preload(),
-                                TextInput::make('distance_m')
-                                    ->label('Afstand (m)')
-                                    ->numeric()
-                                    ->minValue(0)
-                                    ->maxValue(2000),
-                                TextInput::make('rounds_fired')
-                                    ->label('Afgevuurde patronen')
-                                    ->numeric()
-                                    ->minValue(0)
-                                    ->required()
-                                    ->default(0),
-                                Hidden::make('ammo_type')
-                                    ->dehydrated(),
-                                Select::make('ammo_type_id')
-                                    ->label('Munitietype')
-                                    ->options(fn () => AmmoType::query()
-                                        ->where('user_id', auth()->id())
-                                        ->orderBy('name')
-                                        ->pluck('name', 'id'))
-                                    ->searchable()
-                                    ->preload()
-                                    ->afterStateUpdated(function ($state, callable $set): void {
-                                        if (! $state) {
-                                            return;
-                                        }
-
-                                        $ammoType = AmmoType::query()->find($state);
-
-                                        if ($ammoType) {
-                                            $set('ammo_type', $ammoType->name);
-                                        }
-                                    }),
-                                Textarea::make('group_quality_text')
-                                    ->label('Groepering / kwaliteit')
-                                    ->rows(2)
-                                    ->columnSpanFull(),
-                                Select::make('deviation')
-                                    ->label('Afwijking')
-                                    ->options(
-                                        collect(Deviation::cases())
-                                            ->mapWithKeys(fn (Deviation $case) => [$case->value => ucfirst($case->value)])
-                                            ->all(),
-                                    )
-                                    ->native(false),
-                                TextInput::make('flyers_count')
-                                    ->label('Flyers (aantal)')
-                                    ->numeric()
-                                    ->minValue(0)
-                                    ->default(0),
-                            ])
-                            ->columns(2)
-                            ->orderable(false)
-                            ->addActionLabel('Regel toevoegen')
-                            ->collapsed(false),
-                        // Eventueel uitbreiden met munitie-voorraad check of scorevelden.
+                        static::sessionWeaponsRepeater(),
                     ]),
 
                 InfoSection::make('Bijlagen')
                     ->description('Upload foto’s of PDF’s als context')
                     ->schema([
-                        Repeater::make('attachments')
-                            ->label('Bijlagen')
-                            ->relationship()
-                            ->schema([
-                                FileUpload::make('path')
-                                    ->label('Bestand')
-                                    ->required()
-                                    ->maxSize(20480)
-                                    ->directory('attachments')
-                                    ->preserveFilenames()
-                                    ->downloadable()
-                                    ->openable()
-                                    ->getUploadedFileNameForStorageUsing(fn (TemporaryUploadedFile $file): string => $file->getClientOriginalName())
-                                    ->afterStateUpdated(function ($state, callable $set): void {
-                                        if (! $state) {
-                                            return;
-                                        }
-
-                                        $file = is_array($state) ? end($state) : $state;
-
-                                        if (! $file instanceof TemporaryUploadedFile) {
-                                            return;
-                                        }
-
-                                        $set('original_name', $file->getClientOriginalName());
-                                        $set('mime_type', $file->getMimeType());
-                                        $set('size', $file->getSize());
-                                    }),
-                                Hidden::make('original_name')
-                                    ->dehydrated()
-                                    ->required(),
-                                Hidden::make('mime_type')
-                                    ->dehydrated()
-                                    ->required(),
-                                Hidden::make('size')
-                                    ->dehydrated()
-                                    ->required(),
-                            ])
-                            ->columns(2)
-                            ->orderable(false)
-                            ->itemLabel(fn (array $state): string => $state['original_name'] ?? 'Bijlage')
-                            ->addActionLabel('Bijlage toevoegen'),
-                        // Extra tuning: validatie op toegestane mime-types of max grootte.
+                        static::attachmentsRepeater(),
                     ])
                     ->collapsed(),
-
             ]);
+    }
+
+    public static function userIdField(): Hidden
+    {
+        return Hidden::make('user_id')
+            ->default(fn () => auth()->id())
+            ->required()
+            ->dehydrated(fn ($state) => filled($state));
+    }
+
+    /**
+     * Basisvelden van de sessie (zonder notities), herbruikt door de
+     * Edit-form en de Range Console nieuwe-sessie wizard (stap Sessie).
+     *
+     * @return array<int, \Filament\Schemas\Components\Component>
+     */
+    public static function sessionDetailFields(): array
+    {
+        return [
+            DatePicker::make('date')
+                ->label('Datum')
+                ->native(false)
+                ->required(),
+            Select::make('range_location_id')
+                ->label('Baan/vereniging')
+                ->options(fn () => Location::query()
+                    ->where('user_id', auth()->id())
+                    ->where('is_range', true)
+                    ->orderBy('name')
+                    ->pluck('name', 'id'))
+                ->searchable()
+                ->preload()
+                ->nullable()
+                ->afterStateUpdated(function ($state, callable $set): void {
+                    if (! $state) {
+                        return;
+                    }
+
+                    $location = Location::query()->find($state);
+
+                    if ($location) {
+                        $set('range_name', $location->name);
+                    }
+                }),
+            Select::make('location_id')
+                ->label('Locatie')
+                ->options(fn () => Location::query()
+                    ->where('user_id', auth()->id())
+                    ->orderBy('name')
+                    ->pluck('name', 'id'))
+                ->searchable()
+                ->preload()
+                ->nullable()
+                ->afterStateUpdated(function ($state, callable $set): void {
+                    if (! $state) {
+                        return;
+                    }
+
+                    $location = Location::query()->find($state);
+
+                    if ($location) {
+                        $set('location', $location->name);
+                    }
+                }),
+            Hidden::make('range_name')
+                ->dehydrated(),
+            Hidden::make('location')
+                ->dehydrated(),
+        ];
+    }
+
+    /**
+     * Notitie-velden, herbruikt door de Edit-form en de wizard (stap Notities).
+     *
+     * @return array<int, \Filament\Schemas\Components\Component>
+     */
+    public static function notesFields(): array
+    {
+        return [
+            Textarea::make('notes_raw')
+                ->label('Notities (ruw)')
+                ->rows(4)
+                ->columnSpanFull(),
+            Textarea::make('manual_reflection')
+                ->label('Handmatige reflectie')
+                ->rows(3)
+                ->columnSpanFull(),
+        ];
+    }
+
+    public static function sessionWeaponsRepeater(): Repeater
+    {
+        return Repeater::make('sessionWeapons')
+            ->label('Sessiewapens')
+            ->relationship()
+            ->schema([
+                Select::make('weapon_id')
+                    ->label('Wapen')
+                    ->relationship(
+                        name: 'weapon',
+                        titleAttribute: 'name',
+                        modifyQueryUsing: fn (Builder $query) => $query->where('user_id', auth()->id()),
+                    )
+                    ->required()
+                    ->preload(),
+                TextInput::make('distance_m')
+                    ->label('Afstand (m)')
+                    ->numeric()
+                    ->minValue(0)
+                    ->maxValue(2000),
+                TextInput::make('rounds_fired')
+                    ->label('Afgevuurde patronen')
+                    ->numeric()
+                    ->minValue(0)
+                    ->required()
+                    ->default(0),
+                Hidden::make('ammo_type')
+                    ->dehydrated(),
+                Select::make('ammo_type_id')
+                    ->label('Munitietype')
+                    ->options(fn () => AmmoType::query()
+                        ->where('user_id', auth()->id())
+                        ->orderBy('name')
+                        ->pluck('name', 'id'))
+                    ->searchable()
+                    ->preload()
+                    ->afterStateUpdated(function ($state, callable $set): void {
+                        if (! $state) {
+                            return;
+                        }
+
+                        $ammoType = AmmoType::query()->find($state);
+
+                        if ($ammoType) {
+                            $set('ammo_type', $ammoType->name);
+                        }
+                    }),
+                Textarea::make('group_quality_text')
+                    ->label('Groepering / kwaliteit')
+                    ->rows(2)
+                    ->columnSpanFull(),
+                Select::make('deviation')
+                    ->label('Afwijking')
+                    ->options(
+                        collect(Deviation::cases())
+                            ->mapWithKeys(fn (Deviation $case) => [$case->value => ucfirst($case->value)])
+                            ->all(),
+                    )
+                    ->native(false),
+                TextInput::make('flyers_count')
+                    ->label('Flyers (aantal)')
+                    ->numeric()
+                    ->minValue(0)
+                    ->default(0),
+            ])
+            ->columns(2)
+            ->orderable(false)
+            ->addActionLabel('Regel toevoegen')
+            ->collapsed(false);
+    }
+
+    public static function attachmentsRepeater(): Repeater
+    {
+        return Repeater::make('attachments')
+            ->label('Bijlagen')
+            ->relationship()
+            ->schema([
+                FileUpload::make('path')
+                    ->label('Bestand')
+                    ->required()
+                    ->maxSize(20480)
+                    ->directory('attachments')
+                    ->preserveFilenames()
+                    ->downloadable()
+                    ->openable()
+                    ->getUploadedFileNameForStorageUsing(fn (TemporaryUploadedFile $file): string => $file->getClientOriginalName())
+                    ->afterStateUpdated(function ($state, callable $set): void {
+                        if (! $state) {
+                            return;
+                        }
+
+                        $file = is_array($state) ? end($state) : $state;
+
+                        if (! $file instanceof TemporaryUploadedFile) {
+                            return;
+                        }
+
+                        $set('original_name', $file->getClientOriginalName());
+                        $set('mime_type', $file->getMimeType());
+                        $set('size', $file->getSize());
+                    }),
+                Hidden::make('original_name')
+                    ->dehydrated()
+                    ->required(),
+                Hidden::make('mime_type')
+                    ->dehydrated()
+                    ->required(),
+                Hidden::make('size')
+                    ->dehydrated()
+                    ->required(),
+            ])
+            ->columns(2)
+            ->orderable(false)
+            ->itemLabel(fn (array $state): string => $state['original_name'] ?? 'Bijlage')
+            ->addActionLabel('Bijlage toevoegen');
     }
 
     public static function table(Table $table): Table

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -295,6 +295,10 @@ class SessionResource extends Resource implements CopilotResourceContract
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query
+                ->with('sessionWeapons.weapon')
+                ->withSum('shots as total_score', 'score')
+                ->withExists('aiReflection'))
             ->columns([
                 TextColumn::make('date')
                     ->label('Datum')
@@ -322,12 +326,12 @@ class SessionResource extends Resource implements CopilotResourceContract
                     ->sortable(),
                 TextColumn::make('totalScore')
                     ->label('Score')
-                    ->state(fn (Session $record): int => (int) $record->shots()->sum('score'))
+                    ->state(fn (Session $record): int => (int) ($record->total_score ?? 0))
                     ->color(fn ($state): string => ((int) $state) > 0 ? 'success' : 'gray')
                     ->weight('semibold'),
                 TextColumn::make('reflectionStatus')
                     ->label('Status')
-                    ->state(fn (Session $record): string => $record->aiReflection()->exists() ? 'AI' : 'open')
+                    ->state(fn (Session $record): string => $record->ai_reflection_exists ? 'AI' : 'open')
                     ->badge()
                     ->color(fn (string $state): string => $state === 'AI' ? 'success' : 'warning'),
                 TextColumn::make('aiReflection.summary')

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -280,15 +280,25 @@ class SessionResource extends Resource implements CopilotResourceContract
                     ->badge()
                     ->toggleable(),
                 TextColumn::make('totalRounds')
-                    ->label('Aantal schoten')
+                    ->label('Schoten')
                     ->state(fn (Session $record) => $record->sessionWeapons->sum('rounds_fired'))
                     ->sortable(),
+                TextColumn::make('totalScore')
+                    ->label('Score')
+                    ->state(fn (Session $record): int => (int) $record->shots()->sum('score'))
+                    ->color(fn ($state): string => ((int) $state) > 0 ? 'success' : 'gray')
+                    ->weight('semibold'),
+                TextColumn::make('reflectionStatus')
+                    ->label('Status')
+                    ->state(fn (Session $record): string => $record->aiReflection()->exists() ? 'AI' : 'open')
+                    ->badge()
+                    ->color(fn (string $state): string => $state === 'AI' ? 'success' : 'warning'),
                 TextColumn::make('aiReflection.summary')
                     ->label('AI-reflectie')
                     ->icon('heroicon-m-sparkles')
                     ->limit(40)
                     ->placeholder('Nog niet gegenereerd')
-                    ->toggleable()
+                    ->toggleable(isToggledHiddenByDefault: true)
                     ->visible(fn (): bool => static::features()->aiEnabled()),
             ])
             ->filters([

--- a/app/Filament/Resources/SessionResource/Pages/CreateSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/CreateSession.php
@@ -1,11 +1,68 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Filament\Resources\SessionResource\Pages;
 
 use App\Filament\Resources\SessionResource;
 use Filament\Resources\Pages\CreateRecord;
+use Filament\Resources\Pages\CreateRecord\Concerns\HasWizard;
+use Filament\Schemas\Components\View as ViewComponent;
+use Filament\Schemas\Components\Wizard\Step;
+use Filament\Support\Icons\Heroicon;
 
 class CreateSession extends CreateRecord
 {
+    use HasWizard;
+
     protected static string $resource = SessionResource::class;
+
+    /**
+     * Range Console nieuwe-sessie wizard — 4 stappen conform
+     * new-session-wizard.jsx (decision 5: in-page Filament Wizard).
+     *
+     * @return array<int, Step>
+     */
+    public function getSteps(): array
+    {
+        return [
+            Step::make('Wapen')
+                ->icon(Heroicon::OutlinedBolt)
+                ->description('Welke wapens gebruik je?')
+                ->schema([
+                    SessionResource::userIdField(),
+                    SessionResource::sessionWeaponsRepeater(),
+                ]),
+
+            Step::make('Sessie')
+                ->icon(Heroicon::OutlinedCalendarDays)
+                ->description('Datum, baan en locatie')
+                ->columns(2)
+                ->schema(SessionResource::sessionDetailFields()),
+
+            Step::make('Schoten')
+                ->icon(Heroicon::OutlinedViewfinderCircle)
+                ->description('Log je schoten na het opslaan')
+                ->schema([
+                    ViewComponent::make('filament.resources.sessions.wizard-shots-step'),
+                ]),
+
+            Step::make('Notities')
+                ->icon(Heroicon::OutlinedPencilSquare)
+                ->description('Reflectie en bijlagen')
+                ->schema([
+                    ...SessionResource::notesFields(),
+                    SessionResource::attachmentsRepeater(),
+                ]),
+        ];
+    }
+
+    /**
+     * Na afronden direct naar het schotenbord: daar logt de schutter de
+     * werkelijke schoten (de board vereist een opgeslagen sessie).
+     */
+    protected function getRedirectUrl(): string
+    {
+        return SessionResource::getUrl('shots', ['record' => $this->getRecord()]);
+    }
 }

--- a/app/Filament/Resources/SessionResource/Pages/ListSessions.php
+++ b/app/Filament/Resources/SessionResource/Pages/ListSessions.php
@@ -1,14 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Filament\Resources\SessionResource\Pages;
 
 use App\Filament\Resources\SessionResource;
+use App\Services\RangeConsoleSummaryService;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
 
 class ListSessions extends ListRecords
 {
     protected static string $resource = SessionResource::class;
+
+    protected string $view = 'filament.resources.sessions.list-sessions';
+
+    public function getRangeConsoleSummary(): RangeConsoleSummaryService
+    {
+        return new RangeConsoleSummaryService(auth()->user());
+    }
 
     protected function getHeaderActions(): array
     {

--- a/app/Filament/Resources/SessionResource/Pages/ViewSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/ViewSession.php
@@ -15,6 +15,8 @@ class ViewSession extends ViewRecord
 {
     protected static string $resource = SessionResource::class;
 
+    protected string $view = 'filament.resources.sessions.view-session';
+
     protected Width|string|null $maxContentWidth = Width::Full;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/WeaponResource.php
+++ b/app/Filament/Resources/WeaponResource.php
@@ -126,6 +126,30 @@ class WeaponResource extends Resource implements CopilotResourceContract
                             ->label('Notities')
                             ->columnSpanFull(),
                     ]),
+
+                InfoSection::make('Kalibratie')
+                    ->description('Optionele afstelling per wapen — wordt getoond op het wapen-detail scherm.')
+                    ->columns(2)
+                    ->collapsed()
+                    ->schema([
+                        TextInput::make('korrel_correction')
+                            ->label('Korrel')
+                            ->helperText('Bv. "+2" of "−1 R"')
+                            ->maxLength(16),
+                        TextInput::make('vizier_correction')
+                            ->label('Vizier')
+                            ->helperText('Bv. "−1 R" of "0"')
+                            ->maxLength(16),
+                        TextInput::make('trigger_weight_g')
+                            ->label('Trekkergewicht (g)')
+                            ->numeric()
+                            ->minValue(0)
+                            ->maxValue(5000),
+                        TextInput::make('grip_size')
+                            ->label('Handgreep')
+                            ->helperText('Bv. "M · v2"')
+                            ->maxLength(32),
+                    ]),
             ]);
     }
 

--- a/app/Filament/Resources/WeaponResource/Pages/ViewWeapon.php
+++ b/app/Filament/Resources/WeaponResource/Pages/ViewWeapon.php
@@ -13,6 +13,8 @@ class ViewWeapon extends ViewRecord
 {
     protected static string $resource = WeaponResource::class;
 
+    protected string $view = 'filament.resources.weapons.view-weapon';
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Models/Weapon.php
+++ b/app/Models/Weapon.php
@@ -15,6 +15,10 @@ class Weapon extends Model
         'name',
         'weapon_type',
         'caliber',
+        'korrel_correction',
+        'vizier_correction',
+        'trigger_weight_g',
+        'grip_size',
         'serial_number',
         'storage_location',
         'storage_location_id',
@@ -27,6 +31,7 @@ class Weapon extends Model
         'owned_since' => 'date',
         'is_active' => 'boolean',
         'weapon_type' => WeaponType::class,
+        'trigger_weight_g' => 'integer',
     ];
 
     public function user()

--- a/app/Services/CoachContextService.php
+++ b/app/Services/CoachContextService.php
@@ -63,6 +63,8 @@ final class CoachContextService
             ->orderByDesc('session_count')
             ->value('weapon_id');
 
-        return $weaponId ? Weapon::query()->find($weaponId) : null;
+        return $weaponId
+            ? Weapon::query()->where('user_id', $this->user->getKey())->find($weaponId)
+            : null;
     }
 }

--- a/app/Services/CoachContextService.php
+++ b/app/Services/CoachContextService.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Session;
+use App\Models\SessionWeapon;
+use App\Models\User;
+use App\Models\Weapon;
+use EslamRedaDiv\FilamentCopilot\Models\CopilotConversation;
+use Illuminate\Support\Collection;
+
+/**
+ * Levert context-data voor de AI-coach pagina: recente Copilot-gesprekken,
+ * laatste sessie en meest-gebruikte wapen van deze user.
+ *
+ * Hybride per decision 4: Copilot regelt message-state, deze service
+ * voedt de chat-list rail + context-rail in de eigen 3-koloms view.
+ */
+final class CoachContextService
+{
+    public function __construct(private readonly User $user) {}
+
+    /**
+     * Recente Copilot-gesprekken van deze user (laatst bewerkt eerst).
+     */
+    public function recentConversations(int $limit = 6): Collection
+    {
+        return CopilotConversation::query()
+            ->forParticipant($this->user)
+            ->latest('updated_at')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function latestConversation(): ?CopilotConversation
+    {
+        return $this->recentConversations(1)->first();
+    }
+
+    public function lastSession(): ?Session
+    {
+        return Session::query()
+            ->where('user_id', $this->user->getKey())
+            ->with(['sessionWeapons.weapon', 'aiReflection'])
+            ->orderByDesc('date')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * Wapen met het hoogste aantal sessies voor deze user.
+     */
+    public function topWeapon(): ?Weapon
+    {
+        $weaponId = SessionWeapon::query()
+            ->whereIn('session_id', Session::query()
+                ->where('user_id', $this->user->getKey())
+                ->select('id'))
+            ->selectRaw('weapon_id, COUNT(DISTINCT session_id) as session_count')
+            ->groupBy('weapon_id')
+            ->orderByDesc('session_count')
+            ->value('weapon_id');
+
+        return $weaponId ? Weapon::query()->find($weaponId) : null;
+    }
+}

--- a/app/Services/RangeConsoleSummaryService.php
+++ b/app/Services/RangeConsoleSummaryService.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\AiReflection;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Aggregator voor de Range Console sessies-overzicht pagina.
+ *
+ * Bundelt KPI's, "last session" + "latest reflection" + trend-data
+ * voor één user. Read-only, één instance per request.
+ */
+final class RangeConsoleSummaryService
+{
+    public function __construct(private readonly User $user) {}
+
+    public function sessionsThisMonth(): int
+    {
+        return $this->userSessions()
+            ->whereBetween('date', [now()->startOfMonth(), now()->endOfMonth()])
+            ->count();
+    }
+
+    public function sessionsLastMonth(): int
+    {
+        return $this->userSessions()
+            ->whereBetween('date', [
+                now()->subMonthNoOverflow()->startOfMonth(),
+                now()->subMonthNoOverflow()->endOfMonth(),
+            ])
+            ->count();
+    }
+
+    public function sessionsThisMonthDelta(): int
+    {
+        return $this->sessionsThisMonth() - $this->sessionsLastMonth();
+    }
+
+    public function totalSessions(): int
+    {
+        return $this->userSessions()->count();
+    }
+
+    /**
+     * Aantal schoten over de laatste 30 dagen (count, niet score-som).
+     */
+    public function shotsLast30d(): int
+    {
+        return SessionShot::query()
+            ->whereIn('session_id', $this->userSessions()
+                ->whereDate('date', '>=', now()->subDays(30)->startOfDay())
+                ->select('id'))
+            ->count();
+    }
+
+    /**
+     * Beste 10-shot serie over alle sessies van de user. Returnt null
+     * als er geen volle serie van 10 is gelogd.
+     */
+    public function bestSeriesScore(): ?int
+    {
+        $sessions = $this->userSessions()->get();
+
+        $best = null;
+        foreach ($sessions as $session) {
+            foreach ((new SessionStatsService($session))->seriesScores(10) as $serieSum) {
+                if ($best === null || $serieSum > $best) {
+                    $best = $serieSum;
+                }
+            }
+        }
+
+        return $best;
+    }
+
+    public function aiReflectionCount(): int
+    {
+        return AiReflection::query()
+            ->whereIn('session_id', $this->userSessions()->select('id'))
+            ->count();
+    }
+
+    /**
+     * Sessies van de user zonder AI-reflectie (laatste 30 dagen),
+     * een proxy voor "wachtrij".
+     */
+    public function pendingAiReflections(): int
+    {
+        return $this->userSessions()
+            ->whereDate('date', '>=', now()->subDays(30)->startOfDay())
+            ->whereDoesntHave('aiReflection')
+            ->count();
+    }
+
+    public function lastSession(): ?Session
+    {
+        return $this->userSessions()
+            ->with(['shots', 'sessionWeapons.weapon', 'aiReflection'])
+            ->orderByDesc('date')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    public function latestReflection(): ?AiReflection
+    {
+        return AiReflection::query()
+            ->whereIn('session_id', $this->userSessions()->select('id'))
+            ->latest('updated_at')
+            ->first();
+    }
+
+    /**
+     * Som van shot-scores per sessie over de laatste $days dagen.
+     * Sleutel = ISO datum (één sessie per dag, anders combineerd).
+     *
+     * @return array<string, int>
+     */
+    public function trend30d(int $days = 30): array
+    {
+        $since = now()->subDays($days)->startOfDay();
+
+        $sessionIds = $this->userSessions()
+            ->whereDate('date', '>=', $since)
+            ->pluck('id');
+
+        if ($sessionIds->isEmpty()) {
+            return [];
+        }
+
+        $scoresBySession = SessionShot::query()
+            ->whereIn('session_id', $sessionIds)
+            ->selectRaw('session_id, SUM(score) as total')
+            ->groupBy('session_id')
+            ->pluck('total', 'session_id');
+
+        return Session::query()
+            ->whereIn('id', $sessionIds)
+            ->orderBy('date')
+            ->get(['id', 'date'])
+            ->mapWithKeys(fn (Session $s): array => [
+                $s->date->toDateString() => (int) ($scoresBySession[$s->id] ?? 0),
+            ])
+            ->all();
+    }
+
+    private function userSessions(): Builder
+    {
+        return Session::query()->where('user_id', $this->user->getKey());
+    }
+}

--- a/app/Services/RangeConsoleSummaryService.php
+++ b/app/Services/RangeConsoleSummaryService.php
@@ -27,7 +27,12 @@ final class RangeConsoleSummaryService
             ->count();
     }
 
-    public function sessionsLastMonth(): int
+    public function sessionsThisMonthDelta(): int
+    {
+        return $this->sessionsThisMonth() - $this->sessionsLastMonth();
+    }
+
+    private function sessionsLastMonth(): int
     {
         return $this->userSessions()
             ->whereBetween('date', [
@@ -35,11 +40,6 @@ final class RangeConsoleSummaryService
                 now()->subMonthNoOverflow()->endOfMonth(),
             ])
             ->count();
-    }
-
-    public function sessionsThisMonthDelta(): int
-    {
-        return $this->sessionsThisMonth() - $this->sessionsLastMonth();
     }
 
     public function totalSessions(): int
@@ -62,14 +62,36 @@ final class RangeConsoleSummaryService
     /**
      * Beste 10-shot serie over alle sessies van de user. Returnt null
      * als er geen volle serie van 10 is gelogd.
+     *
+     * Eén query voor alle shots (geen N+1 over sessies): groepeer per
+     * sessie, hak in series van 10 en pak de hoogste volledige serie.
      */
     public function bestSeriesScore(): ?int
     {
-        $sessions = $this->userSessions()->get();
+        $sessionIds = $this->userSessions()->pluck('id');
+
+        if ($sessionIds->isEmpty()) {
+            return null;
+        }
+
+        $shotsBySession = SessionShot::query()
+            ->whereIn('session_id', $sessionIds)
+            ->orderBy('session_id')
+            ->orderBy('turn_index')
+            ->orderBy('shot_index')
+            ->orderBy('id')
+            ->get(['session_id', 'score'])
+            ->groupBy('session_id');
 
         $best = null;
-        foreach ($sessions as $session) {
-            foreach ((new SessionStatsService($session))->seriesScores(10) as $serieSum) {
+        foreach ($shotsBySession as $shots) {
+            foreach ($shots->pluck('score')->chunk(10) as $chunk) {
+                if ($chunk->count() < 10) {
+                    continue;
+                }
+
+                $serieSum = (int) $chunk->sum();
+
                 if ($best === null || $serieSum > $best) {
                     $best = $serieSum;
                 }

--- a/app/Services/SessionStatsService.php
+++ b/app/Services/SessionStatsService.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Session;
+use Illuminate\Support\Collection;
+
+/**
+ * Berekent afgeleide statistieken voor één sessie op basis van haar shots.
+ *
+ * Lazy: shots worden één keer geladen en gecachet binnen de instance.
+ */
+final class SessionStatsService
+{
+    private ?Collection $cachedShots = null;
+
+    public function __construct(private readonly Session $session) {}
+
+    /**
+     * Score-array (0–10) in chronologische volgorde.
+     *
+     * @return array<int, int>
+     */
+    public function scores(): array
+    {
+        return $this->shots()
+            ->pluck('score')
+            ->map(fn ($s): int => (int) $s)
+            ->all();
+    }
+
+    public function totalShots(): int
+    {
+        return $this->shots()->count();
+    }
+
+    public function totalScore(): int
+    {
+        return (int) $this->shots()->sum('score');
+    }
+
+    public function tienen(): int
+    {
+        return $this->shots()->where('ring', 10)->count();
+    }
+
+    public function negens(): int
+    {
+        return $this->shots()->where('ring', 9)->count();
+    }
+
+    public function bestShot(): ?int
+    {
+        $max = $this->shots()->max('score');
+
+        return $max !== null ? (int) $max : null;
+    }
+
+    /**
+     * Geschatte groep-diameter in mm. Gebaseerd op 2 × σ van de
+     * normalised hit-coords, geschaald naar een ISSF 10m luchtpistool
+     * target diameter (155.5mm). Returnt null bij <2 shots.
+     */
+    public function groupMm(): ?float
+    {
+        $shots = $this->shots();
+
+        if ($shots->count() < 2) {
+            return null;
+        }
+
+        $xs = $shots->pluck('x_normalized')->map(fn ($v): float => (float) $v)->all();
+        $ys = $shots->pluck('y_normalized')->map(fn ($v): float => (float) $v)->all();
+
+        $varX = $this->variance($xs);
+        $varY = $this->variance($ys);
+
+        $sigma = sqrt($varX + $varY);
+        $targetDiameterMm = 155.5;
+
+        return round(2.0 * $sigma * $targetDiameterMm, 1);
+    }
+
+    /**
+     * Gemiddelde cadans (seconden tussen opeenvolgende schoten).
+     * Returnt null als shots geen onderlinge timestamp-verschillen tonen.
+     */
+    public function avgCadansSec(): ?float
+    {
+        $shots = $this->shots()->values();
+
+        if ($shots->count() < 2) {
+            return null;
+        }
+
+        $deltas = [];
+        for ($i = 1; $i < $shots->count(); $i++) {
+            $prev = $shots[$i - 1]->created_at;
+            $curr = $shots[$i]->created_at;
+
+            if ($prev === null || $curr === null) {
+                continue;
+            }
+
+            $delta = $curr->diffInSeconds($prev);
+
+            if ($delta > 0) {
+                $deltas[] = $delta;
+            }
+        }
+
+        if ($deltas === []) {
+            return null;
+        }
+
+        return round(array_sum($deltas) / count($deltas), 1);
+    }
+
+    /**
+     * Series-scores: groepeert shots per $perSerie en sommeert per groep.
+     * Series is empty bij geen shots.
+     *
+     * @return array<int, int>
+     */
+    public function seriesScores(int $perSerie = 10): array
+    {
+        $scores = $this->scores();
+
+        if ($scores === [] || $perSerie < 1) {
+            return [];
+        }
+
+        return collect($scores)
+            ->chunk($perSerie)
+            ->filter(fn (Collection $chunk): bool => $chunk->count() === $perSerie)
+            ->map(fn (Collection $chunk): int => (int) $chunk->sum())
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Schoten-per-serie afleiden uit total_shots. ≤10 → totaal als 1 serie,
+     * anders 10 (ISSF-default). Werkt met decision 2 uit het PLAN.
+     */
+    public function shotsPerSerie(): int
+    {
+        $total = $this->totalShots();
+
+        if ($total === 0) {
+            return 10;
+        }
+
+        return $total < 10 ? $total : 10;
+    }
+
+    /**
+     * Indices (0-based, inclusief) van de zwakste serie.
+     * Bv. bij 6 series van 10 schoten en de 4e serie laagst → [30, 39].
+     * Returnt null bij <2 volle series.
+     *
+     * @return array{0: int, 1: int}|null
+     */
+    public function dipRange(): ?array
+    {
+        $perSerie = $this->shotsPerSerie();
+        $series = $this->seriesScores($perSerie);
+
+        if (count($series) < 2) {
+            return null;
+        }
+
+        $minIndex = 0;
+        foreach ($series as $i => $sum) {
+            if ($sum < $series[$minIndex]) {
+                $minIndex = $i;
+            }
+        }
+
+        return [$minIndex * $perSerie, ($minIndex + 1) * $perSerie - 1];
+    }
+
+    private function shots(): Collection
+    {
+        if ($this->cachedShots === null) {
+            $this->cachedShots = $this->session
+                ->shots()
+                ->orderBy('turn_index')
+                ->orderBy('shot_index')
+                ->orderBy('id')
+                ->get();
+        }
+
+        return $this->cachedShots;
+    }
+
+    /**
+     * @param  array<int, float>  $values
+     */
+    private function variance(array $values): float
+    {
+        $n = count($values);
+
+        if ($n === 0) {
+            return 0.0;
+        }
+
+        $mean = array_sum($values) / $n;
+        $sumSquaredDiff = 0.0;
+
+        foreach ($values as $v) {
+            $sumSquaredDiff += ($v - $mean) ** 2;
+        }
+
+        return $sumSquaredDiff / $n;
+    }
+}

--- a/app/Services/SessionStatsService.php
+++ b/app/Services/SessionStatsService.php
@@ -86,6 +86,10 @@ final class SessionStatsService
     /**
      * Gemiddelde cadans (seconden tussen opeenvolgende schoten).
      * Returnt null als shots geen onderlinge timestamp-verschillen tonen.
+     *
+     * Schoten met exact gelijke timestamps (delta 0) worden bewust
+     * overgeslagen: dat duidt op bulk-inserts (bv. seeding of import),
+     * geen echte cadans. Een sessie waarvan álle deltas 0 zijn levert null.
      */
     public function avgCadansSec(): ?float
     {
@@ -104,7 +108,9 @@ final class SessionStatsService
                 continue;
             }
 
-            $delta = $curr->diffInSeconds($prev);
+            // abs(): Carbon 3 levert een signed diff op; we willen de
+            // magnitude van de tijd tussen twee schoten.
+            $delta = abs($curr->diffInSeconds($prev));
 
             if ($delta > 0) {
                 $deltas[] = $delta;
@@ -168,6 +174,11 @@ final class SessionStatsService
         $series = $this->seriesScores($perSerie);
 
         if (count($series) < 2) {
+            return null;
+        }
+
+        // Geen echte dip als alle series even hoog scoren.
+        if (min($series) === max($series)) {
             return null;
         }
 

--- a/app/Services/WeaponInsightsService.php
+++ b/app/Services/WeaponInsightsService.php
@@ -63,13 +63,16 @@ final class WeaponInsightsService
         }
 
         $maxScore = $perSession->max();
-        $sessionId = $perSession->search($maxScore);
+        $topSessionIds = $perSession
+            ->filter(fn (int $total): bool => $total === $maxScore)
+            ->keys();
 
-        if ($sessionId === false) {
-            return null;
-        }
-
-        $session = Session::query()->find($sessionId);
+        // Bij gelijke topscore: de chronologisch laatste sessie wint.
+        $session = Session::query()
+            ->whereIn('id', $topSessionIds)
+            ->orderByDesc('date')
+            ->orderByDesc('id')
+            ->first(['id', 'date']);
 
         return $session?->date;
     }
@@ -114,6 +117,9 @@ final class WeaponInsightsService
     public function recentSessions(int $limit = 5): Collection
     {
         return $this->sessionsWithWeaponQuery()
+            ->withSum('shots as score_total', 'score')
+            ->withSum('sessionWeapons as rounds_total', 'rounds_fired')
+            ->withExists('aiReflection')
             ->orderByDesc('date')
             ->limit($limit)
             ->get();

--- a/app/Services/WeaponInsightsService.php
+++ b/app/Services/WeaponInsightsService.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Session;
+use App\Models\SessionWeapon;
+use App\Models\Weapon;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Levert KPI's, trend-data en recente sessies voor één wapen.
+ *
+ * Gebruikt door WeaponResource view-pagina en list-pagina-widgets.
+ */
+final class WeaponInsightsService
+{
+    public function __construct(private readonly Weapon $weapon) {}
+
+    public function sessionCount(): int
+    {
+        return $this->weapon->sessionWeapons()->distinct('session_id')->count('session_id');
+    }
+
+    public function totalShots(): int
+    {
+        return (int) $this->weapon->sessionWeapons()->sum('rounds_fired');
+    }
+
+    /**
+     * Gemiddelde score (som per sessie) over alle sessies met dit wapen.
+     */
+    public function avgScore(): ?float
+    {
+        $perSession = $this->scoresPerSession();
+
+        if ($perSession->isEmpty()) {
+            return null;
+        }
+
+        return round($perSession->avg(), 1);
+    }
+
+    public function bestScore(): ?int
+    {
+        $perSession = $this->scoresPerSession();
+
+        if ($perSession->isEmpty()) {
+            return null;
+        }
+
+        return (int) $perSession->max();
+    }
+
+    public function bestScoreDate(): ?Carbon
+    {
+        $perSession = $this->scoresPerSession();
+
+        if ($perSession->isEmpty()) {
+            return null;
+        }
+
+        $maxScore = $perSession->max();
+        $sessionId = $perSession->search($maxScore);
+
+        if ($sessionId === false) {
+            return null;
+        }
+
+        $session = Session::query()->find($sessionId);
+
+        return $session?->date;
+    }
+
+    /**
+     * Score-trend over de laatste $days dagen, per sessie.
+     * Sleutel = ISO datum, waarde = sessie-totaalscore.
+     *
+     * @return array<string, int>
+     */
+    public function trendData(int $days = 30): array
+    {
+        $since = now()->subDays($days)->startOfDay();
+
+        $sessionIds = $this->sessionsWithWeaponQuery()
+            ->whereDate('date', '>=', $since)
+            ->pluck('id');
+
+        if ($sessionIds->isEmpty()) {
+            return [];
+        }
+
+        $shots = \App\Models\SessionShot::query()
+            ->whereIn('session_id', $sessionIds)
+            ->selectRaw('session_id, SUM(score) as total')
+            ->groupBy('session_id')
+            ->pluck('total', 'session_id');
+
+        return Session::query()
+            ->whereIn('id', $sessionIds)
+            ->orderBy('date')
+            ->get(['id', 'date'])
+            ->mapWithKeys(fn (Session $s): array => [
+                $s->date->toDateString() => (int) ($shots[$s->id] ?? 0),
+            ])
+            ->all();
+    }
+
+    /**
+     * Laatste $limit sessies waarin dit wapen is gebruikt.
+     */
+    public function recentSessions(int $limit = 5): Collection
+    {
+        return $this->sessionsWithWeaponQuery()
+            ->orderByDesc('date')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * Map: session_id => totaalscore (som van shots) voor sessies met dit wapen.
+     */
+    private function scoresPerSession(): Collection
+    {
+        $sessionIds = $this->sessionsWithWeaponQuery()->pluck('id');
+
+        if ($sessionIds->isEmpty()) {
+            return collect();
+        }
+
+        return \App\Models\SessionShot::query()
+            ->whereIn('session_id', $sessionIds)
+            ->selectRaw('session_id, SUM(score) as total')
+            ->groupBy('session_id')
+            ->pluck('total', 'session_id')
+            ->map(fn ($v): int => (int) $v);
+    }
+
+    private function sessionsWithWeaponQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return Session::query()
+            ->whereIn('id', SessionWeapon::query()
+                ->where('weapon_id', $this->weapon->getKey())
+                ->select('session_id'));
+    }
+}

--- a/database/migrations/2026_05_21_120000_add_calibration_fields_to_weapons_table.php
+++ b/database/migrations/2026_05_21_120000_add_calibration_fields_to_weapons_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('weapons', function (Blueprint $table): void {
+            $table->string('korrel_correction', 16)->nullable()->after('caliber');
+            $table->string('vizier_correction', 16)->nullable()->after('korrel_correction');
+            $table->unsignedSmallInteger('trigger_weight_g')->nullable()->after('vizier_correction');
+            $table->string('grip_size', 32)->nullable()->after('trigger_weight_g');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('weapons', function (Blueprint $table): void {
+            $table->dropColumn([
+                'korrel_correction',
+                'vizier_correction',
+                'trigger_weight_g',
+                'grip_size',
+            ]);
+        });
+    }
+};

--- a/resources/views/components/aimtrack/ai-reflection-card.blade.php
+++ b/resources/views/components/aimtrack/ai-reflection-card.blade.php
@@ -1,0 +1,62 @@
+@props([
+    'reflection' => null,
+    'sessionId' => null,
+    'generatedAt' => null,
+    'compact' => false,
+])
+
+@php
+    $summary = $reflection?->summary ?? null;
+    $positives = $reflection?->positives ?? null;
+    $improvements = $reflection?->improvements ?? null;
+    $nextFocus = $reflection?->next_focus ?? null;
+
+    $headerSub = $sessionId !== null ? '· '.$sessionId : '';
+    $tsLabel = $generatedAt
+        ? (is_string($generatedAt) ? $generatedAt : $generatedAt->diffForHumans())
+        : null;
+
+    $listOrDash = static function ($value): string {
+        if (is_array($value)) {
+            return collect($value)->filter()->implode(' · ');
+        }
+        return filled($value) ? (string) $value : '—';
+    };
+@endphp
+
+<x-aimtrack.bracket-frame
+    :rounded="8"
+    :padding="16"
+    {{ $attributes->merge(['class' => 'aimtrack-ai-reflection-card', 'style' => 'display: flex; flex-direction: column; gap: 12px;']) }}
+>
+    <div style="display: flex; align-items: center; gap: 8px; font-size: 11px; font-family: var(--at-font-mono); letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-accent);">
+        <span role="presentation">✦</span>
+        <span>AI-reflectie {{ $headerSub }}</span>
+        @if ($tsLabel)
+            <span style="margin-left: auto; color: var(--at-muted);">{{ $tsLabel }}</span>
+        @endif
+    </div>
+
+    <div style="font-size: 13px; line-height: 1.55; color: var(--at-text);">
+        {{ filled($summary) ? $summary : '—' }}
+    </div>
+
+    @unless ($compact)
+        <div style="height: 1px; background: var(--at-line);"></div>
+
+        <div style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
+            <div class="at-label" style="color: var(--at-accent);">STERK</div>
+            <div style="color: var(--at-text);">{{ $listOrDash($positives) }}</div>
+            <div class="at-label">VERBETER</div>
+            <div style="color: var(--at-text);">{{ $listOrDash($improvements) }}</div>
+            <div class="at-label">VOLGENDE</div>
+            <div style="color: var(--at-text);">{{ $listOrDash($nextFocus) }}</div>
+        </div>
+    @endunless
+
+    @isset($actions)
+        <div style="display: flex; gap: 6px; margin-top: 4px;">
+            {{ $actions }}
+        </div>
+    @endisset
+</x-aimtrack.bracket-frame>

--- a/resources/views/components/aimtrack/page-header.blade.php
+++ b/resources/views/components/aimtrack/page-header.blade.php
@@ -1,0 +1,47 @@
+@props([
+    'title' => '',
+    'subtitle' => null,
+    'reticleSize' => 180,
+    'reticleOpacity' => 0.07,
+    'reticleTop' => -30,
+    'reticleRight' => -20,
+    'showReticle' => true,
+])
+
+@php
+    $reticleSize = (int) $reticleSize;
+    $reticleOpacity = (float) $reticleOpacity;
+    $reticleTop = (int) $reticleTop;
+    $reticleRight = (int) $reticleRight;
+@endphp
+
+<div
+    {{ $attributes->merge([
+        'class' => 'aimtrack-page-header',
+        'style' => 'position: relative; overflow: visible;',
+    ]) }}
+>
+    @if ($showReticle)
+        <x-aimtrack.watermark-bg
+            :size="$reticleSize"
+            :opacity="$reticleOpacity"
+            :top="$reticleTop"
+            :right="$reticleRight"
+        />
+    @endif
+
+    <div style="position: relative; z-index: 1; display: flex; align-items: flex-start; gap: 16px;">
+        <div style="flex: 1; min-width: 0;">
+            <h1 style="font-family: var(--at-font-display); font-size: var(--at-text-heading); font-weight: 600; letter-spacing: -0.01em; margin: 0; color: var(--at-text);">{{ $title }}</h1>
+            @if ($subtitle)
+                <p style="color: var(--at-muted); font-size: var(--at-text-small); margin: 4px 0 0;">{{ $subtitle }}</p>
+            @endif
+        </div>
+
+        @isset($actions)
+            <div style="display: flex; align-items: center; gap: 8px; flex-shrink: 0;">
+                {{ $actions }}
+            </div>
+        @endisset
+    </div>
+</div>

--- a/resources/views/components/aimtrack/series-card.blade.php
+++ b/resources/views/components/aimtrack/series-card.blade.php
@@ -1,0 +1,57 @@
+@props([
+    'series' => [],
+    'shotsPerSerie' => 10,
+    'goodThreshold' => 95,
+    'title' => 'Series',
+    'sub' => null,
+])
+
+@php
+    $series = collect($series)->map(fn ($v) => (float) $v)->all();
+    $shotsPerSerie = (int) $shotsPerSerie;
+    $goodThreshold = (float) $goodThreshold;
+    $maxPossible = (float) ($shotsPerSerie * 10);
+    $minPossible = $maxPossible * 0.8;
+
+    $sub = $sub ?? ('tot '.number_format((float) array_sum($series), 1, '.', ''));
+
+    $fmt = static fn (float $value, int $decimals = 1): string => number_format($value, $decimals, '.', '');
+    $pct = static function (float $v) use ($minPossible, $maxPossible): float {
+        $span = max(0.0001, $maxPossible - $minPossible);
+        return max(0.0, min(100.0, (($v - $minPossible) / $span) * 100.0));
+    };
+@endphp
+
+<div
+    {{ $attributes->merge([
+        'class' => 'aimtrack-series-card',
+        'style' => 'background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;',
+    ]) }}
+>
+    <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+        <div style="font-size: 13px; font-weight: 600; color: var(--at-text); margin: 0;">{{ $title }} · {{ count($series) }} × {{ $shotsPerSerie }} schoten</div>
+        <div class="at-label" style="margin-left: auto;">{{ $sub }}</div>
+    </div>
+
+    @if (count($series) > 0)
+        <div style="display: grid; grid-template-columns: repeat({{ count($series) }}, 1fr);">
+            @foreach ($series as $i => $v)
+                @php
+                    $good = $v >= $goodThreshold;
+                    $valueColor = $good ? 'var(--at-accent)' : 'var(--at-text)';
+                    $barColor = $good ? 'var(--at-accent)' : 'var(--at-muted)';
+                    $rightBorder = $i < count($series) - 1 ? '1px solid var(--at-line)' : 'none';
+                @endphp
+                <div style="padding: 14px; border-right: {{ $rightBorder }}; display: flex; flex-direction: column; gap: 4px;">
+                    <div class="at-label" style="letter-spacing: 0.12em;">SERIE {{ $i + 1 }}</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 22px; font-weight: 600; color: {{ $valueColor }}; letter-spacing: -0.02em;">{{ $fmt($v) }}</div>
+                    <div style="height: 4px; background: var(--at-line); border-radius: 2px; position: relative; overflow: hidden;">
+                        <div style="position: absolute; inset: 0; width: {{ $fmt($pct($v), 2) }}%; background: {{ $barColor }};"></div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @else
+        <div style="padding: 24px 16px; color: var(--at-muted); font-size: 12px; text-align: center;">—</div>
+    @endif
+</div>

--- a/resources/views/components/aimtrack/shot-strip.blade.php
+++ b/resources/views/components/aimtrack/shot-strip.blade.php
@@ -1,0 +1,77 @@
+@props([
+    'shots' => [],
+    'totalSlots' => null,
+    'dipRange' => null,
+    'height' => 80,
+    'showLegend' => true,
+])
+
+@php
+    $scores = [];
+    foreach ($shots as $s) {
+        if (is_numeric($s)) {
+            $scores[] = (float) $s;
+        } elseif (is_array($s) && isset($s['score'])) {
+            $scores[] = (float) $s['score'];
+        } elseif (is_object($s) && isset($s->score)) {
+            $scores[] = (float) $s->score;
+        }
+    }
+    $totalSlots = $totalSlots !== null ? (int) $totalSlots : max(count($scores), 60);
+    $height = (int) $height;
+
+    [$dipFrom, $dipTo] = is_array($dipRange) && count($dipRange) === 2
+        ? [(int) $dipRange[0], (int) $dipRange[1]]
+        : [null, null];
+
+    $fmt = static fn (float $value): string => rtrim(rtrim(number_format($value, 3, '.', ''), '0'), '.');
+
+    $barHeight = static function (float $v) use ($height): float {
+        $clamped = max(0.0, min(10.0, $v));
+        return max(6.0, ($clamped / 10.0) * ($height - 8));
+    };
+
+    $emptyCount = max(0, $totalSlots - count($scores));
+@endphp
+
+<div
+    {{ $attributes->merge([
+        'class' => 'aimtrack-shot-strip',
+        'style' => "padding: 14px; border: 1px solid var(--at-line); border-radius: var(--at-r-lg); background: var(--at-bg);",
+    ]) }}
+>
+    <div style="display: flex; align-items: flex-end; gap: 2px; height: {{ $height }}px;">
+        @foreach ($scores as $i => $v)
+            @php
+                $h = $barHeight((float) $v);
+                $isTen = $v >= 10;
+                $inDip = $dipFrom !== null && $i >= $dipFrom && $i <= $dipTo;
+                $bg = $isTen
+                    ? 'var(--at-accent)'
+                    : ($inDip ? 'color-mix(in srgb, var(--at-warn) 70%, transparent)' : 'color-mix(in srgb, var(--at-muted) 40%, transparent)');
+            @endphp
+            <div title="#{{ $i + 1 }}: {{ $fmt((float) $v) }}" style="flex: 1; height: {{ $fmt($h) }}px; background: {{ $bg }}; border-radius: 1px; min-width: 4px;"></div>
+        @endforeach
+        @for ($i = 0; $i < $emptyCount; $i++)
+            <div style="flex: 1; height: 6px; background: var(--at-line); border-radius: 1px; min-width: 4px; opacity: 0.45;"></div>
+        @endfor
+    </div>
+
+    <div style="display: flex; justify-content: space-between; margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">
+        <span>1</span>
+        <span>{{ (int) round($totalSlots / 4) }}</span>
+        <span>{{ (int) round($totalSlots / 2) }}</span>
+        <span>{{ (int) round($totalSlots * 3 / 4) }}</span>
+        <span>{{ $totalSlots }}</span>
+    </div>
+
+    @if ($showLegend)
+        <div style="display: flex; gap: 18px; margin-top: 12px; font-size: 11px; color: var(--at-muted); font-family: var(--at-font-mono);">
+            <span><span style="display: inline-block; width: 8px; height: 8px; background: var(--at-accent); margin-right: 6px;"></span>10+ ringen</span>
+            @if ($dipFrom !== null)
+                <span><span style="display: inline-block; width: 8px; height: 8px; background: color-mix(in srgb, var(--at-warn) 70%, transparent); margin-right: 6px;"></span>dip {{ $dipFrom + 1 }}–{{ $dipTo + 1 }}</span>
+            @endif
+            <span><span style="display: inline-block; width: 8px; height: 8px; background: color-mix(in srgb, var(--at-muted) 40%, transparent); margin-right: 6px;"></span>normaal</span>
+        </div>
+    @endif
+</div>

--- a/resources/views/components/aimtrack/sparkline.blade.php
+++ b/resources/views/components/aimtrack/sparkline.blade.php
@@ -1,0 +1,52 @@
+@props([
+    'data' => [],
+    'width' => 280,
+    'height' => 70,
+    'color' => null,
+    'strokeWidth' => 1.8,
+    'fill' => false,
+])
+
+@php
+    $values = collect($data)->map(fn ($v) => (float) $v)->all();
+    $width = (float) $width;
+    $height = (float) $height;
+    $color = $color ?? 'var(--at-accent)';
+    $strokeWidth = (float) $strokeWidth;
+
+    $fmt = static fn (float $value): string => rtrim(rtrim(number_format($value, 3, '.', ''), '0'), '.') ?: '0';
+
+    $hasData = count($values) >= 2;
+    $min = $hasData ? min($values) : 0.0;
+    $max = $hasData ? max($values) : 1.0;
+    $range = max(0.0001, $max - $min);
+
+    $points = [];
+    foreach ($values as $i => $v) {
+        $x = count($values) <= 1 ? $width / 2 : ($i / (count($values) - 1)) * $width;
+        $y = $height - 2 - (($v - $min) / $range) * ($height - 6);
+        $points[] = $fmt($x).','.$fmt($y);
+    }
+    $polyline = implode(' ', $points);
+    $areaPath = $hasData
+        ? "M{$points[0]} L".implode(' L', array_slice($points, 1))." L{$fmt($width)},{$fmt($height)} L0,{$fmt($height)} Z"
+        : '';
+@endphp
+
+<svg
+    {{ $attributes->merge(['class' => 'aimtrack-sparkline', 'style' => 'display: block;']) }}
+    width="{{ $fmt($width) }}"
+    height="{{ $fmt($height) }}"
+    viewBox="0 0 {{ $fmt($width) }} {{ $fmt($height) }}"
+    role="img"
+    aria-label="Trend"
+>
+    @if ($hasData)
+        @if ($fill)
+            <path d="{{ $areaPath }}" fill="{{ $color }}" opacity="0.12" />
+        @endif
+        <polyline points="{{ $polyline }}" fill="none" stroke="{{ $color }}" stroke-width="{{ $fmt($strokeWidth) }}" stroke-linejoin="round" stroke-linecap="round" />
+    @else
+        <line x1="0" y1="{{ $fmt($height / 2) }}" x2="{{ $fmt($width) }}" y2="{{ $fmt($height / 2) }}" stroke="var(--at-line)" stroke-width="1" stroke-dasharray="3 4" />
+    @endif
+</svg>

--- a/resources/views/components/aimtrack/stat-card.blade.php
+++ b/resources/views/components/aimtrack/stat-card.blade.php
@@ -1,0 +1,35 @@
+@props([
+    'label' => '',
+    'value' => '',
+    'sub' => null,
+    'subTone' => 'muted',
+    'valueTone' => 'text',
+])
+
+@php
+    $valueColor = match ($valueTone) {
+        'accent' => 'var(--at-accent)',
+        'warn'   => 'var(--at-warn)',
+        'muted'  => 'var(--at-muted)',
+        default  => 'var(--at-text)',
+    };
+
+    $subColor = match ($subTone) {
+        'accent' => 'var(--at-accent)',
+        'warn'   => 'var(--at-warn)',
+        default  => 'var(--at-muted)',
+    };
+@endphp
+
+<div
+    {{ $attributes->merge([
+        'class' => 'aimtrack-stat-card',
+        'style' => 'padding: 16px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg);',
+    ]) }}
+>
+    <div class="at-label">{{ $label }}</div>
+    <div style="font-family: var(--at-font-mono); font-size: var(--at-data-lg); font-weight: 600; margin-top: 6px; color: {{ $valueColor }}; letter-spacing: -0.01em; line-height: 1.1;">{{ $value }}</div>
+    @if ($sub !== null)
+        <div style="font-size: 11px; color: {{ $subColor }}; margin-top: 4px; display: flex; align-items: center; gap: 4px;">{{ $sub }}</div>
+    @endif
+</div>

--- a/resources/views/components/aimtrack/target-rings.blade.php
+++ b/resources/views/components/aimtrack/target-rings.blade.php
@@ -1,0 +1,87 @@
+@props([
+    'size' => 200,
+    'rings' => 10,
+    'accent' => null,
+    'dim' => null,
+    'ringStroke' => 1,
+    'hits' => [],
+    'scoreLabels' => false,
+])
+
+@php
+    $size = (float) $size;
+    $rings = max(2, (int) $rings);
+    $accent = $accent ?? 'var(--at-accent)';
+    $dim = $dim ?? 'var(--at-text)';
+    $ringStroke = (float) $ringStroke;
+
+    $cx = $size / 2;
+    $cy = $size / 2;
+    $maxR = $size * 0.46;
+    $hits = is_iterable($hits) ? (is_array($hits) ? $hits : iterator_to_array($hits)) : [];
+
+    $fmt = static fn (float $value): string => rtrim(rtrim(number_format($value, 3, '.', ''), '0'), '.');
+@endphp
+
+<svg
+    {{ $attributes->merge(['class' => 'aimtrack-target-rings', 'style' => 'display: block;']) }}
+    width="{{ $fmt($size) }}"
+    height="{{ $fmt($size) }}"
+    viewBox="0 0 {{ $fmt($size) }} {{ $fmt($size) }}"
+    role="img"
+    aria-label="Hit-patroon"
+>
+    @for ($i = $rings; $i >= 1; $i--)
+        @php
+            $r = $maxR * ($i / $rings);
+            $isCenter = $i <= 2;
+            $stroke = $isCenter ? $accent : $dim;
+            $opacity = $isCenter ? 0.7 : 0.32;
+        @endphp
+        <circle
+            cx="{{ $fmt($cx) }}"
+            cy="{{ $fmt($cy) }}"
+            r="{{ $fmt($r) }}"
+            fill="none"
+            stroke="{{ $stroke }}"
+            stroke-width="{{ $fmt($ringStroke) }}"
+            opacity="{{ $fmt((float) $opacity) }}"
+        />
+    @endfor
+
+    @if ($scoreLabels)
+        @for ($i = 1; $i <= $rings; $i++)
+            @php
+                $r = $maxR * ($i / $rings) - ($maxR / $rings) * 0.5;
+                $labelY = $cy + $r;
+                $value = $rings - $i + 1;
+            @endphp
+            <text
+                x="{{ $fmt($cx) }}"
+                y="{{ $fmt($labelY + 3) }}"
+                text-anchor="middle"
+                fill="var(--at-muted)"
+                style="font-family: var(--at-font-mono); font-size: 8px; letter-spacing: 0.06em;"
+            >{{ $value }}</text>
+        @endfor
+    @endif
+
+    @foreach ($hits as $hit)
+        @php
+            $hx = (float) ($hit['x'] ?? 0);
+            $hy = (float) ($hit['y'] ?? 0);
+            $hr = isset($hit['r']) ? (float) $hit['r'] : null;
+            $px = $cx + ($hx * $maxR);
+            $py = $cy + ($hy * $maxR);
+            $color = ($hr !== null && $hr >= 10) ? $accent : 'var(--at-text)';
+            $dotR = max(2.0, $size * 0.012);
+        @endphp
+        <circle
+            cx="{{ $fmt($px) }}"
+            cy="{{ $fmt($py) }}"
+            r="{{ $fmt($dotR) }}"
+            fill="{{ $color }}"
+            opacity="0.85"
+        />
+    @endforeach
+</svg>

--- a/resources/views/filament/pages/coach-page.blade.php
+++ b/resources/views/filament/pages/coach-page.blade.php
@@ -1,34 +1,131 @@
-<x-filament-panels::page>
-    <div class="space-y-6">
-        <x-filament::section icon="heroicon-o-sparkles">
-            <x-slot name="heading">Welkom bij je AI-coach</x-slot>
-            <x-slot name="description">
-                Stel open vragen over je training, techniek of wapenkeuze. De coach
-                gebruikt automatisch jouw recente sessies, wapenoverzicht en eerdere
-                AI-reflecties als context.
-            </x-slot>
+@php
+    use Illuminate\Support\Carbon;
 
-            <div class="prose prose-sm dark:prose-invert max-w-none">
-                <p>Voorbeeldvragen:</p>
-                <ul>
-                    <li>Welke trends zie je in mijn afwijkingen op 25m?</li>
-                    <li>Vergelijk mijn laatste sessie met die ervoor.</li>
-                    <li>Geef tips voor mijn Glock 17 bij snelvuur op 15m.</li>
-                </ul>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                    De coach is geen vervanging voor erkende instructeurs. Volg altijd
-                    baanregels en wettelijke richtlijnen.
+    /** @var \App\Services\CoachContextService $coach */
+    $coach = $this->getCoachContext();
+
+    $conversations = $coach->recentConversations(6);
+    $latestConversation = $coach->latestConversation();
+    $lastSession = $coach->lastSession();
+    $topWeapon = $coach->topWeapon();
+
+    $sampleQuestions = [
+        'Vergelijk met vorige maand',
+        'Wat trainen deze week?',
+        'Trekkerafstelling LP500',
+        'WM-4 status',
+    ];
+@endphp
+
+<x-filament-panels::page>
+    <div style="display: grid; grid-template-columns: 260px minmax(0, 1fr) 280px; gap: 16px; align-items: stretch; min-height: 540px;">
+        <aside style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); padding: 16px 12px; display: flex; flex-direction: column; gap: 4px; overflow: auto;">
+            <div class="at-label" style="padding: 4px 8px 10px;">RECENTE GESPREKKEN</div>
+            @forelse ($conversations as $conv)
+                @php
+                    $isActive = $latestConversation && $latestConversation->id === $conv->id;
+                @endphp
+                <div wire:key="conv-{{ $conv->id }}" style="padding: 10px; border-radius: var(--at-r-md); background: {{ $isActive ? 'var(--at-panel-2)' : 'transparent' }}; border: 1px solid {{ $isActive ? 'var(--at-line)' : 'transparent' }};">
+                    <div style="display: flex; align-items: center; gap: 6px;">
+                        @if ($isActive)
+                            <span style="width: 6px; height: 6px; border-radius: 50%; background: var(--at-accent);"></span>
+                        @endif
+                        <div style="font-size: 12px; color: var(--at-text); font-weight: {{ $isActive ? 600 : 500 }}; flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                            {{ $conv->title ?: 'Gesprek '.substr((string) $conv->id, 0, 6) }}
+                        </div>
+                    </div>
+                    <div style="font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); margin-top: 2px; margin-left: {{ $isActive ? '12px' : '0' }};">
+                        {{ Carbon::parse($conv->updated_at)->diffForHumans() }}
+                    </div>
+                </div>
+            @empty
+                <div style="padding: 16px 8px; color: var(--at-muted); font-size: 12px; line-height: 1.55;">
+                    Nog geen gesprekken met de coach. Open de chat hieronder om je eerste vraag te stellen.
+                </div>
+            @endforelse
+        </aside>
+
+        <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); display: flex; flex-direction: column; min-width: 0;">
+            <div style="padding: 20px 24px; border-bottom: 1px solid var(--at-line);">
+                <div class="at-label">AI-COACH · CONTEXT-RIJK GESPREK</div>
+                <h2 style="font-family: var(--at-font-display); font-size: 22px; font-weight: 600; letter-spacing: -0.01em; margin: 6px 0 0; color: var(--at-text);">Stel een vraag aan je coach</h2>
+                <p style="margin: 6px 0 0; font-size: 12px; color: var(--at-muted); line-height: 1.5;">
+                    De coach gebruikt automatisch je laatste sessies, wapens en eerdere reflecties.
+                    Antwoorden draaien op je <span style="color: var(--at-accent);">eigen instance</span> — geen data verlaat de server.
                 </p>
             </div>
-        </x-filament::section>
 
-        <div class="flex">
-            <x-filament::button
-                icon="heroicon-o-chat-bubble-left-right"
-                x-on:click="window.dispatchEvent(new CustomEvent('copilot-open'))"
-            >
-                Open de chat
-            </x-filament::button>
+            <div style="flex: 1; padding: 24px; display: flex; flex-direction: column; gap: 20px; min-height: 0; overflow: auto;">
+                <div style="background: color-mix(in srgb, var(--at-accent) 6%, transparent); border: 1px solid var(--at-accent-25); border-radius: var(--at-r-md); padding: 16px;">
+                    <div class="at-label" style="color: var(--at-accent);">SUGGESTIE</div>
+                    <div style="font-size: 13.5px; line-height: 1.55; color: var(--at-text); margin-top: 6px;">
+                        @if ($lastSession)
+                            Wil je een reflectie op <strong>sessie {{ 'S-'.str_pad((string) $lastSession->id, 4, '0', STR_PAD_LEFT) }}</strong>
+                            ({{ $lastSession->date?->translatedFormat('d M') ?? '—' }})? Of stel een open vraag over je training.
+                        @else
+                            Log eerst een sessie of stel direct een open vraag — de coach werkt ook zonder data.
+                        @endif
+                    </div>
+                </div>
+
+                <div>
+                    <div class="at-label" style="margin-bottom: 8px;">VOORBEELDVRAGEN</div>
+                    <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+                        @foreach ($sampleQuestions as $q)
+                            <span style="padding: 5px 10px; border-radius: 999px; border: 1px solid var(--at-line); color: var(--at-muted); font-size: 11px; font-family: var(--at-font-mono); letter-spacing: 0.04em;">{{ $q }}</span>
+                        @endforeach
+                    </div>
+                </div>
+
+                <div style="margin-top: auto; display: flex; align-items: center; gap: 10px;">
+                    <button
+                        type="button"
+                        x-on:click="window.dispatchEvent(new CustomEvent('copilot-open'))"
+                        style="padding: 10px 16px; border-radius: var(--at-r-md); border: none; background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; cursor: pointer; display: inline-flex; align-items: center; gap: 8px;"
+                    >
+                        Open coach
+                    </button>
+                    <span style="font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">⌃⇧K · OPENT FLOATING CHAT</span>
+                </div>
+            </div>
         </div>
+
+        <aside style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); padding: 20px 18px; display: flex; flex-direction: column; gap: 14px; overflow: auto;">
+            <div class="at-label">CONTEXT IN GESPREK</div>
+
+            @if ($lastSession)
+                @php
+                    $sessionLabel = 'S-'.str_pad((string) $lastSession->id, 4, '0', STR_PAD_LEFT);
+                @endphp
+                <div style="padding: 12px; background: var(--at-panel-2); border: 1px solid var(--at-line); border-radius: var(--at-r-md); display: flex; align-items: center; gap: 10px;">
+                    <div style="flex: 1; min-width: 0;">
+                        <div style="font-size: 12px; color: var(--at-text); font-weight: 600;">{{ $sessionLabel }} · {{ $lastSession->date?->translatedFormat('d M') ?? '—' }}</div>
+                        <div style="font-size: 11px; color: var(--at-muted); font-family: var(--at-font-mono);">{{ $lastSession->range_name ?? '—' }}</div>
+                    </div>
+                    <span style="display: inline-flex; align-items: center; padding: 2px 6px; border-radius: 4px; background: var(--at-accent-12); color: var(--at-accent); border: 1px solid var(--at-accent-25); font-family: var(--at-font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase;">IN</span>
+                </div>
+            @endif
+
+            @if ($topWeapon)
+                <div style="padding: 12px; background: var(--at-panel-2); border: 1px solid var(--at-line); border-radius: var(--at-r-md); display: flex; align-items: center; gap: 10px;">
+                    <div style="flex: 1; min-width: 0;">
+                        <div style="font-size: 12px; color: var(--at-text); font-weight: 600;">{{ $topWeapon->name }}</div>
+                        <div style="font-size: 11px; color: var(--at-muted); font-family: var(--at-font-mono);">{{ $topWeapon->caliber ?? '—' }}</div>
+                    </div>
+                    <span style="display: inline-flex; align-items: center; padding: 2px 6px; border-radius: 4px; background: var(--at-accent-12); color: var(--at-accent); border: 1px solid var(--at-accent-25); font-family: var(--at-font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase;">IN</span>
+                </div>
+            @endif
+
+            @unless ($lastSession || $topWeapon)
+                <div style="padding: 12px; color: var(--at-muted); font-size: 12px; line-height: 1.55;">
+                    Geen sessies of wapens gevonden. De coach werkt nog zonder context.
+                </div>
+            @endunless
+
+            <div class="at-label" style="margin-top: 8px;">PRIVACY</div>
+            <div style="font-size: 11px; color: var(--at-muted); line-height: 1.6;">
+                Antwoorden gegenereerd op je <span style="color: var(--at-accent);">eigen instance</span>. Geen data verlaat de server.
+            </div>
+        </aside>
     </div>
 </x-filament-panels::page>

--- a/resources/views/filament/resources/sessions/list-sessions.blade.php
+++ b/resources/views/filament/resources/sessions/list-sessions.blade.php
@@ -1,0 +1,114 @@
+@php
+    use App\Services\SessionStatsService;
+
+    /** @var \App\Services\RangeConsoleSummaryService $summary */
+    $summary = $this->getRangeConsoleSummary();
+
+    $monthDelta = $summary->sessionsThisMonthDelta();
+    $monthDeltaLabel = $monthDelta >= 0 ? '+'.$monthDelta : (string) $monthDelta;
+    $pending = $summary->pendingAiReflections();
+    $lastSession = $summary->lastSession();
+    $lastStats = $lastSession ? new SessionStatsService($lastSession) : null;
+    $reflection = $summary->latestReflection();
+    $trend = $summary->trend30d();
+    $bestSerie = $summary->bestSeriesScore();
+@endphp
+
+<x-filament-panels::page>
+    <x-aimtrack.page-header
+        title="Sessies"
+        :subtitle="'Overzicht van je trainingen · '.$summary->totalSessions().' totaal · gefilterd op afgelopen 30 dagen'"
+        :reticle-opacity="0.07"
+        :reticle-size="200"
+    />
+
+    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+        <x-aimtrack.stat-card
+            label="Sessies / mnd"
+            :value="(string) $summary->sessionsThisMonth()"
+            :sub="$monthDeltaLabel.' vs vorige maand'"
+            :sub-tone="$monthDelta >= 0 ? 'accent' : 'warn'"
+        />
+        <x-aimtrack.stat-card
+            label="Schoten totaal"
+            :value="number_format($summary->shotsLast30d(), 0, ',', '.')"
+            sub="laatste 30d"
+        />
+        <x-aimtrack.stat-card
+            label="Beste serie"
+            :value="$bestSerie !== null ? (string) $bestSerie : '—'"
+            :sub="$bestSerie !== null ? '10-shot serie' : 'geen volle serie'"
+            :value-tone="$bestSerie !== null ? 'accent' : 'muted'"
+        />
+        <x-aimtrack.stat-card
+            label="AI-reflecties"
+            :value="(string) $summary->aiReflectionCount()"
+            :sub="$pending > 0 ? $pending.' in wachtrij' : 'alles bijgewerkt'"
+        />
+    </div>
+
+    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 16px; align-items: start;">
+        <div style="min-width: 0;">
+            {{ $this->table }}
+        </div>
+
+        <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+            <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Laatste sessie</div>
+                    <div class="at-label" style="margin-left: auto;">{{ $lastSession ? 'S-'.str_pad((string) $lastSession->id, 4, '0', STR_PAD_LEFT) : '—' }}</div>
+                </div>
+                <div style="padding: 18px; display: flex; flex-direction: column; align-items: center; gap: 12px;">
+                    @if ($lastSession && $lastStats && $lastStats->totalShots() > 0)
+                        @php
+                            $hits = $lastSession->shots->map(fn ($shot) => [
+                                'x' => (float) ($shot->x_normalized ?? 0) - 0.5,
+                                'y' => (float) ($shot->y_normalized ?? 0) - 0.5,
+                                'r' => (int) ($shot->ring ?? 0),
+                            ])->all();
+                        @endphp
+                        <x-aimtrack.target-rings :size="200" :hits="$hits" />
+                        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; width: 100%;">
+                            <div>
+                                <div class="at-label" style="letter-spacing: 0.14em;">Score</div>
+                                <div style="font-family: var(--at-font-mono); font-size: 18px; font-weight: 600; color: var(--at-accent);">{{ $lastStats->totalScore() }}</div>
+                            </div>
+                            <div>
+                                <div class="at-label" style="letter-spacing: 0.14em;">Beste</div>
+                                <div style="font-family: var(--at-font-mono); font-size: 18px; font-weight: 600; color: var(--at-text);">{{ $lastStats->bestShot() ?? '—' }}</div>
+                            </div>
+                            <div>
+                                <div class="at-label" style="letter-spacing: 0.14em;">Groep</div>
+                                <div style="font-family: var(--at-font-mono); font-size: 18px; font-weight: 600; color: var(--at-text);">{{ $lastStats->groupMm() !== null ? $lastStats->groupMm() : '—' }}<span style="font-size: 11px; color: var(--at-muted);">mm</span></div>
+                            </div>
+                        </div>
+                    @else
+                        <div style="padding: 32px 8px; color: var(--at-muted); font-size: 12px; text-align: center;">Nog geen sessies gelogd</div>
+                    @endif
+                </div>
+            </div>
+
+            <x-aimtrack.ai-reflection-card
+                :reflection="$reflection"
+                :session-id="$reflection?->session_id ? 'S-'.str_pad((string) $reflection->session_id, 4, '0', STR_PAD_LEFT) : null"
+                :generated-at="$reflection?->updated_at"
+            />
+
+            <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Trend</div>
+                    <div class="at-label" style="margin-left: auto;">30d</div>
+                </div>
+                <div style="padding: 14px;">
+                    <x-aimtrack.sparkline :data="array_values($trend)" :width="296" :height="70" :fill="true" />
+                    @if (count($trend) >= 2)
+                        <div style="display: flex; justify-content: space-between; margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">
+                            <span>{{ \Illuminate\Support\Carbon::parse(array_key_first($trend))->format('d M') }}</span>
+                            <span>{{ \Illuminate\Support\Carbon::parse(array_key_last($trend))->format('d M') }}</span>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/resources/sessions/view-session.blade.php
+++ b/resources/views/filament/resources/sessions/view-session.blade.php
@@ -1,0 +1,137 @@
+@php
+    use App\Services\SessionStatsService;
+    use Illuminate\Support\Carbon;
+
+    /** @var \App\Models\Session $session */
+    $session = $this->getRecord();
+    $stats = new SessionStatsService($session);
+
+    $session->loadMissing(['shots', 'sessionWeapons.weapon', 'aiReflection']);
+
+    $totalShots = $stats->totalShots();
+    $totalScore = $stats->totalScore();
+    $tienen = $stats->tienen();
+    $negens = $stats->negens();
+    $bestShot = $stats->bestShot();
+    $groupMm = $stats->groupMm();
+    $cadans = $stats->avgCadansSec();
+    $perSerie = $stats->shotsPerSerie();
+    $series = $stats->seriesScores($perSerie);
+    $dipRange = $stats->dipRange();
+
+    $sessionLabel = 'S-'.str_pad((string) $session->id, 4, '0', STR_PAD_LEFT);
+    $dateLabel = $session->date ? Carbon::parse($session->date)->translatedFormat('l d F Y') : '—';
+
+    $firstSessionWeapon = $session->sessionWeapons->first();
+    $weapon = $firstSessionWeapon?->weapon;
+    $distance = $firstSessionWeapon?->distance_m;
+    $disciplineLabel = $weapon
+        ? trim(($weapon->weapon_type?->value ?? '').' '.($distance ? $distance.'m' : ''))
+        : '—';
+    if ($disciplineLabel === '') {
+        $disciplineLabel = '—';
+    }
+
+    $hits = $session->shots->map(fn ($shot) => [
+        'x' => (float) ($shot->x_normalized ?? 0) - 0.5,
+        'y' => (float) ($shot->y_normalized ?? 0) - 0.5,
+        'r' => (int) ($shot->ring ?? 0),
+    ])->all();
+
+    $reflectionRecord = $session->aiReflection;
+@endphp
+
+<x-filament-panels::page>
+    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 16px; align-items: start;">
+        <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+            <div style="position: relative; padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <x-aimtrack.watermark-bg :size="220" :opacity="0.07" :top="-60" :right="-40" />
+                @if ($reflectionRecord)
+                    <x-aimtrack.monogram-stamp label="WM-4 OK" corner="top-right" />
+                @endif
+                <div style="position: relative; z-index: 1; display: flex; align-items: flex-start; gap: 24px;">
+                    <div style="flex: 1; min-width: 0;">
+                        <div class="at-label">SESSIE · {{ $sessionLabel }} · {{ $dateLabel }}</div>
+                        <h1 style="font-family: var(--at-font-display); font-size: 26px; font-weight: 600; letter-spacing: -0.01em; margin: 6px 0 0; color: var(--at-text);">
+                            {{ ucfirst($disciplineLabel) }} · {{ $totalShots }} schoten
+                        </h1>
+                        <div style="display: flex; gap: 16px; margin-top: 10px; font-size: 12px; color: var(--at-muted); flex-wrap: wrap;">
+                            <span>{{ $session->range_name ?? '—' }}</span>
+                            <span>{{ $weapon?->name ?? '—' }}{{ $weapon?->caliber ? ' · '.$weapon->caliber : '' }}</span>
+                            <span>{{ $cadans !== null ? round(($cadans * max(1, $totalShots)) / 60, 0).' min' : '—' }}</span>
+                        </div>
+                    </div>
+                    <div style="text-align: right; position: relative;">
+                        <div class="at-label">EINDSCORE</div>
+                        <div style="font-family: var(--at-font-mono); font-size: 44px; font-weight: 600; color: var(--at-accent); line-height: 1; letter-spacing: -0.02em;">{{ $totalScore }}</div>
+                        <div style="font-family: var(--at-font-mono); font-size: 12px; color: var(--at-muted); margin-top: 2px;">{{ $totalShots > 0 ? round($totalScore / $totalShots, 1).' gem' : '—' }}</div>
+                    </div>
+                </div>
+            </div>
+
+            <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;">
+                <x-aimtrack.stat-card label="Beste schot" :value="$bestShot !== null ? (string) $bestShot : '—'" />
+                <x-aimtrack.stat-card label="Tienen" :value="$tienen.'/'.max(1, $totalShots)" :value-tone="$tienen > 0 ? 'accent' : 'text'" />
+                <x-aimtrack.stat-card label="Negens" :value="$negens.'/'.max(1, $totalShots)" />
+                <x-aimtrack.stat-card label="Groep" :value="$groupMm !== null ? $groupMm.' mm' : '—'" />
+                <x-aimtrack.stat-card label="Gem. cadans" :value="$cadans !== null ? $cadans.' s' : '—'" />
+            </div>
+
+            <x-aimtrack.series-card :series="$series" :shots-per-serie="$perSerie" />
+
+            @if ($totalShots > 0)
+                <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                    <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                        <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Schot-voor-schot</div>
+                        <div class="at-label" style="margin-left: auto;">{{ $totalShots }} schoten</div>
+                    </div>
+                    <div style="padding: 14px 16px 16px;">
+                        <x-aimtrack.shot-strip
+                            :shots="$session->shots->pluck('score')->all()"
+                            :total-slots="$totalShots"
+                            :dip-range="$dipRange"
+                            :height="80"
+                        />
+                    </div>
+                </div>
+            @else
+                <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); padding: 32px 16px; color: var(--at-muted); font-size: 12px; text-align: center;">
+                    Nog geen schoten gelogd voor deze sessie.
+                </div>
+            @endif
+        </div>
+
+        <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+            <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Hit-patroon</div>
+                    <div class="at-label" style="margin-left: auto;">{{ $totalShots }} schoten</div>
+                </div>
+                <div style="padding: 16px; display: flex; flex-direction: column; align-items: center; gap: 12px;">
+                    @if ($totalShots > 0)
+                        <x-aimtrack.target-rings :size="240" :hits="$hits" />
+                    @else
+                        <div style="padding: 40px 8px; color: var(--at-muted); font-size: 12px;">Nog geen hits geregistreerd</div>
+                    @endif
+                </div>
+            </div>
+
+            <x-aimtrack.ai-reflection-card
+                :reflection="$reflectionRecord"
+                :session-id="$sessionLabel"
+                :generated-at="$reflectionRecord?->updated_at"
+            />
+
+            @if (filled($session->manual_reflection))
+                <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                    <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line);">
+                        <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Eigen notitie</div>
+                    </div>
+                    <div style="padding: 16px; font-size: 13px; line-height: 1.55; color: var(--at-text); font-style: italic;">
+                        {{ $session->manual_reflection }}
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -1,0 +1,107 @@
+@php
+    // Decimaal-numpad uit new-session-wizard.jsx — exact deze volgorde/labels.
+    $numpad = ['10.9', '10.8', '10.7', '10.6', '10.5', '10.4', '10.3', '10.2', '10.1', '10.0', '9.9', '9.8', '9.7', '9.6', '9.5', '9.0', '8', '0'];
+
+    // Decision 6: AI-tijdens-sessie tip is hard-coded mock-tekst (geen runtime call).
+    $aiTip = 'Goed bezig — schot 1–10 zit boven je gemiddelde. Hou je cadans rond 30s aan.';
+@endphp
+
+<div class="aimtrack-wizard-shots" style="display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 16px; align-items: start;">
+    <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+        <div style="display: flex; align-items: flex-end; gap: 24px; flex-wrap: wrap;">
+            <div>
+                <div class="at-label">VOORTGANG</div>
+                <div style="display: flex; align-items: baseline; gap: 6px; margin-top: 6px;">
+                    <div style="font-family: var(--at-font-mono); font-size: 36px; font-weight: 600; color: var(--at-text); line-height: 1; letter-spacing: -0.02em;">0</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 14px; color: var(--at-muted);">/ 60</div>
+                </div>
+            </div>
+            <div>
+                <div class="at-label">LOPENDE SCORE</div>
+                <div style="font-family: var(--at-font-mono); font-size: 36px; font-weight: 600; color: var(--at-accent); line-height: 1; margin-top: 6px; letter-spacing: -0.02em;">—</div>
+            </div>
+            <div>
+                <div class="at-label">GEM. PER SCHOT</div>
+                <div style="font-family: var(--at-font-mono); font-size: 36px; font-weight: 600; color: var(--at-text); line-height: 1; margin-top: 6px; letter-spacing: -0.02em;">—</div>
+            </div>
+            <div style="margin-left: auto; display: flex; align-items: center; gap: 10px; padding: 6px 10px; border-radius: var(--at-r-md); background: var(--at-accent-12); border: 1px solid var(--at-accent-25);">
+                <span style="width: 6px; height: 6px; border-radius: 50%; background: var(--at-accent);"></span>
+                <span style="font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.16em; color: var(--at-accent);">OPNAME START NA OPSLAAN</span>
+            </div>
+        </div>
+
+        <x-aimtrack.shot-strip :shots="[]" :total-slots="60" :show-legend="false" />
+
+        <div>
+            <div class="at-label">VOLGEND SCHOT · PREVIEW</div>
+            <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 6px; margin-top: 10px; opacity: 0.55; pointer-events: none;" aria-hidden="true">
+                @foreach ($numpad as $value)
+                    @php
+                        $isTen = str_starts_with($value, '10');
+                        $isMiss = $value === '0';
+                        $bg = $isTen ? 'var(--at-accent-12)' : ($isMiss ? 'color-mix(in srgb, var(--at-warn) 8%, transparent)' : 'var(--at-bg)');
+                        $border = $isTen ? 'var(--at-accent-25)' : ($isMiss ? 'color-mix(in srgb, var(--at-warn) 20%, transparent)' : 'var(--at-line)');
+                        $color = $isTen ? 'var(--at-accent)' : ($isMiss ? 'var(--at-warn)' : 'var(--at-text)');
+                    @endphp
+                    <div style="padding: 11px 0; border-radius: var(--at-r-md); background: {{ $bg }}; border: 1px solid {{ $border }}; color: {{ $color }}; text-align: center; font-family: var(--at-font-mono); font-size: 14px; font-weight: 600; letter-spacing: -0.01em;">{{ $value }}</div>
+                @endforeach
+            </div>
+
+            <div style="display: flex; align-items: center; gap: 8px; margin-top: 12px; font-size: 11px; color: var(--at-muted); font-family: var(--at-font-mono);">
+                <span style="margin-left: auto; letter-spacing: 0.08em;">OF VUL HANDMATIG IN ↓</span>
+            </div>
+            <div style="margin-top: 10px; display: flex; align-items: center; gap: 10px; opacity: 0.55; pointer-events: none;" aria-hidden="true">
+                <input readonly value="10." style="flex: 1; padding: 12px 14px; border-radius: var(--at-r-lg); background: var(--at-bg); border: 2px solid var(--at-accent); color: var(--at-text); font-family: var(--at-font-mono); font-size: 18px; font-weight: 600; letter-spacing: -0.01em; outline: none;" />
+                <span style="padding: 12px 18px; border-radius: var(--at-r-lg); background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 14px; display: inline-flex; align-items: center; gap: 6px;">Bevestig →</span>
+            </div>
+        </div>
+
+        <div style="display: flex; align-items: flex-start; gap: 10px; padding: 14px; border: 1px dashed var(--at-line); border-radius: var(--at-r-md); background: var(--at-bg);">
+            <span style="color: var(--at-accent); font-size: 16px; line-height: 1.2;" role="presentation">◎</span>
+            <div style="font-size: 12px; line-height: 1.55; color: var(--at-muted);">
+                Het scorebord hierboven is een voorbeeld. Je legt de echte schoten vast op het
+                <span style="color: var(--at-text); font-weight: 600;">schotenbord</span>, dat direct opent zodra je deze sessie afrondt.
+                Daar tik je elk schot op de roos — score en ring worden automatisch berekend.
+            </div>
+        </div>
+    </div>
+
+    <aside style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+        <div>
+            <div class="at-label">SESSIE</div>
+            <div style="font-size: 14px; font-weight: 600; color: var(--at-text); margin-top: 6px;">Nieuwe sessie</div>
+            <div style="font-size: 12px; color: var(--at-muted); font-family: var(--at-font-mono); margin-top: 2px;">Datum &amp; baan: stap Sessie</div>
+        </div>
+
+        <div>
+            <div class="at-label">WAPEN</div>
+            <div style="margin-top: 6px; padding: 10px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                <span style="color: var(--at-accent); font-size: 16px; line-height: 1;" role="presentation">⦿</span>
+                <div style="flex: 1; min-width: 0;">
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Zoals gekozen in stap Wapen</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted);">wapen · kaliber · serial</div>
+                </div>
+            </div>
+        </div>
+
+        <div>
+            <div class="at-label">OPTIES</div>
+            <div style="margin-top: 10px; display: flex; flex-direction: column; gap: 8px;">
+                @foreach ([['AI-reflectie', true], ['Decimaal-notatie', true], ['Toon ringen-view', false]] as [$label, $on])
+                    <div style="display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--at-text);">
+                        <div style="width: 30px; height: 18px; border-radius: 999px; background: {{ $on ? 'var(--at-accent)' : 'var(--at-line)' }}; position: relative; flex-shrink: 0;">
+                            <div style="position: absolute; top: 2px; left: {{ $on ? '14px' : '2px' }}; width: 14px; height: 14px; border-radius: 50%; background: var(--at-cta-text);"></div>
+                        </div>
+                        <span>{{ $label }}</span>
+                    </div>
+                @endforeach
+            </div>
+            <div style="margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">VOORKEUREN · BINNENKORT INSTELBAAR</div>
+        </div>
+
+        <x-aimtrack.bracket-frame :rounded="8" :padding="14" style="background: var(--at-accent-12); display: flex; flex-direction: column; gap: 6px;">
+            <div style="font-family: var(--at-font-mono); font-size: 10px; color: var(--at-accent); letter-spacing: 0.14em;">● AI TIJDENS SESSIE</div>
+            <div style="font-size: 12px; line-height: 1.5; color: var(--at-text);">{{ $aiTip }}</div>
+        </x-aimtrack.bracket-frame>
+    </aside>
+</div>

--- a/resources/views/filament/resources/weapons/view-weapon.blade.php
+++ b/resources/views/filament/resources/weapons/view-weapon.blade.php
@@ -1,0 +1,157 @@
+@php
+    use App\Services\WeaponInsightsService;
+    use Illuminate\Support\Carbon;
+
+    /** @var \App\Models\Weapon $weapon */
+    $weapon = $this->getRecord();
+    $insights = new WeaponInsightsService($weapon);
+
+    $idCode = 'W-'.str_pad((string) $weapon->id, 3, '0', STR_PAD_LEFT);
+    $typeLabel = $weapon->weapon_type?->value ?? '—';
+    $caliberLabel = $weapon->caliber ?? '—';
+
+    $sessionCount = $insights->sessionCount();
+    $totalShots = $insights->totalShots();
+    $avgScore = $insights->avgScore();
+    $bestScore = $insights->bestScore();
+    $bestDate = $insights->bestScoreDate();
+    $trendData = $insights->trendData(365);
+    $recentSessions = $insights->recentSessions(5);
+
+    $statusRows = [
+        ['Status', $weapon->is_active ? 'Actief' : 'Uit gebruik', $weapon->is_active ? 'ok' : null],
+        ['Aangeschaft', $weapon->owned_since?->translatedFormat('M Y') ?? '—', null],
+        ['Kaliber', $caliberLabel, null],
+        ['Type', ucfirst($typeLabel), null],
+        ['Serial', $weapon->serial_number ?? '—', null],
+        ['Opslag', $weapon->storageLocation?->name ?? ($weapon->storage_location ?? '—'), null],
+    ];
+
+    $kalibratieRows = [
+        ['Korrel', $weapon->korrel_correction ?? '—'],
+        ['Vizier', $weapon->vizier_correction ?? '—'],
+        ['Trekker', $weapon->trigger_weight_g !== null ? $weapon->trigger_weight_g.' g' : '—'],
+        ['Handgreep', $weapon->grip_size ?? '—'],
+    ];
+@endphp
+
+<x-filament-panels::page>
+    <div style="display: grid; grid-template-columns: 340px minmax(0, 1fr); gap: 16px; align-items: start;">
+        <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+            <div style="padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg);">
+                <div style="aspect-ratio: 16/10; background: linear-gradient(135deg, var(--at-panel-2), var(--at-panel)); border: 1px solid var(--at-line); border-radius: var(--at-r-md); display: flex; align-items: center; justify-content: center; position: relative;">
+                    <svg width="65%" height="65%" viewBox="0 0 200 100" style="opacity: 0.7;" role="img" aria-label="Wapen silhouet">
+                        <path d="M20 60 L160 60 L168 50 L175 50 L175 60 L185 60 L180 70 L155 70 L150 85 L130 85 L125 75 L40 75 L40 80 L25 80 Z" fill="none" stroke="var(--at-accent)" stroke-width="1.5" />
+                        <circle cx="55" cy="68" r="3" fill="var(--at-accent)" />
+                        <line x1="40" y1="60" x2="40" y2="75" stroke="var(--at-accent)" stroke-width="1" />
+                    </svg>
+                    <div style="position: absolute; top: 8px; left: 8px; font-family: var(--at-font-mono); font-size: 9px; color: var(--at-muted); letter-spacing: 0.18em;">FOTO</div>
+                </div>
+
+                <div style="margin-top: 14px;">
+                    <div class="at-label">{{ strtoupper($typeLabel) }} · {{ $caliberLabel }}</div>
+                    <h1 style="font-family: var(--at-font-display); font-size: 22px; font-weight: 600; letter-spacing: -0.01em; margin: 4px 0 0; color: var(--at-text);">{{ $weapon->name }}</h1>
+                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted); margin-top: 6px;">ID · {{ $idCode }}</div>
+                </div>
+
+                <div style="height: 1px; background: var(--at-line); margin: 14px 0;"></div>
+
+                @foreach ($statusRows as [$key, $value, $kind])
+                    <div style="display: flex; justify-content: space-between; padding: 6px 0; font-size: 12px;">
+                        <div style="color: var(--at-muted);">{{ $key }}</div>
+                        <div style="color: var(--at-text);">
+                            @if (($kind ?? null) === 'ok')
+                                <span style="color: var(--at-accent);">● </span>
+                            @endif
+                            {{ $value }}
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+
+            <div style="padding: 16px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg);">
+                <div class="at-label" style="margin-bottom: 10px;">KALIBRATIE</div>
+                <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;">
+                    @foreach ($kalibratieRows as [$key, $value])
+                        <div>
+                            <div style="font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">{{ strtoupper($key) }}</div>
+                            <div style="font-family: var(--at-font-mono); font-size: 16px; color: var(--at-text);">{{ $value }}</div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+
+        <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+            <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+                <x-aimtrack.stat-card label="Sessies" :value="(string) $sessionCount" :sub="$sessionCount > 0 ? 'totaal' : 'nog geen'" />
+                <x-aimtrack.stat-card label="Schoten totaal" :value="number_format($totalShots, 0, ',', '.')" />
+                <x-aimtrack.stat-card
+                    label="Gem. score"
+                    :value="$avgScore !== null ? number_format($avgScore, 1, '.', '') : '—'"
+                    :value-tone="$avgScore !== null ? 'accent' : 'muted'"
+                />
+                <x-aimtrack.stat-card
+                    label="Beste"
+                    :value="$bestScore !== null ? (string) $bestScore : '—'"
+                    :sub="$bestDate?->translatedFormat('d M Y') ?? '—'"
+                />
+            </div>
+
+            <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Score-trend · alle sessies</div>
+                    <div class="at-label" style="margin-left: auto;">{{ count($trendData) }} sessies</div>
+                </div>
+                <div style="padding: 18px;">
+                    <x-aimtrack.sparkline :data="array_values($trendData)" :width="760" :height="140" :stroke-width="2" :fill="true" />
+                    @if (count($trendData) >= 2)
+                        <div style="display: flex; justify-content: space-between; margin-top: 10px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">
+                            <span>{{ Carbon::parse(array_key_first($trendData))->translatedFormat('M Y') }}</span>
+                            <span>{{ Carbon::parse(array_key_last($trendData))->translatedFormat('M Y') }}</span>
+                        </div>
+                    @else
+                        <div style="margin-top: 10px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em; text-align: center;">Onvoldoende data voor trend</div>
+                    @endif
+                </div>
+            </div>
+
+            <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Sessies met dit wapen</div>
+                    <div class="at-label" style="margin-left: auto;">{{ $recentSessions->count() }} recent · {{ $sessionCount }} totaal</div>
+                </div>
+                @if ($recentSessions->isEmpty())
+                    <div style="padding: 32px 16px; color: var(--at-muted); font-size: 12px; text-align: center;">Nog geen sessies met dit wapen.</div>
+                @else
+                    <div style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 8px 16px; font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-muted); border-bottom: 1px solid var(--at-line);">
+                        <div>Datum</div><div>Locatie</div><div>Schoten</div><div>Score</div><div>Status</div>
+                    </div>
+                    @foreach ($recentSessions as $session)
+                        @php
+                            $sessionLabel = 'S-'.str_pad((string) $session->id, 4, '0', STR_PAD_LEFT);
+                            $sessionScore = (int) $session->shots()->sum('score');
+                            $sessionShots = (int) $session->sessionWeapons()->sum('rounds_fired');
+                        @endphp
+                        <div style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 12px 16px; border-bottom: 1px solid var(--at-line); align-items: center; font-size: 12px;">
+                            <div style="font-family: var(--at-font-mono); color: var(--at-muted); font-size: 11px;">
+                                {{ $session->date?->translatedFormat('d M') ?? '—' }}
+                                <div style="font-size: 9px; opacity: 0.7;">{{ $sessionLabel }}</div>
+                            </div>
+                            <div style="color: var(--at-text);">{{ $session->range_name ?? '—' }}</div>
+                            <div style="font-family: var(--at-font-mono); color: var(--at-text);">{{ $sessionShots }}</div>
+                            <div style="font-family: var(--at-font-mono); color: var(--at-accent); font-weight: 600;">{{ $sessionScore }}</div>
+                            <div>
+                                @if ($session->aiReflection()->exists())
+                                    <span style="display: inline-flex; align-items: center; gap: 4px; padding: 2px 6px; border-radius: 4px; background: var(--at-accent-12); color: var(--at-accent); border: 1px solid var(--at-accent-25); font-family: var(--at-font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase;">AI</span>
+                                @else
+                                    <span style="font-family: var(--at-font-mono); font-size: 9px; color: var(--at-muted); letter-spacing: 0.08em; text-transform: uppercase;">open</span>
+                                @endif
+                            </div>
+                        </div>
+                    @endforeach
+                @endif
+            </div>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/resources/weapons/view-weapon.blade.php
+++ b/resources/views/filament/resources/weapons/view-weapon.blade.php
@@ -130,8 +130,8 @@
                     @foreach ($recentSessions as $session)
                         @php
                             $sessionLabel = 'S-'.str_pad((string) $session->id, 4, '0', STR_PAD_LEFT);
-                            $sessionScore = (int) $session->shots()->sum('score');
-                            $sessionShots = (int) $session->sessionWeapons()->sum('rounds_fired');
+                            $sessionScore = (int) ($session->score_total ?? 0);
+                            $sessionShots = (int) ($session->rounds_total ?? 0);
                         @endphp
                         <div style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 12px 16px; border-bottom: 1px solid var(--at-line); align-items: center; font-size: 12px;">
                             <div style="font-family: var(--at-font-mono); color: var(--at-muted); font-size: 11px;">
@@ -142,7 +142,7 @@
                             <div style="font-family: var(--at-font-mono); color: var(--at-text);">{{ $sessionShots }}</div>
                             <div style="font-family: var(--at-font-mono); color: var(--at-accent); font-weight: 600;">{{ $sessionScore }}</div>
                             <div>
-                                @if ($session->aiReflection()->exists())
+                                @if ($session->ai_reflection_exists)
                                     <span style="display: inline-flex; align-items: center; gap: 4px; padding: 2px 6px; border-radius: 4px; background: var(--at-accent-12); color: var(--at-accent); border: 1px solid var(--at-accent-25); font-family: var(--at-font-mono); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase;">AI</span>
                                 @else
                                     <span style="font-family: var(--at-font-mono); font-size: 9px; color: var(--at-muted); letter-spacing: 0.08em; text-transform: uppercase;">open</span>

--- a/tests/Feature/RangeConsole/AiCoachScreenTest.php
+++ b/tests/Feature/RangeConsole/AiCoachScreenTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\CoachPage;
+use App\Models\Session;
+use App\Models\SessionWeapon;
+use App\Models\User;
+use App\Models\Weapon;
+use App\Support\Features\AimtrackFeatureToggle;
+use EslamRedaDiv\FilamentCopilot\Models\CopilotConversation;
+use Livewire\Livewire;
+
+beforeEach(function (): void {
+    $this->mock(AimtrackFeatureToggle::class, function ($mock): void {
+        $mock->shouldReceive('aiEnabled')->andReturn(true);
+        $mock->shouldReceive('aiDisabled')->andReturn(false);
+    });
+});
+
+it('renders the 3-column layout with rails and CTA for an empty user', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CoachPage::class)
+        ->assertOk()
+        ->assertSee('RECENTE GESPREKKEN')
+        ->assertSee('Stel een vraag aan je coach')
+        ->assertSee('VOORBEELDVRAGEN')
+        ->assertSee('CONTEXT IN GESPREK')
+        ->assertSee('PRIVACY')
+        ->assertSee('Open coach')
+        ->assertSee('Geen sessies of wapens gevonden')
+        ->assertSee('Nog geen gesprekken met de coach');
+});
+
+it('lists recent Copilot conversations on the left rail', function (): void {
+    $user = User::factory()->create();
+
+    foreach (range(1, 3) as $i) {
+        CopilotConversation::query()->create([
+            'participant_type' => $user->getMorphClass(),
+            'participant_id' => $user->getKey(),
+            'panel_id' => 'admin',
+            'title' => "Gesprek met onderwerp #{$i}",
+            'updated_at' => now()->subHours($i),
+            'created_at' => now()->subHours($i),
+        ]);
+    }
+
+    Livewire::actingAs($user)
+        ->test(CoachPage::class)
+        ->assertSee('Gesprek met onderwerp #1')
+        ->assertSee('Gesprek met onderwerp #2')
+        ->assertSee('Gesprek met onderwerp #3');
+});
+
+it('shows the last session and top weapon in the context rail when data exists', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create(['name' => 'Walther LP500', 'caliber' => '4.5 mm']);
+
+    foreach (range(1, 3) as $i) {
+        $session = Session::factory()->for($user)->create([
+            'date' => now()->subDays($i),
+            'range_name' => 'SV Diemen',
+        ]);
+        SessionWeapon::factory()->for($session)->for($weapon)->create();
+    }
+
+    Livewire::actingAs($user)
+        ->test(CoachPage::class)
+        ->assertSee('SV Diemen')
+        ->assertSee('Walther LP500')
+        ->assertSee('4.5 mm');
+});
+
+it('scopes conversations to the participant user', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    CopilotConversation::query()->create([
+        'participant_type' => $other->getMorphClass(),
+        'participant_id' => $other->getKey(),
+        'panel_id' => 'admin',
+        'title' => 'Geheim gesprek van iemand anders',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(CoachPage::class)
+        ->assertDontSee('Geheim gesprek van iemand anders');
+});

--- a/tests/Feature/RangeConsole/ListSessionsScreenTest.php
+++ b/tests/Feature/RangeConsole/ListSessionsScreenTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\SessionResource\Pages\ListSessions;
+use App\Models\AiReflection;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('renders page header and KPI labels for an empty user', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(ListSessions::class)
+        ->assertOk()
+        ->assertSee('Sessies')
+        ->assertSee('Sessies / mnd')
+        ->assertSee('Schoten totaal')
+        ->assertSee('Beste serie')
+        ->assertSee('AI-reflecties')
+        ->assertSee('Laatste sessie')
+        ->assertSee('Trend');
+});
+
+it('shows a friendly fallback when user has no sessions yet', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(ListSessions::class)
+        ->assertSee('Nog geen sessies gelogd');
+});
+
+it('renders KPI values from user data', function (): void {
+    $user = User::factory()->create();
+
+    $session = Session::factory()->for($user)->create(['date' => now()->startOfMonth()->addDay()]);
+
+    foreach (range(0, 9) as $i) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => 0,
+            'shot_index' => $i,
+            'ring' => 10,
+            'score' => 10,
+        ]);
+    }
+
+    AiReflection::factory()->for($session)->create([
+        'summary' => 'Sterke openingsserie met 5 tienen.',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ListSessions::class)
+        ->assertSee('Sterke openingsserie')
+        ->assertSee('S-'.str_pad((string) $session->id, 4, '0', STR_PAD_LEFT));
+});
+
+it('renders the AI status badge for sessions with a reflection', function (): void {
+    $user = User::factory()->create();
+    $sessionWithAi = Session::factory()->for($user)->create();
+    $sessionWithout = Session::factory()->for($user)->create();
+    AiReflection::factory()->for($sessionWithAi)->create();
+
+    Livewire::actingAs($user)
+        ->test(ListSessions::class)
+        ->assertCanSeeTableRecords([$sessionWithAi, $sessionWithout]);
+});
+
+it('does not leak sessions from other users into the KPIs', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    Session::factory()->for($other)->count(5)->create(['date' => now()->startOfMonth()->addDay()]);
+
+    Livewire::actingAs($user)
+        ->test(ListSessions::class)
+        ->assertSee('Sessies / mnd')
+        ->assertDontSee('5 in wachtrij');
+});

--- a/tests/Feature/RangeConsole/NewSessionWizardTest.php
+++ b/tests/Feature/RangeConsole/NewSessionWizardTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\SessionResource;
+use App\Filament\Resources\SessionResource\Pages\CreateSession;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Weapon;
+use Livewire\Livewire;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+/**
+ * Complete sessionWeapons repeater-rij. In de browser vult "Regel toevoegen"
+ * de veld-defaults (rounds_fired/flyers_count = 0); de fillForm test-helper
+ * doet dat niet, dus leveren we volledige data aan.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function wizardWeaponRow(Weapon $weapon, int $rounds = 60): array
+{
+    return [
+        [
+            'weapon_id' => $weapon->id,
+            'rounds_fired' => $rounds,
+            'flyers_count' => 0,
+        ],
+    ];
+}
+
+it('renders the 4-step wizard with all step labels', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->assertOk()
+        ->assertSee('Wapen')
+        ->assertSee('Sessie')
+        ->assertSee('Schoten')
+        ->assertSee('Notities');
+});
+
+it('renders the Schoten step preview with readout, numpad and AI tip', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->assertSee('VOORTGANG')
+        ->assertSee('LOPENDE SCORE')
+        ->assertSee('GEM. PER SCHOT')
+        ->assertSee('OPNAME START NA OPSLAAN')
+        ->assertSee('10.9')
+        ->assertSee('OF VUL HANDMATIG IN')
+        ->assertSee('Bevestig')
+        ->assertSee('AI TIJDENS SESSIE')
+        ->assertSee('schotenbord');
+});
+
+it('renders the Schoten step context rail with SESSIE, WAPEN and OPTIES', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->assertSee('SESSIE')
+        ->assertSee('WAPEN')
+        ->assertSee('OPTIES')
+        ->assertSee('AI-reflectie')
+        ->assertSee('Decimaal-notatie');
+});
+
+it('creates a session with weapon row through the wizard', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->fillForm([
+            'date' => '2026-05-20',
+            'sessionWeapons' => wizardWeaponRow($weapon),
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Session::class, [
+        'user_id' => $user->id,
+        'date' => '2026-05-20 00:00:00',
+    ]);
+
+    $session = Session::query()->where('user_id', $user->id)->latest('id')->first();
+
+    expect($session->sessionWeapons()->count())->toBe(1);
+    expect($session->sessionWeapons()->first()->weapon_id)->toBe($weapon->id);
+});
+
+it('redirects to the shot board after creating the session', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->fillForm([
+            'date' => '2026-05-21',
+            'sessionWeapons' => wizardWeaponRow($weapon, 10),
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $session = Session::query()->where('user_id', $user->id)->latest('id')->first();
+
+    expect(SessionResource::getUrl('shots', ['record' => $session]))->toContain('/shots');
+});
+
+it('validates that a date is required before completing the wizard', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->fillForm([
+            'date' => null,
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['date' => 'required']);
+});
+
+it('rejects a weapon row without a weapon_id', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->fillForm([
+            'date' => '2026-05-20',
+            'sessionWeapons' => [
+                ['rounds_fired' => 10, 'flyers_count' => 0],
+            ],
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasFormErrors();
+
+    expect(Session::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+it('rejects a weapon row with distance beyond the allowed maximum', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->fillForm([
+            'date' => '2026-05-20',
+            'sessionWeapons' => [
+                ['weapon_id' => $weapon->id, 'rounds_fired' => 10, 'flyers_count' => 0, 'distance_m' => 9999],
+            ],
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasFormErrors();
+
+    expect(Session::query()->where('user_id', $user->id)->count())->toBe(0);
+});
+
+it('exposes the Bijlagen attachment repeater on the Notities step', function (): void {
+    // De FileUpload-metadata-capture (afterStateUpdated) is bestaande logica,
+    // verbatim hergebruikt uit SessionResource::form(). Hier borgen we de
+    // nieuwe integratie: de wizard Notities-stap stelt de attachments-repeater
+    // beschikbaar. Een echte temp-upload door een geneste repeater simuleren is
+    // bewust buiten scope (bros + dekt bestaande logica).
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->assertOk()
+        ->assertSee('Bijlagen')
+        ->assertSee('Bijlage toevoegen');
+});
+
+it('creates a session with notes through the wizard Notities step', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->fillForm([
+            'date' => '2026-05-22',
+            'sessionWeapons' => wizardWeaponRow($weapon, 10),
+            'notes_raw' => 'Rustige sessie, nieuwe handgreep getest.',
+            'manual_reflection' => 'Volgende keer kortere pauzes.',
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Session::class, [
+        'user_id' => $user->id,
+        'notes_raw' => 'Rustige sessie, nieuwe handgreep getest.',
+        'manual_reflection' => 'Volgende keer kortere pauzes.',
+    ]);
+});

--- a/tests/Feature/RangeConsole/ViewSessionScreenTest.php
+++ b/tests/Feature/RangeConsole/ViewSessionScreenTest.php
@@ -47,6 +47,32 @@ it('renders the session-detail layout with header, stats and shot strip', functi
         ->assertSee('Nieuwe handgreep gebruikt');
 });
 
+it('highlights the concentration-dip series amber on the shot strip', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create();
+
+    // 3 series: serie 1 & 3 sterk (10), serie 2 (schot 11–20) zwak (7) → dip.
+    foreach (range(0, 29) as $i) {
+        $turn = intdiv($i, 10);
+        $value = $turn === 1 ? 7 : 10;
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => $turn,
+            'shot_index' => $i % 10,
+            'ring' => $value,
+            'score' => $value,
+            'x_normalized' => 0.5,
+            'y_normalized' => 0.5,
+        ]);
+    }
+
+    expect((new App\Services\SessionStatsService($session))->dipRange())->toBe([10, 19]);
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $session->id])
+        ->assertOk()
+        ->assertSee('var(--at-warn)');
+});
+
 it('falls back to a friendly empty message when the session has no shots', function (): void {
     $user = User::factory()->create();
     $session = Session::factory()->for($user)->create();

--- a/tests/Feature/RangeConsole/ViewSessionScreenTest.php
+++ b/tests/Feature/RangeConsole/ViewSessionScreenTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\SessionResource\Pages\ViewSession;
+use App\Models\AiReflection;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use Livewire\Livewire;
+
+function seedShots(Session $session, int $count, int $ring = 10, int $score = 10): void
+{
+    foreach (range(0, $count - 1) as $i) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => intdiv($i, 10),
+            'shot_index' => $i % 10,
+            'ring' => $ring,
+            'score' => $score,
+            'x_normalized' => 0.5,
+            'y_normalized' => 0.5,
+        ]);
+    }
+}
+
+it('renders the session-detail layout with header, stats and shot strip', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create([
+        'date' => '2026-05-08',
+        'manual_reflection' => 'Nieuwe handgreep gebruikt vanaf serie 3.',
+    ]);
+    seedShots($session, 20, ring: 10, score: 10);
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $session->id])
+        ->assertOk()
+        ->assertSee('SESSIE · S-'.str_pad((string) $session->id, 4, '0', STR_PAD_LEFT))
+        ->assertSee('EINDSCORE')
+        ->assertSee('Beste schot')
+        ->assertSee('Tienen')
+        ->assertSee('Negens')
+        ->assertSee('Groep')
+        ->assertSee('Gem. cadans')
+        ->assertSee('Schot-voor-schot')
+        ->assertSee('Hit-patroon')
+        ->assertSee('Series')
+        ->assertSee('Nieuwe handgreep gebruikt');
+});
+
+it('falls back to a friendly empty message when the session has no shots', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create();
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $session->id])
+        ->assertOk()
+        ->assertSee('Nog geen schoten gelogd');
+});
+
+it('renders the WM-4 OK stamp only when the session has an AI reflection', function (): void {
+    $user = User::factory()->create();
+
+    $sessionWithoutRefl = Session::factory()->for($user)->create();
+    seedShots($sessionWithoutRefl, 10);
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $sessionWithoutRefl->id])
+        ->assertDontSee('WM-4 OK');
+
+    $sessionWithRefl = Session::factory()->for($user)->create();
+    seedShots($sessionWithRefl, 10);
+    AiReflection::factory()->for($sessionWithRefl)->create([
+        'summary' => 'Sterke openingsserie.',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $sessionWithRefl->id])
+        ->assertSee('WM-4 OK')
+        ->assertSee('Sterke openingsserie');
+});
+
+it('omits the eigen-notitie panel when the session has no manual reflection', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create(['manual_reflection' => null]);
+    seedShots($session, 5);
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $session->id])
+        ->assertDontSee('Eigen notitie');
+});
+
+it('refuses to render sessions owned by another user via the eloquent scope', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $foreignSession = Session::factory()->for($other)->create();
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $foreignSession->id]);
+})->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);

--- a/tests/Feature/RangeConsole/ViewWeaponScreenTest.php
+++ b/tests/Feature/RangeConsole/ViewWeaponScreenTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\WeaponResource\Pages\ViewWeapon;
+use App\Models\AiReflection;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\SessionWeapon;
+use App\Models\User;
+use App\Models\Weapon;
+use Livewire\Livewire;
+
+function weaponShots(Session $session, int $count, int $ring = 10, int $score = 10): void
+{
+    foreach (range(0, $count - 1) as $i) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => intdiv($i, 10),
+            'shot_index' => $i % 10,
+            'ring' => $ring,
+            'score' => $score,
+        ]);
+    }
+}
+
+it('renders weapon-detail ID card, KPIs and trend headers for a fresh weapon', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create([
+        'name' => 'Walther LP500',
+        'caliber' => '4.5 mm',
+        'serial_number' => 'LP500-4421',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ViewWeapon::class, ['record' => $weapon->id])
+        ->assertOk()
+        ->assertSee('Walther LP500')
+        ->assertSee('LP500-4421')
+        ->assertSee('KALIBRATIE')
+        ->assertSee('KORREL')
+        ->assertSee('Sessies')
+        ->assertSee('Schoten totaal')
+        ->assertSee('Gem. score')
+        ->assertSee('Score-trend')
+        ->assertSee('Sessies met dit wapen')
+        ->assertSee('Nog geen sessies met dit wapen');
+});
+
+it('shows the kalibratie values when present, dashes when null', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create([
+        'korrel_correction' => '+2',
+        'vizier_correction' => '−1 R',
+        'trigger_weight_g' => 520,
+        'grip_size' => 'M · v2',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ViewWeapon::class, ['record' => $weapon->id])
+        ->assertSee('+2')
+        ->assertSee('−1 R')
+        ->assertSee('520 g')
+        ->assertSee('M · v2');
+
+    $empty = Weapon::factory()->for($user)->create([
+        'korrel_correction' => null,
+        'vizier_correction' => null,
+        'trigger_weight_g' => null,
+        'grip_size' => null,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ViewWeapon::class, ['record' => $empty->id])
+        ->assertSee('—');
+});
+
+it('renders KPIs and the sessies-tabel when the weapon has sessions', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    foreach (range(1, 3) as $i) {
+        $session = Session::factory()->for($user)->create([
+            'date' => now()->subDays($i * 2),
+            'range_name' => 'SV Diemen',
+        ]);
+        SessionWeapon::factory()->for($session)->for($weapon)->create(['rounds_fired' => 10]);
+        weaponShots($session, 10, 10, 10);
+    }
+
+    $latest = Session::query()->where('user_id', $user->id)->orderByDesc('date')->first();
+    AiReflection::factory()->for($latest)->create();
+
+    Livewire::actingAs($user)
+        ->test(ViewWeapon::class, ['record' => $weapon->id])
+        ->assertSee('SV Diemen')
+        ->assertSee('AI')
+        ->assertSeeText('open');
+});
+
+it('refuses to render a weapon owned by another user', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+    $foreign = Weapon::factory()->for($other)->create();
+
+    Livewire::actingAs($user)
+        ->test(ViewWeapon::class, ['record' => $foreign->id]);
+})->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);

--- a/tests/Unit/Aimtrack/AiReflectionCardComponentTest.php
+++ b/tests/Unit/Aimtrack/AiReflectionCardComponentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('ai-reflection-card wraps content in bracket-frame with accent corners', function (): void {
+    $html = Blade::render('<x-aimtrack.ai-reflection-card />');
+
+    expect($html)
+        ->toContain('AI-reflectie')
+        ->toContain('var(--at-accent)');
+
+    expect(substr_count($html, 'aria-hidden="true"'))->toBe(4);
+});
+
+test('ai-reflection-card renders summary, sterk, verbeter, volgende rows', function (): void {
+    $reflection = (object) [
+        'summary' => 'Sterke openingsserie met 5× tien op rij.',
+        'positives' => ['Openingsritme', 'Polsstabiliteit'],
+        'improvements' => ['Adempauze rond schot 30'],
+        'next_focus' => '2× 10 min droogoefenen',
+    ];
+    $html = Blade::render('<x-aimtrack.ai-reflection-card :reflection="$reflection" session-id="S-0247" />', ['reflection' => $reflection]);
+
+    expect($html)
+        ->toContain('S-0247')
+        ->toContain('Sterke openingsserie')
+        ->toContain('STERK')
+        ->toContain('Openingsritme · Polsstabiliteit')
+        ->toContain('VERBETER')
+        ->toContain('Adempauze rond schot 30')
+        ->toContain('VOLGENDE')
+        ->toContain('2× 10 min droogoefenen');
+});
+
+test('ai-reflection-card shows dash for missing reflection fields', function (): void {
+    $reflection = (object) ['summary' => null, 'positives' => null, 'improvements' => null, 'next_focus' => null];
+    $html = Blade::render('<x-aimtrack.ai-reflection-card :reflection="$reflection" />', ['reflection' => $reflection]);
+
+    expect(substr_count($html, '—'))->toBeGreaterThanOrEqual(4);
+});
+
+test('ai-reflection-card omits sterk/verbeter/volgende grid in compact mode', function (): void {
+    $reflection = (object) ['summary' => 'Compact view', 'positives' => 'x', 'improvements' => 'y', 'next_focus' => 'z'];
+    $html = Blade::render('<x-aimtrack.ai-reflection-card :reflection="$reflection" :compact="true" />', ['reflection' => $reflection]);
+
+    expect($html)
+        ->toContain('Compact view')
+        ->not->toContain('STERK')
+        ->not->toContain('VERBETER');
+});
+
+test('ai-reflection-card renders actions slot when provided', function (): void {
+    $html = Blade::render('<x-aimtrack.ai-reflection-card><x-slot:actions><button>Vraag coach</button></x-slot:actions></x-aimtrack.ai-reflection-card>');
+
+    expect($html)->toContain('<button>Vraag coach</button>');
+});

--- a/tests/Unit/Aimtrack/PageHeaderComponentTest.php
+++ b/tests/Unit/Aimtrack/PageHeaderComponentTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('page-header renders title and subtitle with default reticle watermark', function (): void {
+    $html = Blade::render('<x-aimtrack.page-header title="Sessies" subtitle="247 totaal" />');
+
+    expect($html)
+        ->toContain('>Sessies</h1>')
+        ->toContain('>247 totaal</p>')
+        ->toContain('position: absolute')
+        ->toContain('var(--at-accent)');
+});
+
+test('page-header can hide the reticle watermark', function (): void {
+    $html = Blade::render('<x-aimtrack.page-header title="x" :show-reticle="false" />');
+
+    expect($html)
+        ->toContain('>x</h1>')
+        ->not->toContain('aria-hidden="true"');
+});
+
+test('page-header honours reticle size, opacity and position props', function (): void {
+    $html = Blade::render('<x-aimtrack.page-header title="x" reticle-size="220" reticle-opacity="0.12" reticle-top="-50" reticle-right="-10" />');
+
+    expect($html)
+        ->toContain('top: -50px')
+        ->toContain('right: -10px')
+        ->toContain('opacity: 0.12');
+});
+
+test('page-header renders actions slot when provided', function (): void {
+    $html = Blade::render('<x-aimtrack.page-header title="x"><x-slot:actions><button>Filter</button></x-slot:actions></x-aimtrack.page-header>');
+
+    expect($html)
+        ->toContain('<button>Filter</button>')
+        ->toContain('flex-shrink: 0');
+});
+
+test('page-header omits subtitle paragraph when subtitle is null', function (): void {
+    $html = Blade::render('<x-aimtrack.page-header title="x" />');
+
+    expect(substr_count($html, '<p '))->toBe(0);
+});

--- a/tests/Unit/Aimtrack/SeriesCardComponentTest.php
+++ b/tests/Unit/Aimtrack/SeriesCardComponentTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('series-card renders one cell per serie with score', function (): void {
+    $series = [91, 88, 95, 87, 90, 96];
+    $html = Blade::render('<x-aimtrack.series-card :series="$series" />', ['series' => $series]);
+
+    expect($html)
+        ->toContain('SERIE 1')
+        ->toContain('SERIE 6')
+        ->toContain('>91.0<')
+        ->toContain('>96.0<')
+        ->toContain('6 × 10 schoten');
+});
+
+test('series-card uses accent colour for series at or above good threshold', function (): void {
+    $series = [91, 95];
+    $html = Blade::render('<x-aimtrack.series-card :series="$series" good-threshold="95" />', ['series' => $series]);
+
+    expect($html)->toContain('var(--at-accent)');
+});
+
+test('series-card shows dash when series is empty', function (): void {
+    $html = Blade::render('<x-aimtrack.series-card :series="[]" />');
+
+    expect($html)
+        ->toContain('—')
+        ->not->toContain('SERIE 1');
+});
+
+test('series-card honours custom shots-per-serie label', function (): void {
+    $series = [49, 50];
+    $html = Blade::render('<x-aimtrack.series-card :series="$series" :shots-per-serie="5" />', ['series' => $series]);
+
+    expect($html)->toContain('2 × 5 schoten');
+});
+
+test('series-card computes default sub line as total of series', function (): void {
+    $series = [90, 91, 89];
+    $html = Blade::render('<x-aimtrack.series-card :series="$series" />', ['series' => $series]);
+
+    expect($html)->toContain('tot 270.0');
+});

--- a/tests/Unit/Aimtrack/ShotStripComponentTest.php
+++ b/tests/Unit/Aimtrack/ShotStripComponentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('shot-strip renders bars for given scores', function (): void {
+    $shots = [10, 9, 8, 10];
+    $html = Blade::render('<x-aimtrack.shot-strip :shots="$shots" :total-slots="4" :show-legend="false" />', ['shots' => $shots]);
+
+    expect(substr_count($html, '<div title='))->toBe(4);
+});
+
+test('shot-strip pads with placeholder slots up to totalSlots', function (): void {
+    $shots = [10, 9];
+    $html = Blade::render('<x-aimtrack.shot-strip :shots="$shots" :total-slots="6" :show-legend="false" />', ['shots' => $shots]);
+
+    expect(substr_count($html, '<div title='))->toBe(2);
+    expect($html)->toContain('var(--at-line)');
+});
+
+test('shot-strip highlights tens with accent', function (): void {
+    $shots = [10, 8, 10];
+    $html = Blade::render('<x-aimtrack.shot-strip :shots="$shots" :total-slots="3" :show-legend="false" />', ['shots' => $shots]);
+
+    expect(substr_count($html, 'background: var(--at-accent)'))->toBeGreaterThanOrEqual(2);
+});
+
+test('shot-strip marks dip range with warn colour', function (): void {
+    $shots = [10, 9, 7, 7, 8];
+    $html = Blade::render('<x-aimtrack.shot-strip :shots="$shots" :total-slots="5" :dip-range="[2, 3]" :show-legend="false" />', ['shots' => $shots]);
+
+    expect($html)
+        ->toContain('var(--at-warn)');
+});
+
+test('shot-strip legend renders by default and can be hidden', function (): void {
+    $shots = [10];
+    $on = Blade::render('<x-aimtrack.shot-strip :shots="$shots" />', ['shots' => $shots]);
+    $off = Blade::render('<x-aimtrack.shot-strip :shots="$shots" :show-legend="false" />', ['shots' => $shots]);
+
+    expect($on)->toContain('10+ ringen');
+    expect($off)->not->toContain('10+ ringen');
+});
+
+test('shot-strip accepts shots as array of associative entries with score key', function (): void {
+    $shots = [['score' => 10], ['score' => 9]];
+    $html = Blade::render('<x-aimtrack.shot-strip :shots="$shots" :total-slots="2" :show-legend="false" />', ['shots' => $shots]);
+
+    expect(substr_count($html, '<div title='))->toBe(2);
+});

--- a/tests/Unit/Aimtrack/SparklineComponentTest.php
+++ b/tests/Unit/Aimtrack/SparklineComponentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('sparkline renders polyline when given 2+ data points', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="$data" />', ['data' => [10, 15, 12, 18, 16]]);
+
+    expect($html)
+        ->toContain('<svg')
+        ->toContain('<polyline')
+        ->toContain('var(--at-accent)');
+});
+
+test('sparkline shows a dashed empty-state line when fewer than 2 points', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[]" />');
+
+    expect($html)
+        ->toContain('<line')
+        ->toContain('var(--at-line)')
+        ->toContain('stroke-dasharray')
+        ->not->toContain('<polyline');
+});
+
+test('sparkline honours width and height props', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2]" width="500" height="100" />');
+
+    expect($html)
+        ->toContain('width="500"')
+        ->toContain('height="100"')
+        ->toContain('viewBox="0 0 500 100"');
+});
+
+test('sparkline renders area fill when fill prop is true', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" :fill="true" />');
+
+    expect($html)
+        ->toContain('<path')
+        ->toContain('opacity="0.12"');
+});
+
+test('sparkline omits area fill by default', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" />');
+
+    expect($html)->not->toContain('<path');
+});

--- a/tests/Unit/Aimtrack/StatCardComponentTest.php
+++ b/tests/Unit/Aimtrack/StatCardComponentTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('stat-card renders label and value with text colour by default', function (): void {
+    $html = Blade::render('<x-aimtrack.stat-card label="SESSIES" value="14" />');
+
+    expect($html)
+        ->toContain('SESSIES')
+        ->toContain('>14<')
+        ->toContain('var(--at-text)')
+        ->toContain('var(--at-panel)');
+});
+
+test('stat-card renders sub line with muted tone by default', function (): void {
+    $html = Blade::render('<x-aimtrack.stat-card label="x" value="1" sub="laatste 30d" />');
+
+    expect($html)
+        ->toContain('laatste 30d')
+        ->toContain('var(--at-muted)');
+});
+
+test('stat-card honours accent value-tone and sub-tone', function (): void {
+    $html = Blade::render('<x-aimtrack.stat-card label="x" value="9" sub="+3" value-tone="accent" sub-tone="accent" />');
+
+    expect(substr_count($html, 'var(--at-accent)'))->toBeGreaterThanOrEqual(2);
+});
+
+test('stat-card omits sub element when sub prop is null', function (): void {
+    $html = Blade::render('<x-aimtrack.stat-card label="x" value="9" />');
+
+    expect(substr_count($html, '<div'))->toBe(3);
+});
+
+test('stat-card supports warn tone for negative deltas', function (): void {
+    $html = Blade::render('<x-aimtrack.stat-card label="x" value="9" sub="-3" sub-tone="warn" />');
+
+    expect($html)->toContain('var(--at-warn)');
+});

--- a/tests/Unit/Aimtrack/TargetRingsComponentTest.php
+++ b/tests/Unit/Aimtrack/TargetRingsComponentTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade;
+
+test('target-rings renders 10 concentric rings by default', function (): void {
+    $html = Blade::render('<x-aimtrack.target-rings />');
+
+    expect($html)
+        ->toContain('<svg')
+        ->toContain('viewBox="0 0 200 200"')
+        ->toContain('aria-label="Hit-patroon"');
+
+    expect(substr_count($html, '<circle'))->toBe(10);
+});
+
+test('target-rings honours size prop', function (): void {
+    $html = Blade::render('<x-aimtrack.target-rings size="320" />');
+
+    expect($html)
+        ->toContain('width="320"')
+        ->toContain('viewBox="0 0 320 320"');
+});
+
+test('target-rings renders score labels when scoreLabels is true', function (): void {
+    $html = Blade::render('<x-aimtrack.target-rings score-labels="true" />');
+
+    expect(substr_count($html, '<text'))->toBe(10);
+});
+
+test('target-rings omits score labels by default', function (): void {
+    $html = Blade::render('<x-aimtrack.target-rings />');
+
+    expect($html)->not->toContain('<text');
+});
+
+test('target-rings plots hit dots when hits array is provided', function (): void {
+    $hits = [
+        ['x' => 0.1, 'y' => -0.2, 'r' => 9],
+        ['x' => 0.0, 'y' => 0.0, 'r' => 10],
+    ];
+    $html = Blade::render('<x-aimtrack.target-rings :hits="$hits" />', ['hits' => $hits]);
+
+    expect(substr_count($html, '<circle'))->toBe(12);
+});
+
+test('target-rings honours custom ring count', function (): void {
+    $html = Blade::render('<x-aimtrack.target-rings rings="5" />');
+
+    expect(substr_count($html, '<circle'))->toBe(5);
+});

--- a/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
+++ b/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\AiReflection;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use App\Services\RangeConsoleSummaryService;
+
+/**
+ * @param  array<string, mixed>  $overrides
+ */
+function summaryShotsFor(Session $session, int $count, array $overrides = []): void
+{
+    foreach (range(0, $count - 1) as $i) {
+        SessionShot::factory()->for($session)->create(array_merge([
+            'turn_index' => intdiv($i, 10),
+            'shot_index' => $i % 10,
+        ], $overrides));
+    }
+}
+
+it('returns zero KPIs for a user with no sessions', function (): void {
+    $service = new RangeConsoleSummaryService(User::factory()->create());
+
+    expect($service->sessionsThisMonth())->toBe(0);
+    expect($service->sessionsLastMonth())->toBe(0);
+    expect($service->shotsLast30d())->toBe(0);
+    expect($service->bestSeriesScore())->toBeNull();
+    expect($service->aiReflectionCount())->toBe(0);
+    expect($service->pendingAiReflections())->toBe(0);
+    expect($service->lastSession())->toBeNull();
+    expect($service->latestReflection())->toBeNull();
+    expect($service->trend30d())->toBe([]);
+});
+
+it('counts sessions in current and previous month separately', function (): void {
+    $user = User::factory()->create();
+
+    Session::factory()->for($user)->count(3)->create(['date' => now()->startOfMonth()->addDays(2)]);
+    Session::factory()->for($user)->count(2)->create(['date' => now()->subMonthNoOverflow()->startOfMonth()->addDays(5)]);
+
+    $service = new RangeConsoleSummaryService($user);
+
+    expect($service->sessionsThisMonth())->toBe(3);
+    expect($service->sessionsLastMonth())->toBe(2);
+    expect($service->sessionsThisMonthDelta())->toBe(1);
+});
+
+it('scopes shotsLast30d to the user and last 30 days', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    $recent = Session::factory()->for($user)->create(['date' => now()->subDays(3)]);
+    $stale = Session::factory()->for($user)->create(['date' => now()->subDays(50)]);
+    $otherSession = Session::factory()->for($other)->create(['date' => now()->subDays(1)]);
+
+    summaryShotsFor($recent, 6);
+    summaryShotsFor($stale, 5);
+    summaryShotsFor($otherSession, 8);
+
+    expect((new RangeConsoleSummaryService($user))->shotsLast30d())->toBe(6);
+});
+
+it('picks the best 10-shot serie across all user sessions', function (): void {
+    $user = User::factory()->create();
+
+    $sessionA = Session::factory()->for($user)->create();
+    summaryShotsFor($sessionA, 10, ['ring' => 9, 'score' => 9]);
+
+    $sessionB = Session::factory()->for($user)->create();
+    summaryShotsFor($sessionB, 10, ['ring' => 10, 'score' => 10]);
+
+    $sessionC = Session::factory()->for($user)->create();
+    summaryShotsFor($sessionC, 7, ['ring' => 10, 'score' => 10]);
+
+    expect((new RangeConsoleSummaryService($user))->bestSeriesScore())->toBe(100);
+});
+
+it('counts AI reflections only for the user own sessions', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    $mine = Session::factory()->for($user)->count(2)->create();
+    $theirs = Session::factory()->for($other)->create();
+
+    foreach ($mine as $session) {
+        AiReflection::factory()->for($session)->create();
+    }
+    AiReflection::factory()->for($theirs)->create();
+
+    expect((new RangeConsoleSummaryService($user))->aiReflectionCount())->toBe(2);
+});
+
+it('counts pending AI reflections as recent sessions without reflection', function (): void {
+    $user = User::factory()->create();
+
+    $recentWithoutReflection = Session::factory()->for($user)->create(['date' => now()->subDays(5)]);
+    $recentWithReflection = Session::factory()->for($user)->create(['date' => now()->subDays(3)]);
+    AiReflection::factory()->for($recentWithReflection)->create();
+
+    $staleWithoutReflection = Session::factory()->for($user)->create(['date' => now()->subDays(40)]);
+
+    expect((new RangeConsoleSummaryService($user))->pendingAiReflections())->toBe(1);
+});
+
+it('returns lastSession as the most recent by date', function (): void {
+    $user = User::factory()->create();
+
+    Session::factory()->for($user)->create(['date' => now()->subDays(10)]);
+    $newest = Session::factory()->for($user)->create(['date' => now()->subDays(2)]);
+    Session::factory()->for($user)->create(['date' => now()->subDays(5)]);
+
+    expect((new RangeConsoleSummaryService($user))->lastSession()?->id)->toBe($newest->id);
+});
+
+it('returns trend30d with sessions only from the last 30 days', function (): void {
+    $user = User::factory()->create();
+
+    $recent = Session::factory()->for($user)->create(['date' => now()->subDays(7)]);
+    $stale = Session::factory()->for($user)->create(['date' => now()->subDays(60)]);
+
+    summaryShotsFor($recent, 5, ['ring' => 10, 'score' => 10]);
+    summaryShotsFor($stale, 5, ['ring' => 10, 'score' => 10]);
+
+    $trend = (new RangeConsoleSummaryService($user))->trend30d();
+
+    expect($trend)->toHaveCount(1);
+    expect($trend)->toHaveKey($recent->date->toDateString());
+    expect($trend[$recent->date->toDateString()])->toBe(50);
+});

--- a/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
+++ b/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
@@ -25,7 +25,7 @@ it('returns zero KPIs for a user with no sessions', function (): void {
     $service = new RangeConsoleSummaryService(User::factory()->create());
 
     expect($service->sessionsThisMonth())->toBe(0);
-    expect($service->sessionsLastMonth())->toBe(0);
+    expect($service->sessionsThisMonthDelta())->toBe(0);
     expect($service->shotsLast30d())->toBe(0);
     expect($service->bestSeriesScore())->toBeNull();
     expect($service->aiReflectionCount())->toBe(0);
@@ -44,7 +44,8 @@ it('counts sessions in current and previous month separately', function (): void
     $service = new RangeConsoleSummaryService($user);
 
     expect($service->sessionsThisMonth())->toBe(3);
-    expect($service->sessionsLastMonth())->toBe(2);
+    // sessionsLastMonth() is een implementatiedetail van de delta (privé);
+    // delta = dezeMaand - vorigeMaand = 3 - 2 = 1 borgt beide.
     expect($service->sessionsThisMonthDelta())->toBe(1);
 });
 

--- a/tests/Unit/Services/SessionStatsServiceTest.php
+++ b/tests/Unit/Services/SessionStatsServiceTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use App\Services\SessionStatsService;
+
+/**
+ * Helper: seed N shots with unique (turn_index, shot_index) for a session.
+ * Overrides can include ring/score/x_normalized/y_normalized/etc.
+ *
+ * @param  array<string, mixed>  $overrides
+ */
+function statsShotsFor(Session $session, int $count, array $overrides = []): void
+{
+    foreach (range(0, $count - 1) as $i) {
+        SessionShot::factory()->for($session)->create(array_merge([
+            'turn_index' => intdiv($i, 10),
+            'shot_index' => $i % 10,
+        ], $overrides));
+    }
+}
+
+it('returns 0 for tienen/negens/totalScore when session has no shots', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    $service = new SessionStatsService($session);
+
+    expect($service->totalShots())->toBe(0);
+    expect($service->tienen())->toBe(0);
+    expect($service->negens())->toBe(0);
+    expect($service->totalScore())->toBe(0);
+    expect($service->bestShot())->toBeNull();
+    expect($service->scores())->toBe([]);
+});
+
+it('counts tienen and negens by ring not score', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+
+    SessionShot::factory()->for($session)->create(['ring' => 10, 'score' => 10]);
+    SessionShot::factory()->for($session)->create(['ring' => 10, 'score' => 10]);
+    SessionShot::factory()->for($session)->create(['ring' => 9, 'score' => 9]);
+    SessionShot::factory()->for($session)->create(['ring' => 8, 'score' => 8]);
+
+    $service = new SessionStatsService($session);
+
+    expect($service->tienen())->toBe(2);
+    expect($service->negens())->toBe(1);
+    expect($service->totalShots())->toBe(4);
+    expect($service->totalScore())->toBe(37);
+    expect($service->bestShot())->toBe(10);
+});
+
+it('chunks series scores into groups of perSerie', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+
+    foreach (range(1, 20) as $i) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => intdiv($i - 1, 10),
+            'shot_index' => ($i - 1) % 10,
+            'ring' => 10,
+            'score' => 10,
+        ]);
+    }
+
+    $service = new SessionStatsService($session);
+
+    expect($service->seriesScores(10))->toBe([100, 100]);
+    expect($service->shotsPerSerie())->toBe(10);
+});
+
+it('drops a partial last series from seriesScores', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+
+    foreach (range(1, 13) as $i) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => intdiv($i - 1, 10),
+            'shot_index' => ($i - 1) % 10,
+            'ring' => 9,
+            'score' => 9,
+        ]);
+    }
+
+    $service = new SessionStatsService($session);
+
+    expect($service->seriesScores(10))->toBe([90]);
+});
+
+it('detects the dip range as the lowest-scoring serie', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+
+    foreach (range(0, 29) as $i) {
+        $turn = intdiv($i, 10);
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => $turn,
+            'shot_index' => $i % 10,
+            'ring' => $turn === 1 ? 7 : 10,
+            'score' => $turn === 1 ? 7 : 10,
+        ]);
+    }
+
+    $service = new SessionStatsService($session);
+
+    expect($service->dipRange())->toBe([10, 19]);
+});
+
+it('returns null dipRange when fewer than 2 complete series', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    statsShotsFor($session, 8, ['ring' => 10, 'score' => 10]);
+
+    expect((new SessionStatsService($session))->dipRange())->toBeNull();
+});
+
+it('returns null groupMm when fewer than 2 shots', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    SessionShot::factory()->for($session)->create([
+        'turn_index' => 0,
+        'shot_index' => 0,
+        'x_normalized' => 0.1,
+        'y_normalized' => 0.0,
+    ]);
+
+    expect((new SessionStatsService($session))->groupMm())->toBeNull();
+});
+
+it('returns positive groupMm in millimetres for multiple shots', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    foreach ([[0.0, 0.0], [0.05, -0.05], [-0.05, 0.05]] as $i => [$x, $y]) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => 0,
+            'shot_index' => $i,
+            'x_normalized' => $x,
+            'y_normalized' => $y,
+        ]);
+    }
+
+    $group = (new SessionStatsService($session))->groupMm();
+
+    expect($group)->toBeFloat()->and($group)->toBeGreaterThan(0.0);
+});
+
+it('returns null avgCadansSec when shots have no time spread', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    statsShotsFor($session, 5);
+
+    // Force all shots to share created_at so deltas are zero.
+    $session->shots()->update(['created_at' => now()]);
+
+    expect((new SessionStatsService($session))->avgCadansSec())->toBeNull();
+});
+
+it('caches the loaded shots collection across method calls', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    statsShotsFor($session, 3, ['ring' => 10, 'score' => 10]);
+
+    $service = new SessionStatsService($session);
+
+    $service->totalShots();
+
+    \DB::enableQueryLog();
+    $service->tienen();
+    $service->negens();
+    $service->totalScore();
+    $queries = collect(\DB::getQueryLog())->filter(fn (array $q): bool => str_contains($q['query'], 'session_shots'));
+
+    expect($queries->count())->toBe(0);
+});
+
+it('shotsPerSerie defaults to 10 for empty sessions and longer ones', function (): void {
+    $empty = Session::factory()->for(User::factory())->create();
+    expect((new SessionStatsService($empty))->shotsPerSerie())->toBe(10);
+
+    $small = Session::factory()->for(User::factory())->create();
+    statsShotsFor($small, 5);
+    expect((new SessionStatsService($small))->shotsPerSerie())->toBe(5);
+});

--- a/tests/Unit/Services/SessionStatsServiceTest.php
+++ b/tests/Unit/Services/SessionStatsServiceTest.php
@@ -116,6 +116,13 @@ it('returns null dipRange when fewer than 2 complete series', function (): void 
     expect((new SessionStatsService($session))->dipRange())->toBeNull();
 });
 
+it('returns null dipRange when all series score equally (no real dip)', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    statsShotsFor($session, 20, ['ring' => 10, 'score' => 10]);
+
+    expect((new SessionStatsService($session))->dipRange())->toBeNull();
+});
+
 it('returns null groupMm when fewer than 2 shots', function (): void {
     $session = Session::factory()->for(User::factory())->create();
     SessionShot::factory()->for($session)->create([
@@ -152,6 +159,24 @@ it('returns null avgCadansSec when shots have no time spread', function (): void
     $session->shots()->update(['created_at' => now()]);
 
     expect((new SessionStatsService($session))->avgCadansSec())->toBeNull();
+});
+
+it('averages only positive deltas, skipping same-second shots', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    $base = now()->startOfMinute();
+
+    // Deltas: shot1->2 = 0s (same second, skipped), 2->3 = 4s, 3->4 = 2s.
+    // Expected average over positive deltas = (4 + 2) / 2 = 3.0.
+    $stamps = [$base, $base, $base->copy()->addSeconds(4), $base->copy()->addSeconds(6)];
+    foreach ($stamps as $i => $stamp) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => 0,
+            'shot_index' => $i,
+            'created_at' => $stamp,
+        ]);
+    }
+
+    expect((new SessionStatsService($session))->avgCadansSec())->toBe(3.0);
 });
 
 it('caches the loaded shots collection across method calls', function (): void {

--- a/tests/Unit/Services/SessionStatsServiceTest.php
+++ b/tests/Unit/Services/SessionStatsServiceTest.php
@@ -38,10 +38,14 @@ it('returns 0 for tienen/negens/totalScore when session has no shots', function 
 it('counts tienen and negens by ring not score', function (): void {
     $session = Session::factory()->for(User::factory())->create();
 
-    SessionShot::factory()->for($session)->create(['ring' => 10, 'score' => 10]);
-    SessionShot::factory()->for($session)->create(['ring' => 10, 'score' => 10]);
-    SessionShot::factory()->for($session)->create(['ring' => 9, 'score' => 9]);
-    SessionShot::factory()->for($session)->create(['ring' => 8, 'score' => 8]);
+    foreach ([[10, 10], [10, 10], [9, 9], [8, 8]] as $i => [$ring, $score]) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => 0,
+            'shot_index' => $i,
+            'ring' => $ring,
+            'score' => $score,
+        ]);
+    }
 
     $service = new SessionStatsService($session);
 

--- a/tests/Unit/Services/WeaponInsightsServiceTest.php
+++ b/tests/Unit/Services/WeaponInsightsServiceTest.php
@@ -90,6 +90,25 @@ it('returns a date for bestScoreDate matching the top session', function (): voi
     expect($date?->toDateString())->toBe('2026-04-15');
 });
 
+it('breaks bestScoreDate ties in favour of the most recent session', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    $earlier = Session::factory()->for($user)->create(['date' => '2026-03-01']);
+    $later = Session::factory()->for($user)->create(['date' => '2026-04-20']);
+
+    SessionWeapon::factory()->for($earlier)->for($weapon)->create();
+    SessionWeapon::factory()->for($later)->for($weapon)->create();
+
+    // Both sessions tie at the maximum score of 100.
+    shotsFor($earlier, 10, 10, 10);
+    shotsFor($later, 10, 10, 10);
+
+    $date = (new WeaponInsightsService($weapon))->bestScoreDate();
+
+    expect($date?->toDateString())->toBe('2026-04-20');
+});
+
 it('returns trend data only within the requested window', function (): void {
     $user = User::factory()->create();
     $weapon = Weapon::factory()->for($user)->create();

--- a/tests/Unit/Services/WeaponInsightsServiceTest.php
+++ b/tests/Unit/Services/WeaponInsightsServiceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\SessionWeapon;
+use App\Models\User;
+use App\Models\Weapon;
+use App\Services\WeaponInsightsService;
+
+/**
+ * Helper: seed N shots with unique (turn_index, shot_index) for a session.
+ */
+function shotsFor(\App\Models\Session $session, int $count, int $ring, int $score): void
+{
+    foreach (range(0, $count - 1) as $i) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => intdiv($i, 10),
+            'shot_index' => $i % 10,
+            'ring' => $ring,
+            'score' => $score,
+        ]);
+    }
+}
+
+it('returns zero KPIs when weapon has no sessions', function (): void {
+    $weapon = Weapon::factory()->for(User::factory())->create();
+    $service = new WeaponInsightsService($weapon);
+
+    expect($service->sessionCount())->toBe(0);
+    expect($service->totalShots())->toBe(0);
+    expect($service->avgScore())->toBeNull();
+    expect($service->bestScore())->toBeNull();
+    expect($service->bestScoreDate())->toBeNull();
+    expect($service->trendData())->toBe([]);
+    expect($service->recentSessions())->toHaveCount(0);
+});
+
+it('counts distinct sessions for the weapon', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+    $otherWeapon = Weapon::factory()->for($user)->create();
+
+    $sessionA = Session::factory()->for($user)->create();
+    $sessionB = Session::factory()->for($user)->create();
+    $sessionC = Session::factory()->for($user)->create();
+
+    SessionWeapon::factory()->for($sessionA)->for($weapon)->create(['rounds_fired' => 60]);
+    SessionWeapon::factory()->for($sessionB)->for($weapon)->create(['rounds_fired' => 40]);
+    SessionWeapon::factory()->for($sessionC)->for($otherWeapon)->create(['rounds_fired' => 30]);
+
+    $service = new WeaponInsightsService($weapon);
+
+    expect($service->sessionCount())->toBe(2);
+    expect($service->totalShots())->toBe(100);
+});
+
+it('computes avg and best score across sessions', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    $sessions = Session::factory()->for($user)->count(3)->create();
+
+    foreach ($sessions as $i => $session) {
+        SessionWeapon::factory()->for($session)->for($weapon)->create(['rounds_fired' => 10]);
+        shotsFor($session, 10, 9, 9 + $i);
+    }
+
+    $service = new WeaponInsightsService($weapon);
+
+    expect($service->bestScore())->toBe(110);
+    expect($service->avgScore())->toBe(100.0);
+});
+
+it('returns a date for bestScoreDate matching the top session', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    $low = Session::factory()->for($user)->create(['date' => '2026-04-01']);
+    $high = Session::factory()->for($user)->create(['date' => '2026-04-15']);
+
+    SessionWeapon::factory()->for($low)->for($weapon)->create();
+    SessionWeapon::factory()->for($high)->for($weapon)->create();
+    shotsFor($low, 10, 8, 8);
+    shotsFor($high, 10, 10, 10);
+
+    $date = (new WeaponInsightsService($weapon))->bestScoreDate();
+
+    expect($date?->toDateString())->toBe('2026-04-15');
+});
+
+it('returns trend data only within the requested window', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    $recent = Session::factory()->for($user)->create(['date' => now()->subDays(3)->toDateString()]);
+    $stale = Session::factory()->for($user)->create(['date' => now()->subDays(90)->toDateString()]);
+
+    SessionWeapon::factory()->for($recent)->for($weapon)->create();
+    SessionWeapon::factory()->for($stale)->for($weapon)->create();
+    shotsFor($recent, 5, 10, 10);
+    shotsFor($stale, 5, 10, 10);
+
+    $trend = (new WeaponInsightsService($weapon))->trendData(30);
+
+    expect($trend)->toHaveCount(1);
+    expect($trend)->toHaveKey($recent->date->toDateString());
+    expect($trend[$recent->date->toDateString()])->toBe(50);
+});
+
+it('orders recentSessions desc by date with limit', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    foreach (range(1, 7) as $i) {
+        $session = Session::factory()->for($user)->create(['date' => now()->subDays($i)->toDateString()]);
+        SessionWeapon::factory()->for($session)->for($weapon)->create();
+    }
+
+    $recent = (new WeaponInsightsService($weapon))->recentSessions(3);
+
+    expect($recent)->toHaveCount(3);
+    expect($recent->first()->date->toDateString())->toBe(now()->subDays(1)->toDateString());
+});


### PR DESCRIPTION
## Fase 1 · Range Console — 5 kernschermen

Umbrella: #82 · PLAN: `.ai/plans/PLAN-issue-82-fase-1-range-console.md` (status COMPLETED).
Gebaseerd op `main` na merge van Fase 0 (#86). Alle user-facing tekst NL, Signal Mint dark.

### Wat erin zit
1. **Sessies-overzicht** (`ListSessions`) — KPI-strip (sessies/mnd + delta, schoten 30d, beste 10-shot serie, AI-reflecties) + page-header met T1 watermark + right-rail (laatste-sessie target-rings, T3 AI-reflectie-card, 30d trend-sparkline).
2. **Sessie-detail** (`ViewSession`) — header-card (T1 watermark + T4 "WM-4 OK" stamp), 5 stats, dynamische series-card, shot-strip met concentratie-dip-highlight, hit-pattern target-rings, T3 AI-reflectie + eigen notitie.
3. **Wapen-detail** (`ViewWeapon`) — ID-kaart (silhouet + status + **kalibratie**, nieuwe migratie: korrel/vizier/trekker/handgreep) + 4 KPI's + score-trend + sessies-tabel.
4. **AI-coach** (`CoachPage`) — 3-koloms layout (gesprekken-rail / centrale CTA + voorbeeldvragen / context-rail). Hybride: FilamentCopilot blijft chat-engine, eigen Blade levert de rails.
5. **Nieuwe-sessie wizard** (`CreateSession`) — 4-staps Filament v5 Wizard (Wapen / Sessie / Schoten / Notities). `SessionResource::form()` gerefactord naar herbruikbare static field-groups (Edit ongewijzigd, DRY).

### Architectuur
- Afgeleide statistiek in dedicated services (`SessionStatsService`, `WeaponInsightsService`, `RangeConsoleSummaryService`, `CoachContextService`) — geen business-logica in Blade/Resource (CLAUDE.md rule 11/12).
- 7 herbruikbare `<x-aimtrack.*>` Blade-componenten op de Fase 0 tokens.

### Bewuste keuzes
- **Wizard "Schoten"-stap** is een preview (numpad/readout read-only): het echte `SessionShotBoard` vereist een opgeslagen sessie en logt via target-click → ring/score, niet de decimaal-numpad uit het ontwerp. Na "Sessie afronden" → redirect naar het schotenbord voor echt loggen.
- **Theme-switch** (AC4 uit het umbrella-issue) blijft buiten scope — Signal Mint dark enige palet (afgesproken in Fase 0).

### Kwaliteit
- **163 tests groen** (3× stabiel), `vendor/bin/pint` clean, fresh-migrate clean.
- Twee adversariële multi-agent review-workflows (wizard-diff + branch-breed): **16 findings bevestigd & opgelost**, 16 weerlegd. O.a. N+1's geëlimineerd (eager-load via `withSum`/`withExists`/`with`), user-scoping op `CoachContextService::topWeapon()`, `bestScoreDate()` tie-break, en een **latente Carbon-3 bug** in `avgCadansSec()` (signed diff → methode gaf altijd `null` in productie).

### Niet in deze PR
Empty states (Fase 2), mobile companion (Fase 4), marketing landing (Fase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)