### PR TITLE
Design-fidelity Fase 1b: dark theme, Range Console, AI-features & dashboard (#82)

### DIFF
--- a/.ai/plans/PLAN-issue-82-fase-1b-design-fidelity.md
+++ b/.ai/plans/PLAN-issue-82-fase-1b-design-fidelity.md
@@ -1,0 +1,191 @@
+---
+status: APPROVED
+created: 2026-06-05
+updated: 2026-06-05
+approved: 2026-06-05 (Marcvdc)
+author: Claude (Opus 4.8 1M)
+jira: GH#82
+worktree: aimtrack-design-fidelity (feature/design-fidelity)
+basis: c640d0c (main, post-PR #91)
+---
+
+# PLAN: Issue #82 · Fase 1b — Design-fidelity & AI-stuk
+
+## Status: APPROVED — BUILD gestart 2026-06-05
+
+## Aanleiding
+
+Fase 1 (Range Console, PR #88) is functioneel "COMPLETED" maar de gebruiker
+meldt: _"komt in de buurt maar we zijn er echt niet"_ en _"de AI stuk"_ moet
+worden aangevuld + issue #82 moet overeenkomen.
+
+Een gestructureerde gap-analyse (7 agents: 5 schermen + theme/shell + AI-backend)
+gaf fidelity-scores (0–100) t.o.v. het design-handoff:
+
+| Scherm | Fidelity | Grootste tekorten |
+|---|---|---|
+| Wapen-detail | 72 | tabel-kolommen, kv-rijen, trend-as |
+| Sessie-detail | 62 | EINDSCORE-delta, header-meta, AI-knoppen, X/Y/SD |
+| Sessies-overzicht | 52 | **stock Filament-tabel** i.p.v. dense grid, **Wapens-kaart mist** |
+| AI-stuk (backend) | 52 | **enum-crash**, prompt mist schotdata, insights niet getoond |
+| AI-coach (UI) | 38 | static launcher i.p.v. chat-beleving |
+| Wizard | 38 | chrome niet donker, preview-stap |
+| Theme/shell | 38 | **Filament-chrome consumeert tokens niet** |
+
+### Drie systemische root causes (verklaren ~alle "niet"-gevoel)
+
+- **R1 · Geen Filament-theme-laag.** `AdminPanelProvider` injecteert alleen
+  `--at-*` vars + `primary`. Die worden gebruikt door handgemaakte Blade-kaarten,
+  maar **niet** door Filament's eigen chrome (sidebar/topbar/tabellen/badges/
+  wizard/velden). Elk Filament-oppervlak is een licht eiland in een donkere pagina.
+- **R2 · `target-rings` schalingsbug** (`target-rings.blade.php:74-75`, geen
+  `*0.35` factor + geen crosshair/center-dot/ten-ring-halo) → de "hit pattern"
+  ziet eruit als hagel i.p.v. een groep.
+- **R3 · AI-stuk kapot/leeg.** `ShooterCoach.php:129,162` interpoleert de backed
+  `Deviation`-enum als string → **runtime fatal**; en de prompt bevat geen
+  numerieke schotdata, dus data-gegronde inzichten ("4e serie zakt naar 87.2")
+  zijn onmogelijk.
+
+## Beslissingen (afgestemd met gebruiker 2026-06-05)
+
+1. **Filament-chrome theming** → **`make:filament-theme` + `->viteTheme()`**
+   (gesanctioneerde Filament-weg). Voegt één npm/vite theme-entry toe —
+   **expliciet goedgekeurd** (CLAUDE.md dep/build-akkoord ✓).
+2. **AI-coach** → **floating Copilot-widget blijft chat-engine**; de center-kolom
+   wordt een getrouwe preview/launcher (géén volledige in-page chat-thread).
+3. **Nieuwe AI-features** (`TrainingGoal` + `ScoreDriftService`) → **nu meebouwen**
+   in deze ronde (elk met eigen AC's, zie §G).
+4. **Ronde-scope** → **fundament + top-fidelity** in één worktree/PR
+   (`feature/design-fidelity`); diepere polish + volledige chat-thread +
+   icon-set in vervolg-PR's.
+
+## Data-availability (geverifieerd tegen DB-schema)
+
+- **Aanwezig**: volledige schotdata (`session_shots.x/y_normalized, ring, score`),
+  kalibratie (`korrel_correction, vizier_correction, trigger_weight_g, grip_size`),
+  `sessions.range_name/location`, `weapons.serial_number/owned_since/is_active`,
+  reflectie-shape (`summary/positives/improvements/next_focus`).
+- **Ontbreekt → wordt weggelaten (niet gefaket)**: weer (temp/wind), wapengewicht,
+  "laatste onderhoud".
+- **Discipline** is geen kolom → **afgeleid** uit `weapon_type` + `distance_m`.
+- **Nieuw schema nodig**: `ai_reflections.acknowledged_at` ("Markeer"),
+  `training_goals` tabel (nieuwe feature).
+
+---
+
+## Acceptance criteria
+
+- **AC1** — Filament-panel rendert in **Signal Mint dark** via een echte
+  theme-CSS (viteTheme): sidebar (220px, `--at-panel`, accent active-border),
+  topbar (56px), tabellen, badges, wizard-stepper en form-velden consumeren
+  allemaal de `--at-*` tokens. Geen licht "Filament-eiland" meer.
+- **AC2** — Navigatie gegroepeerd als **LOG / INZICHT / BEHEER** met mono-uppercase
+  groeplabels, nav-badges (sessie- + wapen-count, `NEW` op AI-coach), en
+  sidebar-footer (avatar + naam + club·licentie).
+- **AC3** — `target-rings` toont een correcte, geschaalde groep met crosshair,
+  center-dot en ten-ring-emphasis; pixel-close aan `shared.jsx TargetRings`.
+- **AC4** — Sessies-overzicht: de "Recente sessies"-tabel is een dense Signal-Mint
+  grid-kaart (7 kolommen, mono datum + `S-xxxx` sub, accent-score, AI/open-badge),
+  én de **"Wapens · gebruik"** 3-up kaart met inline sparklines is aanwezig.
+- **AC5** — Sessie-detail: EINDSCORE-delta (`▲ +5 vs gem.` accent), 4-span
+  header-meta (baan, wapen, tijd-window, weglaten-indien-leeg), X/Y/SD-rij onder
+  hit-patroon, en de AI-reflectie-kaart met **"Vraag coach"** + **"Markeer"** knoppen.
+- **AC6** — AI-backend: de `Deviation`-enum-crash is weg (regressietest), en de
+  reflectie-prompt bevat numerieke schotdata (serie-scores, dip-range, tienen/negens,
+  groep-mm, cadans) — bewezen via een prompt-content test.
+- **AC7** — `AiWeaponInsight` (summary/patterns/suggestions) wordt op de wapen-detail
+  getoond in een T3 BracketFrame-kaart (niet alleen via chat).
+- **AC8** — `TrainingGoal`-feature: model + migratie + service + Copilot-tool +
+  UI (voorgestelde-doelen-rail + "Voeg doel toe"-CTA), schutter-gescoped.
+- **AC9** — `ScoreDriftService`: per-schot drift-aggregatie over laatste N
+  matchende sessies (Eloquent), getoond als warn-sparkline; Copilot-tool eroverheen.
+- **AC10** — Pest dekt alle nieuwe/gewijzigde code (≥90%); Pint clean;
+  `php artisan test --compact` groen vóór elke commit.
+- **AC11** — Issue #82 bevat een expliciete **"AI-scope (het AI-stuk)"**-sectie die
+  overeenkomt met de design-belofte (zie §I); geen `DIVERGENT FROM JIRA`.
+
+---
+
+## Workstreams & stappen (per stap: build → test → Pint → sign-off → commit)
+
+### A · Fundament (eerst — unlockt alle schermen)
+- **A1 (R1)** — `php artisan make:filament-theme`, registreer via
+  `->viteTheme('resources/css/filament/admin/theme.css')` op `AdminPanelProvider`,
+  forceer dark. Map `fi-sidebar`/`fi-topbar`/`fi-main`/`fi-ta`/`fi-badge`/
+  `fi-wizard`/`fi-input` op `--at-*`. Numerieke kolommen → `--at-font-mono`.
+- **A2 (R2)** — Fix `target-rings.blade.php`: hit-scaling (`*0.35`, prop `hitScale`),
+  crosshair-lijnen, center-dot, ten-ring-halo, ring-emphasis (10-ring 0.55 / overig 0.22).
+- **A3** — Nav-groepen LOG/INZICHT/BEHEER (`->navigationGroups`), active-item
+  styling (2px accent border-left), `getNavigationBadge()` op Session/Weapon/Coach,
+  sidebar-header (wordmark + `v3.2 · self-hosted`) + footer (render hooks).
+- **A4** — Topbar: mono-breadcrumb + gestylde search + ⌘K-chip.
+- **A5** — `sparkline.blade.php`: echte `<linearGradient>` fill + terminal-dot.
+
+### B · Sessies-overzicht
+- **B1** — Vervang `{{ $this->table }}` door dense Blade-grid-kaart;
+  `RangeConsoleSummaryService::recentSessions()` (Eloquent eager-load).
+- **B2** — Voeg "Wapens · gebruik" 3-up kaart toe; `::weaponUsage()` aggregatie.
+- **B3** — Rail 340→320px; AI-kaart `✦`→accent AI-icoon + "Vraag AI-coach iets"-knop;
+  stat-card delta-pijl-prop.
+
+### C · Sessie-detail
+- **C1** — EINDSCORE-delta `scoreVsAverage()` (accent/warn).
+- **C2** — 4-span header-meta (baan/wapen/tijd-window via eerste-laatste schot-`created_at`/weglaten-indien-leeg).
+- **C3** — X/Y/SD-rij: `SessionStatsService::meanXmm()/meanYmm()/sdMm()`.
+- **C4** — AI-reflectie-knoppen "Vraag coach" (Copilot pre-seed) + "Markeer"
+  (`acknowledged_at`); AI-icoon + `gegenereerd HH:i`; dip-getal in warn-mono (XSS-safe).
+- **C5** — Card-head accent-iconen; rechter-kolom 360→340px; shot-strip-legend `concentratiedip`.
+
+### D · Wapen-detail (dichtst bij — lichte polish)
+- **D1** — Sessies-tabel 5→6 kolommen (Discipline·Baan twee-regelig, trailing `⋯`).
+- **D2** — `SERIAL · {serial_number}` subtitle; kv-rijen aligned (Status `· WM-4`,
+  Aangeschaft, Kaliber + alleen bestaande velden).
+- **D3** — Trend-as 6 kwartaal-ticks; stat-subs (`+N/mnd`, `▲ +x.x`).
+- **D4 (AC7)** — `AiWeaponInsight` in T3 BracketFrame-kaart.
+
+### E · AI-coach (launcher-variant, decision 2)
+- **E1** — Center-kolom: getrouwe preview/launcher (geen volledige thread).
+  Suggestie-chips → echte `<button>`s die `copilot-open` dispatchen.
+- **E2** — Voorgestelde-doelen-rail (uit §G TrainingGoal) + privacy-note.
+
+### F · AI-backend bugfixes (R3 — blocker)
+- **F1 (AC6)** — `$entry->deviation?->value ?? 'n.v.t.'` op `ShooterCoach.php:129,162`
+  + regressietest (reflectie voor sessie met non-null Deviation → geen exception).
+- **F2 (AC6)** — Injecteer `SessionStatsService`-numeriek in `buildSessionPrompt`
+  (+ `GenerateSessionReflectionJob`); prompt-content test.
+
+### G · Nieuwe AI-features (decision 3 — eigen AC's)
+- **G1 (AC8)** — `TrainingGoal`: model + migratie (`user_id, title, detail,
+  source[ai|manual], status, target_month, session_id?, weapon_id?`) + factory +
+  `TrainingGoalService` + Copilot `SuggestTrainingGoalTool`/`AddTrainingGoalTool` +
+  Filament-UI (rail + CTA). Schutter-gescoped. Tests.
+- **G2 (AC9)** — `ScoreDriftService` (Eloquent per-schot-drift over laatste N
+  matchende sessies) + Copilot-tool + warn-sparkline render. Tests.
+
+### H · Kwaliteit
+- Pest per stap (`--filter`), daarna volledige suite. Pint + `php -l`.
+- Pest 4 browser-smoke per Range-Console-scherm (`assertNoJavascriptErrors`).
+- Architectuur-checks (Service voor logica, geen Model-queries in pages, Eloquent-only).
+
+### I · Issue #82 bijwerken (AC11 — vóór BUILD, rule #10)
+Voeg een **"AI-scope (het AI-stuk)"**-sectie toe aan #82 met:
+1. De 2 AI-blockers als AC-regels (enum-crash, prompt-data).
+2. De ontbrekende AI-features (training-goals, score-drift, reflectie-acties +
+   `acknowledged_at`, weapon-insight surfacing).
+3. De architectuur-beslissing coach (launcher i.p.v. in-page thread) als ADR-ref.
+4. Bevestiging dat de AI-scope overeenkomt met de design-belofte.
+
+---
+
+## Niet in deze ronde (vervolg-PR's)
+- Volledige in-page chat-thread (decision 2 = launcher).
+- Wizard-numpad-overhaul / modal-conversie (blijft preview; alleen chrome donker).
+- Eigen icon-set (heroicons blijven voorlopig).
+- Weer/wapengewicht/onderhoud-velden (ontbreken in model).
+- Fase 3 (marketing) & Fase 4 (mobile).
+
+## STOP-gates (CLAUDE.md)
+- PLAN moet **APPROVED** zijn vóór BUILD (deze sign-off).
+- Issue #82 AI-scope bijwerken vóór BUILD (rule #10).
+- Coverage <90% op gewijzigde code → STOP.
+- Commit pas na expliciete goedkeuring per stap.

--- a/app/Enums/TrainingGoalSource.php
+++ b/app/Enums/TrainingGoalSource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum TrainingGoalSource: string
+{
+    case Ai = 'ai';
+    case Manual = 'manual';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Ai => 'AI-suggestie',
+            self::Manual => 'Zelf toegevoegd',
+        };
+    }
+}

--- a/app/Filament/Copilot/Tools/AddTrainingGoalTool.php
+++ b/app/Filament/Copilot/Tools/AddTrainingGoalTool.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Copilot\Tools;
+
+use App\Enums\TrainingGoalSource;
+use App\Models\User;
+use App\Services\TrainingGoalService;
+use EslamRedaDiv\FilamentCopilot\Tools\BaseTool;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+class AddTrainingGoalTool extends BaseTool
+{
+    public function description(): Stringable|string
+    {
+        return 'Legt een concreet trainingsdoel vast voor de huidige schutter (verschijnt onder "Voorgestelde doelen"). Gebruik dit alleen nadat de schutter akkoord is met een voorgesteld doel, of als de schutter expliciet om een doel vraagt. Houd de titel kort en actiegericht (bv. "Micro-pauze na schot 30").';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'title' => $schema->string()->description('Korte, actiegerichte titel van het trainingsdoel (max ~60 tekens).')->required(),
+            'detail' => $schema->string()->description('Optionele toelichting: hoe het doel uit te voeren of waarom.'),
+            'target_month' => $schema->string()->description('Optionele doelmaand in formaat JJJJ-MM, bv. "2026-06".'),
+        ];
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        if (! $this->user instanceof User) {
+            return 'Geen actieve schutter gevonden in de huidige sessie.';
+        }
+
+        $title = trim((string) ($request['title'] ?? ''));
+
+        if ($title === '') {
+            return 'Een trainingsdoel heeft minimaal een titel nodig.';
+        }
+
+        $detail = filled($request['detail'] ?? null) ? (string) $request['detail'] : null;
+        $targetMonth = null;
+
+        if (filled($request['target_month'] ?? null) && preg_match('/^\d{4}-\d{2}$/', (string) $request['target_month']) === 1) {
+            $targetMonth = (string) $request['target_month'];
+        }
+
+        $goal = app(TrainingGoalService::class)->add(
+            user: $this->user,
+            title: $title,
+            detail: $detail,
+            source: TrainingGoalSource::Ai,
+            targetMonth: $targetMonth,
+        );
+
+        return sprintf(
+            'Trainingsdoel toegevoegd (#%d): "%s"%s. Het staat nu onder Voorgestelde doelen.',
+            $goal->id,
+            $goal->title,
+            $targetMonth !== null ? " voor {$targetMonth}" : '',
+        );
+    }
+}

--- a/app/Filament/Copilot/Tools/ScoreDriftTool.php
+++ b/app/Filament/Copilot/Tools/ScoreDriftTool.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Copilot\Tools;
+
+use App\Models\User;
+use App\Services\ScoreDriftService;
+use EslamRedaDiv\FilamentCopilot\Tools\BaseTool;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+class ScoreDriftTool extends BaseTool
+{
+    public function description(): Stringable|string
+    {
+        return 'Analyseert de score-drift van de schutter: het gemiddelde per schot-positie over de laatste sessies, plus het zwakste schot-venster (waar de concentratie wegzakt). Gebruik dit bij vragen als "waarom zakt mijn score rond schot 35?".';
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'sessions' => $schema->integer()->description('Aantal recente sessies om mee te nemen (default 6).'),
+        ];
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        if (! $this->user instanceof User) {
+            return 'Geen actieve schutter gevonden in de huidige sessie.';
+        }
+
+        $sessions = (int) ($request['sessions'] ?? 6);
+        $sessions = max(1, min(20, $sessions));
+
+        $service = new ScoreDriftService($this->user);
+        $averages = $service->perShotAverage($sessions);
+
+        if ($averages === []) {
+            return 'Nog onvoldoende sessies met schoten om score-drift te berekenen.';
+        }
+
+        $window = $service->weakestWindow(min(10, count($averages)), $sessions);
+
+        $perShot = collect($averages)
+            ->map(fn (float $avg, int $pos): string => "schot {$pos}: {$avg}")
+            ->implode(', ');
+
+        $windowText = $window !== null
+            ? sprintf('Zwakste venster: schot %d–%d (gemiddeld %s).', $window['from'], $window['to'], $window['average'])
+            : 'Geen duidelijk zwak venster.';
+
+        return trim(sprintf(
+            "Score-drift over laatste %d sessies (gemiddelde score per schot-positie):\n%s\n\n%s",
+            $sessions,
+            $perShot,
+            $windowText,
+        ));
+    }
+}

--- a/app/Filament/Pages/CoachPage.php
+++ b/app/Filament/Pages/CoachPage.php
@@ -25,9 +25,19 @@ class CoachPage extends Page implements CopilotPageContract
 
     protected static ?string $title = 'AI-coach';
 
-    protected static string|UnitEnum|null $navigationGroup = 'AI & inzichten';
+    protected static string|UnitEnum|null $navigationGroup = 'INZICHT';
 
     protected string $view = 'filament.pages.coach-page';
+
+    public static function getNavigationBadge(): ?string
+    {
+        return 'NEW';
+    }
+
+    public static function getNavigationBadgeColor(): string|array|null
+    {
+        return 'primary';
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/CoachPage.php
+++ b/app/Filament/Pages/CoachPage.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\SessionResource;
 use App\Models\TrainingGoal;
 use App\Models\User;
 use App\Services\CoachContextService;
+use App\Services\ScoreDriftService;
 use App\Services\TrainingGoalService;
 use App\Support\Features\AimtrackFeatureToggle;
 use App\Support\UserOnboardingState;
@@ -111,6 +112,19 @@ class CoachPage extends Page implements CopilotPageContract
         $user = Auth::user();
 
         return app(TrainingGoalService::class)->openGoals($user);
+    }
+
+    /**
+     * Gemiddelde score per schot-positie over de laatste sessies (score-drift).
+     *
+     * @return array<int, float>
+     */
+    public function getScoreDrift(): array
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return (new ScoreDriftService($user))->perShotAverage();
     }
 
     /**

--- a/app/Filament/Pages/CoachPage.php
+++ b/app/Filament/Pages/CoachPage.php
@@ -6,8 +6,10 @@ namespace App\Filament\Pages;
 
 use App\Filament\Copilot\Tools\ShooterContextTool;
 use App\Filament\Resources\SessionResource;
+use App\Models\TrainingGoal;
 use App\Models\User;
 use App\Services\CoachContextService;
+use App\Services\TrainingGoalService;
 use App\Support\Features\AimtrackFeatureToggle;
 use App\Support\UserOnboardingState;
 use BackedEnum;
@@ -95,6 +97,43 @@ class CoachPage extends Page implements CopilotPageContract
             ->body("De coach analyseert je gelogde sessies (afwijkingen, groepering, ademhalingsritmes) en suggereert verbeterpunten. Vanaf {$threshold} sessies is er genoeg patroon om zinvolle feedback te geven.")
             ->info()
             ->persistent()
+            ->send();
+    }
+
+    /**
+     * Open trainingsdoelen van de schutter ("Voorgestelde doelen"-rail).
+     *
+     * @return \Illuminate\Support\Collection<int, TrainingGoal>
+     */
+    public function getTrainingGoals(): \Illuminate\Support\Collection
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return app(TrainingGoalService::class)->openGoals($user);
+    }
+
+    /**
+     * Livewire-action: vink een trainingsdoel af (design: checkbox-kaart).
+     */
+    public function completeGoal(int $goalId): void
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        $goal = TrainingGoal::query()
+            ->where('user_id', $user->id)
+            ->find($goalId);
+
+        if ($goal === null) {
+            return;
+        }
+
+        app(TrainingGoalService::class)->complete($goal);
+
+        Notification::make()
+            ->title('Trainingsdoel afgerond')
+            ->success()
             ->send();
     }
 }

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -87,4 +87,14 @@ class Dashboard extends BaseDashboard
 
         return parent::getTitle();
     }
+
+    /**
+     * Onderdruk Filaments default pagina-heading: zowel de first-run-welkom als
+     * het overzicht renderen hun eigen (gestylede) titel, anders staat
+     * "Dashboard" dubbel op het scherm.
+     */
+    public function getHeading(): string
+    {
+        return '';
+    }
 }

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -6,10 +6,13 @@ namespace App\Filament\Pages;
 
 use App\Filament\Concerns\HasSeedDemoDataAction;
 use App\Models\User;
+use App\Services\RangeConsoleSummaryService;
+use App\Services\TrainingGoalService;
 use App\Support\UserOnboardingState;
 use Filament\Pages\Dashboard as BaseDashboard;
 use Filament\Schemas\Components\View;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 
 /**
@@ -42,7 +45,38 @@ class Dashboard extends BaseDashboard
             ]);
         }
 
-        return parent::content($schema);
+        return $schema->components([
+            View::make('filament.pages.dashboard-overview'),
+        ]);
+    }
+
+    public function getSummary(): RangeConsoleSummaryService
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return new RangeConsoleSummaryService($user);
+    }
+
+    /**
+     * @return Collection<int, \App\Models\TrainingGoal>
+     */
+    public function getTrainingGoals(): Collection
+    {
+        /** @var User $user */
+        $user = Auth::user();
+
+        return app(TrainingGoalService::class)->openGoals($user, 4);
+    }
+
+    /**
+     * Gecureerde KNSA-kennisbank-links (gedeeld met de landingspagina).
+     *
+     * @return array<int, array{title: string, description?: string, url: string}>
+     */
+    public function getKnsaLinks(): array
+    {
+        return config('landing.knsa_links', []);
     }
 
     public function getTitle(): string

--- a/app/Filament/Pages/ExportSessionsPage.php
+++ b/app/Filament/Pages/ExportSessionsPage.php
@@ -28,7 +28,7 @@ class ExportSessionsPage extends Page implements HasForms
 
     protected static ?string $title = 'Export sessies';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'Exports & rapportage';
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
 
     protected string $view = 'filament.pages.export-sessions-page';
 

--- a/app/Filament/Pages/FailedJobsPage.php
+++ b/app/Filament/Pages/FailedJobsPage.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use Filament\Pages\Page;
+
+/**
+ * Beheer-pagina (BEHEER) met de mislukte queue-jobs. Geen gebruikers-
+ * informatie, dus afgeschermd tot admin-users (users.is_admin).
+ */
+class FailedJobsPage extends Page
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-exclamation-triangle';
+
+    protected static ?string $navigationLabel = 'Mislukte jobs';
+
+    protected static ?string $title = 'Mislukte queue-jobs';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
+
+    protected static ?int $navigationSort = 90;
+
+    protected string $view = 'filament.pages.failed-jobs-page';
+
+    public static function canAccess(): bool
+    {
+        return (bool) (auth()->user()?->is_admin);
+    }
+}

--- a/app/Filament/Resources/AmmoTypeResource.php
+++ b/app/Filament/Resources/AmmoTypeResource.php
@@ -28,7 +28,7 @@ class AmmoTypeResource extends Resource
 
     protected static ?string $pluralModelLabel = 'Munitietypen';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'Beheer';
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/AttachmentResource.php
+++ b/app/Filament/Resources/AttachmentResource.php
@@ -28,7 +28,7 @@ class AttachmentResource extends Resource
 
     protected static ?string $pluralModelLabel = 'Bijlagen';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'Dagboek';
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/LocationResource.php
+++ b/app/Filament/Resources/LocationResource.php
@@ -31,7 +31,7 @@ class LocationResource extends Resource
 
     protected static ?string $pluralModelLabel = 'Locaties';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'Beheer';
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -55,7 +55,14 @@ class SessionResource extends Resource implements CopilotResourceContract
 
     protected static ?string $pluralModelLabel = 'Sessies';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'Dagboek';
+    protected static string|\UnitEnum|null $navigationGroup = 'LOG';
+
+    public static function getNavigationBadge(): ?string
+    {
+        $count = static::getEloquentQuery()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/SessionResource/Pages/ViewSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/ViewSession.php
@@ -22,6 +22,11 @@ class ViewSession extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('shotBoard')
+                ->label('Schotenbord (roos)')
+                ->icon('heroicon-m-viewfinder-circle')
+                ->color('primary')
+                ->url(fn (): string => SessionResource::getUrl('shots', ['record' => $this->record])),
             EditAction::make()
                 ->label('Bewerken'),
             Action::make('regenerateAi')

--- a/app/Filament/Resources/SessionResource/Pages/ViewSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/ViewSession.php
@@ -52,6 +52,26 @@ class ViewSession extends ViewRecord
         ];
     }
 
+    /**
+     * Markeer de AI-reflectie van deze sessie als gelezen (design: "Markeer").
+     */
+    public function acknowledgeReflection(): void
+    {
+        $reflection = $this->record->aiReflection;
+
+        if ($reflection === null || $reflection->acknowledged_at !== null) {
+            return;
+        }
+
+        $reflection->update(['acknowledged_at' => now()]);
+        $this->record->load('aiReflection');
+
+        Notification::make()
+            ->title('Reflectie gemarkeerd als gelezen')
+            ->success()
+            ->send();
+    }
+
     protected function features(): AimtrackFeatureToggle
     {
         return app(AimtrackFeatureToggle::class);

--- a/app/Filament/Resources/WeaponResource.php
+++ b/app/Filament/Resources/WeaponResource.php
@@ -50,7 +50,14 @@ class WeaponResource extends Resource implements CopilotResourceContract
 
     protected static ?string $pluralModelLabel = 'Wapens';
 
-    protected static string|\UnitEnum|null $navigationGroup = 'Beheer';
+    protected static string|\UnitEnum|null $navigationGroup = 'LOG';
+
+    public static function getNavigationBadge(): ?string
+    {
+        $count = static::getEloquentQuery()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Models/AiReflection.php
+++ b/app/Models/AiReflection.php
@@ -15,11 +15,13 @@ class AiReflection extends Model
         'positives',
         'improvements',
         'next_focus',
+        'acknowledged_at',
     ];
 
     protected $casts = [
         'positives' => 'array',
         'improvements' => 'array',
+        'acknowledged_at' => 'datetime',
     ];
 
     public function session()

--- a/app/Models/TrainingGoal.php
+++ b/app/Models/TrainingGoal.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\TrainingGoalSource;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TrainingGoal extends Model
+{
+    /** @use HasFactory<\Database\Factories\TrainingGoalFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'detail',
+        'source',
+        'target_month',
+        'session_id',
+        'weapon_id',
+        'completed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'source' => TrainingGoalSource::class,
+            'completed_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function session(): BelongsTo
+    {
+        return $this->belongsTo(Session::class);
+    }
+
+    public function weapon(): BelongsTo
+    {
+        return $this->belongsTo(Weapon::class);
+    }
+
+    /**
+     * @param  Builder<TrainingGoal>  $query
+     * @return Builder<TrainingGoal>
+     */
+    public function scopeOpen(Builder $query): Builder
+    {
+        return $query->whereNull('completed_at');
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->completed_at !== null;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -38,6 +38,11 @@ class User extends Authenticatable
         return $this->hasMany(Weapon::class);
     }
 
+    public function trainingGoals()
+    {
+        return $this->hasMany(TrainingGoal::class);
+    }
+
     public function coachQuestions()
     {
         return $this->hasMany(CoachQuestion::class);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_admin',
     ];
 
     protected $hidden = [
@@ -26,7 +27,13 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'demo_data_seeded_at' => 'datetime',
         'password' => 'hashed',
+        'is_admin' => 'boolean',
     ];
+
+    public function isAdmin(): bool
+    {
+        return (bool) $this->is_admin;
+    }
 
     public function sessions()
     {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -82,6 +82,21 @@ class AdminPanelProvider extends PanelProvider
                 fn (): string => <<<'HTML'
                     <style>
                         .copilot-chat-widget { max-width: min(1024px, 70vw) !important; }
+                        /* De Copilot-widget heeft eigen CSS waarvan de dark:-varianten
+                           niet consistent activeren onder het geforceerde dark panel,
+                           wat wit-op-wit input gaf. Forceer leesbaar contrast. */
+                        .copilot-chat-widget { background-color: var(--at-panel) !important; color: var(--at-text); }
+                        .copilot-chat-widget form { background-color: var(--at-panel-2) !important; }
+                        .copilot-chat-widget textarea,
+                        .copilot-chat-widget input[type="text"] {
+                            color: var(--at-text) !important;
+                            -webkit-text-fill-color: var(--at-text) !important;
+                            background-color: transparent !important;
+                        }
+                        .copilot-chat-widget textarea::placeholder,
+                        .copilot-chat-widget input[type="text"]::placeholder {
+                            color: var(--at-muted) !important;
+                        }
                     </style>
                 HTML,
             )

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers\Filament;
 
-use App\Filament\Widgets\FailedJobsWidget;
 use App\Support\Features\AimtrackFeatureToggle;
 use EslamRedaDiv\FilamentCopilot\FilamentCopilotPlugin;
 use Filament\Actions\Action;
@@ -51,9 +50,7 @@ class AdminPanelProvider extends PanelProvider
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
-            ->widgets([
-                FailedJobsWidget::class,
-            ])
+            ->widgets([])
             ->userMenuItems([
                 Action::make('landing-page')
                     ->label('Terug naar landingpage')

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -43,6 +43,9 @@ class AdminPanelProvider extends PanelProvider
                 'primary' => Color::hex('#64f4b3'),
             ])
             ->font('Inter')
+            ->viteTheme('resources/css/filament/admin/theme.css')
+            ->darkMode(true, isForced: true)
+            ->sidebarWidth('14rem')
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([])

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -46,6 +46,7 @@ class AdminPanelProvider extends PanelProvider
             ->viteTheme('resources/css/filament/admin/theme.css')
             ->darkMode(true, isForced: true)
             ->sidebarWidth('14rem')
+            ->navigationGroups(['LOG', 'INZICHT', 'BEHEER'])
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->pages([])
@@ -63,6 +64,14 @@ class AdminPanelProvider extends PanelProvider
             ->renderHook(
                 PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
                 fn (): string => view('filament.auth.login-extras')->render(),
+            )
+            ->renderHook(
+                PanelsRenderHook::SIDEBAR_LOGO_AFTER,
+                fn (): string => <<<'HTML'
+                    <div style="margin-top: 0.375rem; font-family: var(--at-font-mono); font-size: 0.625rem; letter-spacing: 0.12em; color: var(--at-muted);">
+                        self-hosted
+                    </div>
+                HTML,
             )
             ->renderHook(
                 PanelsRenderHook::HEAD_END,

--- a/app/Services/Ai/ShooterCoach.php
+++ b/app/Services/Ai/ShooterCoach.php
@@ -8,6 +8,7 @@ use App\Models\Session;
 use App\Models\SessionWeapon;
 use App\Models\Weapon;
 use App\Notifications\AiCoachFailureNotification;
+use App\Services\SessionStatsService;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -126,7 +127,7 @@ class ShooterCoach
                 $entry->distance_m ?? 'n.v.t.',
                 $entry->rounds_fired ?? '0',
                 $entry->ammo_type ?? 'onbekend',
-                $entry->deviation ?? 'n.v.t.',
+                $entry->deviation?->value ?? 'n.v.t.',
                 Str::limit($entry->group_quality_text ?? '-', 120)
             ))
             ->filter()
@@ -135,8 +136,11 @@ class ShooterCoach
 
         $manualReflection = $session->manual_reflection ? "Handmatige reflectie gebruiker: {$session->manual_reflection}" : 'Geen handmatige reflectie ingevoerd.';
 
+        $shotStatistics = $this->buildShotStatistics($session);
+
         return trim(<<<PROMPT
 Je bent een AI-coach voor sportschutters. Geef veilige, constructieve adviezen, geen illegale of gevaarlijke tips.
+Baseer je analyse op de concrete schotstatistiek hieronder: benoem reeksen, dips en cijfers expliciet (bv. "serie 4 zakt naar 87").
 
 Context sessie:
 - Datum: {$session->date?->format('Y-m-d')}
@@ -144,10 +148,60 @@ Context sessie:
 - Ruwe notities: {$session->notes_raw}
 - Wapenregels:
 {$weaponLines}
+{$shotStatistics}
 - {$manualReflection}
 
 Gevraagde output: JSON met velden summary (string), positives (array van strings), improvements (array van strings), next_focus (string).
 PROMPT);
+    }
+
+    /**
+     * Numerieke schotstatistiek voor de reflectie-prompt. Zonder deze cijfers
+     * kan de AI alleen op de ruwe notities leunen en de data-gegronde inzichten
+     * uit het ontwerp (serie-scores, concentratiedip, groepering) niet maken.
+     */
+    private function buildShotStatistics(Session $session): string
+    {
+        $stats = new SessionStatsService($session);
+
+        if ($stats->totalShots() === 0) {
+            return '- Schotstatistiek: geen individuele schoten geregistreerd.';
+        }
+
+        $series = $stats->seriesScores();
+        $seriesText = $series === []
+            ? 'n.v.t.'
+            : implode(' · ', array_map(static fn (int $sum): string => (string) $sum, $series));
+
+        $dip = $stats->dipRange();
+        $dipText = $dip === null
+            ? 'geen duidelijke concentratiedip'
+            : sprintf('zwakste reeks rond schot %d–%d', $dip[0] + 1, $dip[1] + 1);
+
+        $group = $stats->groupMm();
+        $cadans = $stats->avgCadansSec();
+        $best = $stats->bestShot();
+
+        return trim(sprintf(
+            "- Schotstatistiek (uit %d geregistreerde schoten):\n".
+            "  · Totaalscore: %d\n".
+            "  · Tienen: %d · Negens: %d\n".
+            "  · Beste schot: %s\n".
+            "  · Groepering: %s\n".
+            "  · Gem. cadans: %s\n".
+            "  · Serie-scores (per %d): %s\n".
+            '  · Concentratie: %s',
+            $stats->totalShots(),
+            $stats->totalScore(),
+            $stats->tienen(),
+            $stats->negens(),
+            $best !== null ? (string) $best : 'n.v.t.',
+            $group !== null ? number_format($group, 1).' mm' : 'n.v.t.',
+            $cadans !== null ? number_format($cadans, 0).'s' : 'n.v.t.',
+            $stats->shotsPerSerie(),
+            $seriesText,
+            $dipText,
+        ));
     }
 
     private function buildWeaponPrompt(Weapon $weapon): string
@@ -159,7 +213,7 @@ PROMPT);
                 $entry->session?->date?->format('Y-m-d') ?? 'onbekende datum',
                 $entry->distance_m ?? 'n.v.t.',
                 $entry->rounds_fired ?? '0',
-                $entry->deviation ?? 'n.v.t.',
+                $entry->deviation?->value ?? 'n.v.t.',
                 Str::limit($entry->group_quality_text ?? '-', 120)
             ))
             ->filter()

--- a/app/Services/RangeConsoleSummaryService.php
+++ b/app/Services/RangeConsoleSummaryService.php
@@ -8,7 +8,9 @@ use App\Models\AiReflection;
 use App\Models\Session;
 use App\Models\SessionShot;
 use App\Models\User;
+use App\Models\Weapon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 
 /**
  * Aggregator voor de Range Console sessies-overzicht pagina.
@@ -169,6 +171,73 @@ final class RangeConsoleSummaryService
                 $s->date->toDateString() => (int) ($scoresBySession[$s->id] ?? 0),
             ])
             ->all();
+    }
+
+    /**
+     * Per-wapen gebruik voor de "Wapens · gebruik" kaart: type, kaliber, naam,
+     * gemiddelde sessiescore, aantal sessies + schoten, en de score-reeks voor
+     * de inline sparkline. Eén aggregaat-query voor alle schoten (geen N+1).
+     *
+     * @return Collection<int, array{name: string, type: string, caliber: string, avg: float, sessions: int, shots: int, trend: int, series: array<int, int>}>
+     */
+    public function weaponUsage(int $limit = 3): Collection
+    {
+        $weapons = Weapon::query()
+            ->where('user_id', $this->user->getKey())
+            ->whereHas('sessionWeapons')
+            ->withCount('sessionWeapons as usage_count')
+            ->orderByDesc('usage_count')
+            ->limit($limit)
+            ->with(['sessionWeapons:id,weapon_id,session_id'])
+            ->get();
+
+        if ($weapons->isEmpty()) {
+            return collect();
+        }
+
+        $sessionIds = $weapons
+            ->flatMap(fn (Weapon $weapon): Collection => $weapon->sessionWeapons->pluck('session_id'))
+            ->unique();
+
+        $sessionStats = SessionShot::query()
+            ->whereIn('session_id', $sessionIds)
+            ->selectRaw('session_id, SUM(score) as total, COUNT(*) as shots')
+            ->groupBy('session_id')
+            ->get()
+            ->keyBy('session_id');
+
+        $sessionDates = Session::query()
+            ->whereIn('id', $sessionIds)
+            ->pluck('date', 'id');
+
+        return $weapons->map(function (Weapon $weapon) use ($sessionStats, $sessionDates): array {
+            $orderedSessionIds = $weapon->sessionWeapons
+                ->pluck('session_id')
+                ->unique()
+                ->sortBy(fn ($id): string => (string) ($sessionDates[$id] ?? ''))
+                ->values();
+
+            $scores = $orderedSessionIds
+                ->map(fn ($id): int => (int) ($sessionStats[$id]->total ?? 0))
+                ->all();
+            $shots = (int) $orderedSessionIds
+                ->sum(fn ($id): int => (int) ($sessionStats[$id]->shots ?? 0));
+
+            $nonZeroScores = array_values(array_filter($scores, static fn (int $score): bool => $score > 0));
+            $avg = $nonZeroScores !== [] ? round(array_sum($nonZeroScores) / count($nonZeroScores), 1) : 0.0;
+            $trend = count($scores) >= 2 ? ($scores[count($scores) - 1] - $scores[0]) : 0;
+
+            return [
+                'name' => $weapon->name,
+                'type' => $weapon->weapon_type?->value ? ucfirst($weapon->weapon_type->value) : '—',
+                'caliber' => (string) ($weapon->caliber ?? ''),
+                'avg' => $avg,
+                'sessions' => $orderedSessionIds->count(),
+                'shots' => $shots,
+                'trend' => $trend,
+                'series' => $scores,
+            ];
+        });
     }
 
     private function userSessions(): Builder

--- a/app/Services/RangeConsoleSummaryService.php
+++ b/app/Services/RangeConsoleSummaryService.php
@@ -240,6 +240,73 @@ final class RangeConsoleSummaryService
         });
     }
 
+    /**
+     * Voortgang per discipline (leergebied) = wapentype + afstand. Per discipline:
+     * aantal sessies, totaal schoten, gem. sessiescore, een chronologische
+     * score-reeks (voor de sparkline) en de trend (laatste − eerste).
+     *
+     * @return Collection<int, array{label: string, sessions: int, shots: int, avg: float, trend: int, series: array<int, int>}>
+     */
+    public function disciplineProgress(int $limit = 6): Collection
+    {
+        $sessions = $this->userSessions()
+            ->with(['sessionWeapons.weapon:id,weapon_type'])
+            ->orderBy('date')
+            ->orderBy('id')
+            ->get(['id', 'date']);
+
+        if ($sessions->isEmpty()) {
+            return collect();
+        }
+
+        $stats = SessionShot::query()
+            ->whereIn('session_id', $sessions->pluck('id'))
+            ->selectRaw('session_id, SUM(score) as total, COUNT(*) as shots')
+            ->groupBy('session_id')
+            ->get()
+            ->keyBy('session_id');
+
+        $grouped = [];
+
+        foreach ($sessions as $session) {
+            $entry = $session->sessionWeapons->first();
+            $type = $entry?->weapon?->weapon_type?->value;
+
+            if ($type === null) {
+                continue;
+            }
+
+            $distance = $entry->distance_m;
+            $label = ucfirst($type).($distance ? " {$distance}m" : '');
+            $stat = $stats->get($session->id);
+
+            $grouped[$label] ??= ['sessions' => 0, 'shots' => 0, 'series' => []];
+            $grouped[$label]['sessions']++;
+            $grouped[$label]['shots'] += (int) ($stat->shots ?? 0);
+            $grouped[$label]['series'][] = (int) ($stat->total ?? 0);
+        }
+
+        return collect($grouped)
+            ->map(function (array $data, string $label): array {
+                $nonZero = array_values(array_filter($data['series'], static fn (int $score): bool => $score > 0));
+                $avg = $nonZero !== [] ? round(array_sum($nonZero) / count($nonZero), 1) : 0.0;
+                $series = $data['series'];
+                $trend = count($series) >= 2 ? ($series[count($series) - 1] - $series[0]) : 0;
+
+                return [
+                    'label' => $label,
+                    'sessions' => $data['sessions'],
+                    'shots' => $data['shots'],
+                    'avg' => $avg,
+                    'trend' => $trend,
+                    'series' => $series,
+                ];
+            })
+            ->sortByDesc('sessions')
+            ->values()
+            ->take($limit);
+    }
+
     private function userSessions(): Builder
     {
         return Session::query()->where('user_id', $this->user->getKey());

--- a/app/Services/ScoreDriftService.php
+++ b/app/Services/ScoreDriftService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\SessionShot;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Score-drift: de gemiddelde score per schot-positie over de laatste N sessies
+ * van een schutter. Maakt zichtbaar wáár in een sessie de score wegzakt
+ * (bv. de typische concentratiedip rond schot 30–40 uit het ontwerp).
+ */
+final class ScoreDriftService
+{
+    public function __construct(private readonly User $user) {}
+
+    /**
+     * Gemiddelde score per 1-based schot-positie over de laatste $sessions
+     * sessies (alleen sessies met schoten). Leeg bij onvoldoende data.
+     *
+     * @return array<int, float>
+     */
+    public function perShotAverage(int $sessions = 6): array
+    {
+        $sessionIds = $this->user->sessions()
+            ->whereHas('shots')
+            ->orderByDesc('date')
+            ->orderByDesc('id')
+            ->limit($sessions)
+            ->pluck('id');
+
+        if ($sessionIds->isEmpty()) {
+            return [];
+        }
+
+        $byPosition = SessionShot::query()
+            ->whereIn('session_id', $sessionIds)
+            ->orderBy('session_id')
+            ->orderBy('turn_index')
+            ->orderBy('shot_index')
+            ->orderBy('id')
+            ->get(['session_id', 'score'])
+            ->groupBy('session_id')
+            ->reduce(function (array $carry, Collection $shots): array {
+                foreach ($shots->values() as $position => $shot) {
+                    $carry[$position + 1][] = (int) $shot->score;
+                }
+
+                return $carry;
+            }, []);
+
+        ksort($byPosition);
+
+        return array_map(
+            static fn (array $scores): float => round(array_sum($scores) / count($scores), 2),
+            $byPosition,
+        );
+    }
+
+    /**
+     * Zwakste aaneengesloten venster van $window schoten (laagste gemiddelde).
+     * Returnt null bij minder posities dan $window.
+     *
+     * @return array{from: int, to: int, average: float}|null
+     */
+    public function weakestWindow(int $window = 10, int $sessions = 6): ?array
+    {
+        $averages = $this->perShotAverage($sessions);
+        $positions = array_keys($averages);
+
+        if (count($positions) < $window) {
+            return null;
+        }
+
+        $values = array_values($averages);
+        $bestStart = 0;
+        $bestSum = null;
+
+        for ($i = 0; $i + $window <= count($values); $i++) {
+            $sum = array_sum(array_slice($values, $i, $window));
+
+            if ($bestSum === null || $sum < $bestSum) {
+                $bestSum = $sum;
+                $bestStart = $i;
+            }
+        }
+
+        return [
+            'from' => $positions[$bestStart],
+            'to' => $positions[$bestStart + $window - 1],
+            'average' => round($bestSum / $window, 2),
+        ];
+    }
+}

--- a/app/Services/SessionStatsService.php
+++ b/app/Services/SessionStatsService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Models\Session;
+use App\Models\SessionShot;
 use Illuminate\Support\Collection;
 
 /**
@@ -190,6 +191,79 @@ final class SessionStatsService
         }
 
         return [$minIndex * $perSerie, ($minIndex + 1) * $perSerie - 1];
+    }
+
+    /**
+     * Gemiddelde horizontale afwijking t.o.v. het roos-centrum in mm
+     * (negatief = links). Geschaald naar een ISSF 10m target (155.5mm).
+     */
+    public function meanXmm(): ?float
+    {
+        return $this->meanOffsetMm('x_normalized');
+    }
+
+    /**
+     * Gemiddelde verticale afwijking t.o.v. het centrum in mm (negatief = laag).
+     */
+    public function meanYmm(): ?float
+    {
+        return $this->meanOffsetMm('y_normalized');
+    }
+
+    /**
+     * Spreiding (1σ) van de hits in mm. Returnt null bij <2 shots.
+     */
+    public function sdMm(): ?float
+    {
+        $shots = $this->shots();
+
+        if ($shots->count() < 2) {
+            return null;
+        }
+
+        $xs = $shots->pluck('x_normalized')->map(fn ($v): float => (float) $v)->all();
+        $ys = $shots->pluck('y_normalized')->map(fn ($v): float => (float) $v)->all();
+
+        return round(sqrt($this->variance($xs) + $this->variance($ys)) * 155.5, 1);
+    }
+
+    private function meanOffsetMm(string $column): ?float
+    {
+        $shots = $this->shots();
+
+        if ($shots->count() < 1) {
+            return null;
+        }
+
+        $mean = $shots->pluck($column)->map(fn ($v): float => (float) $v)->avg();
+
+        return round(((float) $mean - 0.5) * 155.5, 1);
+    }
+
+    /**
+     * Verschil tussen deze eindscore en het gemiddelde van álle sessies van
+     * de schutter (▲/▼ vs gem.). Returnt null bij <2 sessies-met-schoten of
+     * geen schoten in deze sessie.
+     */
+    public function scoreVsAverage(): ?int
+    {
+        if ($this->totalShots() === 0) {
+            return null;
+        }
+
+        $totals = SessionShot::query()
+            ->whereIn('session_id', Session::query()
+                ->where('user_id', $this->session->user_id)
+                ->select('id'))
+            ->groupBy('session_id')
+            ->selectRaw('session_id, SUM(score) as total')
+            ->pluck('total');
+
+        if ($totals->count() < 2) {
+            return null;
+        }
+
+        return (int) round($this->totalScore() - (float) $totals->avg());
     }
 
     private function shots(): Collection

--- a/app/Services/TrainingGoalService.php
+++ b/app/Services/TrainingGoalService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\TrainingGoalSource;
+use App\Models\TrainingGoal;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Beheert trainingsdoelen van een schutter. Doelen komen van de gebruiker zelf
+ * (manual) of van de AI-coach (ai, via de Copilot-tool) — zie het ontwerp
+ * "Voorgestelde doelen" + "Voeg doel toe".
+ */
+final class TrainingGoalService
+{
+    /**
+     * Open (niet-afgeronde) doelen, nieuwste eerst.
+     *
+     * @return Collection<int, TrainingGoal>
+     */
+    public function openGoals(User $user, int $limit = 5): Collection
+    {
+        return $user->trainingGoals()
+            ->open()
+            ->latest()
+            ->latest('id')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function add(
+        User $user,
+        string $title,
+        ?string $detail = null,
+        TrainingGoalSource $source = TrainingGoalSource::Manual,
+        ?string $targetMonth = null,
+        ?int $sessionId = null,
+        ?int $weaponId = null,
+    ): TrainingGoal {
+        return $user->trainingGoals()->create([
+            'title' => $title,
+            'detail' => $detail,
+            'source' => $source,
+            'target_month' => $targetMonth,
+            'session_id' => $sessionId,
+            'weapon_id' => $weaponId,
+        ]);
+    }
+
+    public function complete(TrainingGoal $goal): TrainingGoal
+    {
+        if ($goal->completed_at === null) {
+            $goal->update(['completed_at' => now()]);
+        }
+
+        return $goal;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
-            "@php artisan filament:assets --ansi"
+            "@php artisan filament:assets --ansi",
+            "@php artisan vendor:publish --tag=filament-copilot-assets --force --ansi"
         ],
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""

--- a/config/filament-copilot.php
+++ b/config/filament-copilot.php
@@ -135,6 +135,7 @@ return [
 
     'global_tools' => [
         \App\Filament\Copilot\Tools\ShooterContextTool::class,
+        \App\Filament\Copilot\Tools\AddTrainingGoalTool::class,
     ],
 
 ];

--- a/config/filament-copilot.php
+++ b/config/filament-copilot.php
@@ -136,6 +136,7 @@ return [
     'global_tools' => [
         \App\Filament\Copilot\Tools\ShooterContextTool::class,
         \App\Filament\Copilot\Tools\AddTrainingGoalTool::class,
+        \App\Filament\Copilot\Tools\ScoreDriftTool::class,
     ],
 
 ];

--- a/database/factories/TrainingGoalFactory.php
+++ b/database/factories/TrainingGoalFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\TrainingGoalSource;
+use App\Models\TrainingGoal;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TrainingGoal>
+ */
+class TrainingGoalFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'title' => rtrim($this->faker->sentence(4), '.'),
+            'detail' => $this->faker->optional()->sentence(),
+            'source' => TrainingGoalSource::Manual,
+            'target_month' => now()->format('Y-m'),
+            'session_id' => null,
+            'weapon_id' => null,
+            'completed_at' => null,
+        ];
+    }
+
+    public function ai(): static
+    {
+        return $this->state(fn (): array => ['source' => TrainingGoalSource::Ai]);
+    }
+
+    public function completed(): static
+    {
+        return $this->state(fn (): array => ['completed_at' => now()]);
+    }
+}

--- a/database/migrations/2026_06_05_193919_add_acknowledged_at_to_ai_reflections_table.php
+++ b/database/migrations/2026_06_05_193919_add_acknowledged_at_to_ai_reflections_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ai_reflections', function (Blueprint $table): void {
+            $table->timestamp('acknowledged_at')->nullable()->after('next_focus');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ai_reflections', function (Blueprint $table): void {
+            $table->dropColumn('acknowledged_at');
+        });
+    }
+};

--- a/database/migrations/2026_06_05_194239_create_training_goals_table.php
+++ b/database/migrations/2026_06_05_194239_create_training_goals_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('training_goals', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('title');
+            $table->text('detail')->nullable();
+            $table->string('source')->default('manual'); // ai | manual
+            $table->string('target_month', 7)->nullable(); // bv. '2026-06'
+            $table->foreignId('session_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('weapon_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'completed_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('training_goals');
+    }
+};

--- a/database/migrations/2026_06_05_211051_add_is_admin_to_users_table.php
+++ b/database/migrations/2026_06_05_211051_add_is_admin_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->boolean('is_admin')->default(false)->after('email_verified_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/database/seeders/CopilotDemoSeeder.php
+++ b/database/seeders/CopilotDemoSeeder.php
@@ -24,6 +24,7 @@ class CopilotDemoSeeder extends Seeder
                 'name' => 'Demo Schutter',
                 'password' => Hash::make('admin12345'),
                 'email_verified_at' => now(),
+                'is_admin' => true,
             ],
         );
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,11 @@ fi
 
 php artisan storage:link --ansi >/dev/null 2>&1 || true
 
+# FilamentCopilot publiceert zijn CSS/JS naar public/vendor/filament-copilot via
+# vendor:publish (niet via filament:assets). Zonder deze stap rendert de
+# AI-chat-widget niet. In alle omgevingen draaien (idempotent met --force).
+php artisan vendor:publish --tag=filament-copilot-assets --force --ansi >/dev/null 2>&1 || true
+
 if [ "${APP_ENV:-local}" = "local" ]; then
     php artisan filament:assets --ansi >/dev/null 2>&1 || true
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1803 @@
+{
+    "name": "app",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "devDependencies": {
+                "@tailwindcss/vite": "^4.0.0",
+                "laravel-vite-plugin": "^1.2.0",
+                "tailwindcss": "^4.0.0",
+                "vite": "^6.0.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+            "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+            "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+            "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+            "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+            "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+            "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+            "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+            "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+            "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+            "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+            "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+            "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+            "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+            "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+            "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+            "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+            "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+            "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+            "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+            "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+            "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+            "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+            "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+            "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+            "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@tailwindcss/node": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+            "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "enhanced-resolve": "^5.21.0",
+                "jiti": "^2.6.1",
+                "lightningcss": "1.32.0",
+                "magic-string": "^0.30.21",
+                "source-map-js": "^1.2.1",
+                "tailwindcss": "4.3.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+            "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "optionalDependencies": {
+                "@tailwindcss/oxide-android-arm64": "4.3.0",
+                "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+                "@tailwindcss/oxide-darwin-x64": "4.3.0",
+                "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+                "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+                "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-android-arm64": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+            "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-arm64": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+            "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-x64": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+            "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-freebsd-x64": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+            "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+            "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+            "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+            "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+            "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+            "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+            "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+            "bundleDependencies": [
+                "@napi-rs/wasm-runtime",
+                "@emnapi/core",
+                "@emnapi/runtime",
+                "@tybys/wasm-util",
+                "@emnapi/wasi-threads",
+                "tslib"
+            ],
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.10.0",
+                "@emnapi/runtime": "^1.10.0",
+                "@emnapi/wasi-threads": "^1.2.1",
+                "@napi-rs/wasm-runtime": "^1.1.4",
+                "@tybys/wasm-util": "^0.10.1",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+            "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+            "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/vite": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+            "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tailwindcss/node": "4.3.0",
+                "@tailwindcss/oxide": "4.3.0",
+                "tailwindcss": "4.3.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.2.0 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.23.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
+            "integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/jiti": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/laravel-vite-plugin": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-1.3.0.tgz",
+            "integrity": "sha512-P5qyG56YbYxM8OuYmK2OkhcKe0AksNVJUjq9LUZ5tOekU9fBn9LujYyctI4t9XoLjuMvHJXXpCoPntY1oKltuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "vite-plugin-full-reload": "^1.1.0"
+            },
+            "bin": {
+                "clean-orphaned-assets": "bin/clean.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.12",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+            "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.61.1",
+                "@rollup/rollup-android-arm64": "4.61.1",
+                "@rollup/rollup-darwin-arm64": "4.61.1",
+                "@rollup/rollup-darwin-x64": "4.61.1",
+                "@rollup/rollup-freebsd-arm64": "4.61.1",
+                "@rollup/rollup-freebsd-x64": "4.61.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+                "@rollup/rollup-linux-arm64-musl": "4.61.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+                "@rollup/rollup-linux-loong64-musl": "4.61.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+                "@rollup/rollup-linux-x64-gnu": "4.61.1",
+                "@rollup/rollup-linux-x64-musl": "4.61.1",
+                "@rollup/rollup-openbsd-x64": "4.61.1",
+                "@rollup/rollup-openharmony-arm64": "4.61.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+                "@rollup/rollup-win32-x64-gnu": "4.61.1",
+                "@rollup/rollup-win32-x64-msvc": "4.61.1",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/tailwindcss": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+            "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tapable": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/vite": {
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
+                "postcss": "^8.5.3",
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "jiti": ">=1.21.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-full-reload": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
+            "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build"
+    },
+    "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "laravel-vite-plugin": "^1.2.0",
+        "tailwindcss": "^4.0.0",
+        "vite": "^6.0.0"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,8 +16,13 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="sqlite" force="true"/>
+        <env name="DB_DATABASE" value=":memory:" force="true"/>
+        <!-- Laravel leest env uit $_SERVER; de dev-container injecteert
+             DB_CONNECTION=pgsql via env_file. <server force> overschrijft dat
+             zodat tests nooit tegen de dev-DB draaien (en die wissen). -->
+        <server name="DB_CONNECTION" value="sqlite" force="true"/>
+        <server name="DB_DATABASE" value=":memory:" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,0 +1,6 @@
+@import 'tailwindcss';
+
+/*
+ * Algemene front-end entry (welcome/landing). De Filament-admin gebruikt een
+ * eigen theme: resources/css/filament/admin/theme.css (via ->viteTheme()).
+ */

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -1,0 +1,78 @@
+@import '../../../../vendor/filament/filament/resources/css/theme.css';
+
+@source '../../../../app/Filament/**/*';
+@source '../../../../resources/views/filament/**/*';
+@source '../../../../resources/views/components/aimtrack/**/*';
+
+/*
+ * AimTrack · Signal Mint dark — Filament admin theme
+ *
+ * Bron van waarheid voor de tokens: resources/css/aimtrack-tokens.css en
+ * .ai/design-handoff/project/design-tokens.jsx (issue #82).
+ *
+ * Strategie: Filament's chrome (sidebar/topbar/tabellen/badges/wizard/velden)
+ * gebruikt Tailwind's grijs-schaal (dark:bg-gray-900, border-gray-700, ...).
+ * Door --color-gray-* te hermappen naar de Signal-Mint darks rendert de hele
+ * panel-chrome in het juiste palet i.p.v. Filament's neutrale default —
+ * dat lost root cause R1 op zonder per-component te vechten met specificity.
+ */
+@theme {
+    --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    --mono-font-family: 'JetBrains Mono';
+
+    /* Grijs-schaal → Signal Mint (50 = lichtste tekst, 950 = diepste bg) */
+    --color-gray-50: #e9f0ff;
+    --color-gray-100: #dbe5fb;
+    --color-gray-200: #c2d0ee;
+    --color-gray-300: #a7b6dc;
+    --color-gray-400: #94a3c5; /* --muted */
+    --color-gray-500: #6f7ea6;
+    --color-gray-600: #4a5780;
+    --color-gray-700: #1c2543; /* --line */
+    --color-gray-800: #131c34; /* --panel-2 */
+    --color-gray-900: #0c1428; /* --panel */
+    --color-gray-950: #040711; /* --bg */
+}
+
+/*
+ * Tactical-shell accenten die niet uit de grijs-hermapping volgen.
+ * Bewust beperkt en op stabiele Filament v5 .fi-* hooks.
+ */
+@layer components {
+    /* Nav-groeplabels: mono, uppercase, wijd gespatieerd (LOG / INZICHT / BEHEER) */
+    .fi-sidebar-group-label {
+        font-family: var(--at-font-mono);
+        font-size: 0.625rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--at-muted);
+    }
+
+    /* Actief nav-item: 2px accent-rand links + zwaardere tekst */
+    .fi-sidebar-item.fi-active > .fi-sidebar-item-button,
+    .fi-sidebar-item-active > .fi-sidebar-item-button {
+        border-left: 2px solid var(--at-accent);
+        background-color: var(--at-panel-2);
+        font-weight: 600;
+    }
+
+    /* Nav-badges in mono */
+    .fi-sidebar-item-badge,
+    .fi-badge {
+        font-family: var(--at-font-mono);
+        letter-spacing: 0.05em;
+    }
+
+    /* Topbar + sidebar: scherpe 1px hairlines in --line */
+    .fi-topbar,
+    .fi-sidebar {
+        border-color: var(--at-line);
+    }
+
+    /* Mono op numerieke data: KPI-waardes, tabel-cijferkolommen */
+    .fi-ta-text-item.fi-ta-text-item-numeric,
+    .fi-in-text-item-numeric {
+        font-family: var(--at-font-mono);
+        letter-spacing: -0.01em;
+    }
+}

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -1,8 +1,14 @@
 @import '../../../../vendor/filament/filament/resources/css/theme.css';
 
-@source '../../../../app/Filament/**/*';
-@source '../../../../resources/views/filament/**/*';
-@source '../../../../resources/views/components/aimtrack/**/*';
+/*
+ * Filament importeert Tailwind met source(none): alléén deze @source-paden
+ * worden gescand. Dek daarom ALLE Blade-views (incl. resources/views/livewire,
+ * waar o.a. het interactieve schotenbord staat) + app/**, anders worden
+ * utility-classes als aspect-square / lg:flex-row / inset-0 weggepurged en
+ * klapt de roos-canvas in.
+ */
+@source '../../../../app/**/*.php';
+@source '../../../../resources/views/**/*.blade.php';
 
 /*
  * AimTrack · Signal Mint dark — Filament admin theme

--- a/resources/css/filament/admin/theme.css
+++ b/resources/css/filament/admin/theme.css
@@ -76,3 +76,85 @@
         letter-spacing: -0.01em;
     }
 }
+
+/*
+ * Filament dark gebruikt witte alpha-kleuren (white/5, white/10, white/20)
+ * voor randen, scheidingen, rings en hover-tints. Op het Signal-Mint donker
+ * geven die een "gewassen" lichte look i.p.v. de scherpe --line/--panel-2.
+ * --color-white kan niet globaal hergemapt worden (tekst gebruikt text-white),
+ * dus we herkleuren de zichtbare oppervlakken gericht. Laatste in de
+ * components-layer → wint op gelijke specificiteit van de vendor-regels.
+ */
+@layer components {
+    /* Omkaderde oppervlakken: vervang de witte ring + schaduw door --line */
+    .fi-section:not(.fi-section-not-contained),
+    .fi-ta-ctn,
+    .fi-dropdown-panel,
+    .fi-modal-window,
+    .fi-wi-stats-overview-stat {
+        --tw-ring-color: var(--at-line);
+        box-shadow: none;
+    }
+
+    /* Section/widget header- en footer-scheidingen + header-tint */
+    .fi-section-header,
+    .fi-section-footer,
+    .fi-section-content-ctn,
+    .fi-ta-header,
+    .fi-ta-footer {
+        border-color: var(--at-line) !important;
+    }
+
+    .fi-section.fi-collapsible > .fi-section-header:hover,
+    .fi-ta-header-toolbar {
+        background-color: transparent;
+    }
+
+    /* Tabel: rij-scheidingen + header-cel-randen → --line; hover → --panel-2 */
+    .fi-ta-table {
+        border-color: var(--at-line) !important;
+    }
+
+    .fi-ta-table > tbody > tr,
+    .fi-ta-table > thead > tr > th,
+    .fi-ta-header-cell {
+        border-color: var(--at-line) !important;
+    }
+
+    .fi-ta-row:hover,
+    .fi-ta-row.fi-selected {
+        background-color: var(--at-panel-2) !important;
+    }
+
+    /* Tabel-kolomkoppen in mono-uppercase (design: dense tactical grid) */
+    .fi-ta-header-cell-label {
+        font-family: var(--at-font-mono);
+        font-size: 0.625rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--at-muted);
+        font-weight: 500;
+    }
+
+    /* Inputs / search: donkere achtergrond + --line rand i.p.v. witte ring */
+    .fi-input-wrp {
+        --tw-ring-color: var(--at-line);
+        background-color: var(--at-bg);
+    }
+
+    .fi-input-wrp:focus-within {
+        --tw-ring-color: var(--at-accent);
+    }
+
+    /* Dropdown-items hover-tint */
+    .fi-dropdown-list-item:hover {
+        background-color: var(--at-panel-2);
+    }
+
+    /* Paginatie-knoppen + tab-pills randen */
+    .fi-pagination .fi-btn,
+    .fi-tabs {
+        --tw-ring-color: var(--at-line);
+        border-color: var(--at-line);
+    }
+}

--- a/resources/views/components/aimtrack/ai-reflection-card.blade.php
+++ b/resources/views/components/aimtrack/ai-reflection-card.blade.php
@@ -30,7 +30,9 @@
     {{ $attributes->merge(['class' => 'aimtrack-ai-reflection-card', 'style' => 'display: flex; flex-direction: column; gap: 12px;']) }}
 >
     <div style="display: flex; align-items: center; gap: 8px; font-size: 11px; font-family: var(--at-font-mono); letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-accent);">
-        <span role="presentation">✦</span>
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--at-accent)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" role="presentation">
+            <path d="M12 3l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z" />
+        </svg>
         <span>AI-reflectie {{ $headerSub }}</span>
         @if ($tsLabel)
             <span style="margin-left: auto; color: var(--at-muted);">{{ $tsLabel }}</span>

--- a/resources/views/components/aimtrack/shot-strip.blade.php
+++ b/resources/views/components/aimtrack/shot-strip.blade.php
@@ -69,7 +69,7 @@
         <div style="display: flex; gap: 18px; margin-top: 12px; font-size: 11px; color: var(--at-muted); font-family: var(--at-font-mono);">
             <span><span style="display: inline-block; width: 8px; height: 8px; background: var(--at-accent); margin-right: 6px;"></span>10+ ringen</span>
             @if ($dipFrom !== null)
-                <span><span style="display: inline-block; width: 8px; height: 8px; background: color-mix(in srgb, var(--at-warn) 70%, transparent); margin-right: 6px;"></span>dip {{ $dipFrom + 1 }}–{{ $dipTo + 1 }}</span>
+                <span><span style="display: inline-block; width: 8px; height: 8px; background: color-mix(in srgb, var(--at-warn) 70%, transparent); margin-right: 6px;"></span>concentratiedip {{ $dipFrom + 1 }}–{{ $dipTo + 1 }}</span>
             @endif
             <span><span style="display: inline-block; width: 8px; height: 8px; background: color-mix(in srgb, var(--at-muted) 40%, transparent); margin-right: 6px;"></span>normaal</span>
         </div>

--- a/resources/views/components/aimtrack/sparkline.blade.php
+++ b/resources/views/components/aimtrack/sparkline.blade.php
@@ -22,15 +22,22 @@
     $range = max(0.0001, $max - $min);
 
     $points = [];
+    $lastX = $width / 2;
+    $lastY = $height / 2;
     foreach ($values as $i => $v) {
         $x = count($values) <= 1 ? $width / 2 : ($i / (count($values) - 1)) * $width;
         $y = $height - 2 - (($v - $min) / $range) * ($height - 6);
         $points[] = $fmt($x).','.$fmt($y);
+        $lastX = $x;
+        $lastY = $y;
     }
     $polyline = implode(' ', $points);
     $areaPath = $hasData
         ? "M{$points[0]} L".implode(' L', array_slice($points, 1))." L{$fmt($width)},{$fmt($height)} L0,{$fmt($height)} Z"
         : '';
+
+    // Unieke gradient-id per render (kleur kan een CSS-var zijn, dus niet bruikbaar in een id).
+    $gradientId = 'atspark-'.substr(md5($color.$width.$height.$polyline), 0, 10);
 @endphp
 
 <svg
@@ -43,9 +50,16 @@
 >
     @if ($hasData)
         @if ($fill)
-            <path d="{{ $areaPath }}" fill="{{ $color }}" opacity="0.12" />
+            <defs>
+                <linearGradient id="{{ $gradientId }}" x1="0" x2="0" y1="0" y2="1">
+                    <stop offset="0%" stop-color="{{ $color }}" stop-opacity="0.35" />
+                    <stop offset="100%" stop-color="{{ $color }}" stop-opacity="0" />
+                </linearGradient>
+            </defs>
+            <path d="{{ $areaPath }}" fill="url(#{{ $gradientId }})" />
         @endif
         <polyline points="{{ $polyline }}" fill="none" stroke="{{ $color }}" stroke-width="{{ $fmt($strokeWidth) }}" stroke-linejoin="round" stroke-linecap="round" />
+        <circle cx="{{ $fmt($lastX) }}" cy="{{ $fmt($lastY) }}" r="2.5" fill="{{ $color }}" />
     @else
         <line x1="0" y1="{{ $fmt($height / 2) }}" x2="{{ $fmt($width) }}" y2="{{ $fmt($height / 2) }}" stroke="var(--at-line)" stroke-width="1" stroke-dasharray="3 4" />
     @endif

--- a/resources/views/components/aimtrack/target-rings.blade.php
+++ b/resources/views/components/aimtrack/target-rings.blade.php
@@ -1,23 +1,32 @@
 @props([
     'size' => 200,
-    'rings' => 10,
+    'rings' => 8,
     'accent' => null,
     'dim' => null,
     'ringStroke' => 1,
     'hits' => [],
     'scoreLabels' => false,
+    'hitScale' => 0.35,
 ])
 
 @php
+    // Faithful port of .ai/design-handoff/project/shared.jsx · TargetRings:
+    // 8 concentric rings (10 = outer, emphasized; 3 = inner), dim fill on the
+    // innermost rings, a center 10-ring dot, a dashed crosshair, score labels
+    // for the top rings, and hit dots scaled by `hitScale` so a real shot
+    // group reads as a tight cluster (the *0.35 damping the prototype uses)
+    // instead of spreading to the rim.
     $size = (float) $size;
     $rings = max(2, (int) $rings);
     $accent = $accent ?? 'var(--at-accent)';
     $dim = $dim ?? 'var(--at-text)';
     $ringStroke = (float) $ringStroke;
+    $hitScale = (float) $hitScale;
 
     $cx = $size / 2;
     $cy = $size / 2;
     $maxR = $size * 0.46;
+    $highest = $rings + 2; // 8 rings → numbered 10..3
     $hits = is_iterable($hits) ? (is_array($hits) ? $hits : iterator_to_array($hits)) : [];
 
     $fmt = static fn (float $value): string => rtrim(rtrim(number_format($value, 3, '.', ''), '0'), '.');
@@ -31,38 +40,52 @@
     role="img"
     aria-label="Hit-patroon"
 >
-    @for ($i = $rings; $i >= 1; $i--)
+    @for ($i = 0; $i < $rings; $i++)
         @php
-            $r = $maxR * ($i / $rings);
-            $isCenter = $i <= 2;
-            $stroke = $isCenter ? $accent : $dim;
-            $opacity = $isCenter ? 0.7 : 0.32;
+            $n = $highest - $i;
+            $r = $maxR * (($rings - $i) / $rings);
+            $hasFill = $n <= 4;
         @endphp
         <circle
             cx="{{ $fmt($cx) }}"
             cy="{{ $fmt($cy) }}"
             r="{{ $fmt($r) }}"
-            fill="none"
-            stroke="{{ $stroke }}"
+            fill="{{ $hasFill ? $dim : 'none' }}"
+            fill-opacity="{{ $hasFill ? '0.06' : '0' }}"
+            stroke="{{ $dim }}"
+            stroke-opacity="{{ $fmt($n === $highest ? 0.55 : 0.22) }}"
             stroke-width="{{ $fmt($ringStroke) }}"
-            opacity="{{ $fmt((float) $opacity) }}"
         />
     @endfor
 
+    {{-- Center 10-ring dot --}}
+    <circle
+        cx="{{ $fmt($cx) }}"
+        cy="{{ $fmt($cy) }}"
+        r="{{ $fmt($maxR / $rings * 0.5) }}"
+        fill="{{ $dim }}"
+        fill-opacity="0.18"
+    />
+
+    {{-- Crosshair (dashed) --}}
+    <line x1="{{ $fmt($cx - $maxR * 1.05) }}" y1="{{ $fmt($cy) }}" x2="{{ $fmt($cx + $maxR * 1.05) }}" y2="{{ $fmt($cy) }}"
+        stroke="{{ $dim }}" stroke-opacity="0.18" stroke-width="{{ $fmt($ringStroke) }}" stroke-dasharray="2 4" />
+    <line x1="{{ $fmt($cx) }}" y1="{{ $fmt($cy - $maxR * 1.05) }}" x2="{{ $fmt($cx) }}" y2="{{ $fmt($cy + $maxR * 1.05) }}"
+        stroke="{{ $dim }}" stroke-opacity="0.18" stroke-width="{{ $fmt($ringStroke) }}" stroke-dasharray="2 4" />
+
     @if ($scoreLabels)
-        @for ($i = 1; $i <= $rings; $i++)
-            @php
-                $r = $maxR * ($i / $rings) - ($maxR / $rings) * 0.5;
-                $labelY = $cy + $r;
-                $value = $rings - $i + 1;
-            @endphp
-            <text
-                x="{{ $fmt($cx) }}"
-                y="{{ $fmt($labelY + 3) }}"
-                text-anchor="middle"
-                fill="var(--at-muted)"
-                style="font-family: var(--at-font-mono); font-size: 8px; letter-spacing: 0.06em;"
-            >{{ $value }}</text>
+        @for ($i = 0; $i < $rings; $i++)
+            @php $n = $highest - $i; @endphp
+            @if ($n >= 7)
+                @php $r = $maxR * (($rings - $i) / $rings); @endphp
+                <text
+                    x="{{ $fmt($cx + 4) }}"
+                    y="{{ $fmt($cy - $r + 10) }}"
+                    fill="{{ $dim }}"
+                    fill-opacity="0.45"
+                    style="font-family: var(--at-font-mono); font-size: 9px; letter-spacing: 0.04em;"
+                >{{ $n }}</text>
+            @endif
         @endfor
     @endif
 
@@ -71,17 +94,29 @@
             $hx = (float) ($hit['x'] ?? 0);
             $hy = (float) ($hit['y'] ?? 0);
             $hr = isset($hit['r']) ? (float) $hit['r'] : null;
-            $px = $cx + ($hx * $maxR);
-            $py = $cy + ($hy * $maxR);
-            $color = ($hr !== null && $hr >= 10) ? $accent : 'var(--at-text)';
-            $dotR = max(2.0, $size * 0.012);
+            $px = $cx + ($hx * $maxR * $hitScale);
+            $py = $cy + ($hy * $maxR * $hitScale);
+            $isTen = $hr !== null && $hr >= 9.5;
+            $dotR = max(2.5, $size * 0.0145);
         @endphp
         <circle
             cx="{{ $fmt($px) }}"
             cy="{{ $fmt($py) }}"
             r="{{ $fmt($dotR) }}"
-            fill="{{ $color }}"
-            opacity="0.85"
+            fill="{{ $accent }}"
+            fill-opacity="{{ $isTen ? '0.95' : '0.55' }}"
+            @unless ($isTen) stroke="{{ $accent }}" stroke-width="0.5" @endunless
         />
+        @if ($isTen)
+            <circle
+                cx="{{ $fmt($px) }}"
+                cy="{{ $fmt($py) }}"
+                r="{{ $fmt($dotR * 1.9) }}"
+                fill="none"
+                stroke="{{ $accent }}"
+                stroke-opacity="0.35"
+                stroke-width="{{ $fmt($ringStroke) }}"
+            />
+        @endif
     @endforeach
 </svg>

--- a/resources/views/filament/pages/coach-page.blade.php
+++ b/resources/views/filament/pages/coach-page.blade.php
@@ -88,6 +88,7 @@
             $lastSession = $coach->lastSession();
             $topWeapon = $coach->topWeapon();
             $trainingGoals = $page->getTrainingGoals();
+            $scoreDrift = $page->getScoreDrift();
 
             $sampleQuestions = [
                 'Vergelijk met vorige maand',
@@ -151,10 +152,25 @@
                         <div class="at-label" style="margin-bottom: 8px;">VOORBEELDVRAGEN</div>
                         <div style="display: flex; gap: 8px; flex-wrap: wrap;">
                             @foreach ($sampleQuestions as $q)
-                                <span style="padding: 5px 10px; border-radius: 999px; border: 1px solid var(--at-line); color: var(--at-muted); font-size: 11px; font-family: var(--at-font-mono); letter-spacing: 0.04em;">{{ $q }}</span>
+                                <button
+                                    type="button"
+                                    x-on:click="window.dispatchEvent(new CustomEvent('copilot-open'))"
+                                    style="padding: 5px 10px; border-radius: 999px; border: 1px solid var(--at-line); background: transparent; color: var(--at-muted); font-size: 11px; font-family: var(--at-font-mono); letter-spacing: 0.04em; cursor: pointer;"
+                                >{{ $q }}</button>
                             @endforeach
                         </div>
                     </div>
+
+                    @if (count($scoreDrift) >= 2)
+                        <x-aimtrack.bracket-frame :rounded="8" :padding="16" style="display: flex; flex-direction: column; gap: 10px;">
+                            <div class="at-label" style="color: var(--at-accent);">SCORE-DRIFT · GEM. PER SCHOT · LAATSTE SESSIES</div>
+                            <x-aimtrack.sparkline :data="array_values($scoreDrift)" :width="520" :height="70" :stroke-width="2" :fill="true" color="var(--at-warn)" />
+                            <div style="display: flex; justify-content: space-between; font-family: var(--at-font-mono); font-size: 9px; color: var(--at-muted); letter-spacing: 0.14em;">
+                                <span>SCHOT {{ array_key_first($scoreDrift) }}</span>
+                                <span>SCHOT {{ array_key_last($scoreDrift) }}</span>
+                            </div>
+                        </x-aimtrack.bracket-frame>
+                    @endif
 
                     <div style="margin-top: auto; display: flex; align-items: center; gap: 10px;">
                         <button

--- a/resources/views/filament/pages/coach-page.blade.php
+++ b/resources/views/filament/pages/coach-page.blade.php
@@ -90,12 +90,12 @@
             $trainingGoals = $page->getTrainingGoals();
             $scoreDrift = $page->getScoreDrift();
 
-            $sampleQuestions = [
+            $sampleQuestions = array_values(array_filter([
                 'Vergelijk met vorige maand',
-                'Wat trainen deze week?',
-                'Trekkerafstelling LP500',
-                'WM-4 status',
-            ];
+                'Wat moet ik deze week trainen?',
+                $topWeapon ? 'Trekkerafstelling '.$topWeapon->name : 'Hoe verbeter ik mijn groepering?',
+                $lastSession ? 'Reflectie op mijn laatste sessie' : null,
+            ]));
         @endphp
 
         <div data-testid="ai-coach-chat-ready" style="display: grid; grid-template-columns: 260px minmax(0, 1fr) 280px; gap: 16px; align-items: stretch; min-height: 540px;">

--- a/resources/views/filament/pages/coach-page.blade.php
+++ b/resources/views/filament/pages/coach-page.blade.php
@@ -87,6 +87,7 @@
             $latestConversation = $coach->latestConversation();
             $lastSession = $coach->lastSession();
             $topWeapon = $coach->topWeapon();
+            $trainingGoals = $page->getTrainingGoals();
 
             $sampleQuestions = [
                 'Vergelijk met vorige maand',
@@ -199,6 +200,33 @@
                         Geen sessies of wapens gevonden. De coach werkt nog zonder context.
                     </div>
                 @endunless
+
+                <div class="at-label" style="margin-top: 8px;">VOORGESTELDE DOELEN</div>
+                @forelse ($trainingGoals as $goal)
+                    <div wire:key="goal-{{ $goal->id }}" style="padding: 12px; background: var(--at-panel-2); border: 1px solid var(--at-line); border-radius: var(--at-r-md);">
+                        <div style="display: flex; align-items: flex-start; gap: 8px;">
+                            <button
+                                type="button"
+                                wire:click="completeGoal({{ $goal->id }})"
+                                title="Markeer als afgerond"
+                                style="flex: 0 0 16px; width: 16px; height: 16px; margin-top: 2px; border-radius: 4px; border: 1.5px solid var(--at-accent); background: transparent; cursor: pointer; padding: 0;"
+                            ></button>
+                            <div style="flex: 1; min-width: 0;">
+                                <div style="font-size: 12px; color: var(--at-text); font-weight: 600;">{{ $goal->title }}</div>
+                                @if (filled($goal->detail))
+                                    <div style="font-size: 11px; color: var(--at-muted); margin-top: 2px; line-height: 1.5;">{{ $goal->detail }}</div>
+                                @endif
+                                @if ($goal->source === \App\Enums\TrainingGoalSource::Ai)
+                                    <div style="font-family: var(--at-font-mono); font-size: 9px; color: var(--at-accent); letter-spacing: 0.08em; text-transform: uppercase; margin-top: 4px;">AI-suggestie</div>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                @empty
+                    <div style="font-size: 11px; color: var(--at-muted); line-height: 1.55;">
+                        Nog geen doelen. Vraag de coach om een trainingsdoel voor te stellen.
+                    </div>
+                @endforelse
 
                 <div class="at-label" style="margin-top: 8px;">PRIVACY</div>
                 <div style="font-size: 11px; color: var(--at-muted); line-height: 1.6;">

--- a/resources/views/filament/pages/dashboard-overview.blade.php
+++ b/resources/views/filament/pages/dashboard-overview.blade.php
@@ -1,0 +1,135 @@
+@php
+    /** @var \App\Filament\Pages\Dashboard $page */
+    $page = $this;
+    $summary = $page->getSummary();
+
+    $monthDelta = $summary->sessionsThisMonthDelta();
+    $monthDeltaLabel = $monthDelta >= 0 ? '+'.$monthDelta : (string) $monthDelta;
+    $bestSerie = $summary->bestSeriesScore();
+    $pending = $summary->pendingAiReflections();
+
+    $disciplines = $summary->disciplineProgress();
+    $goals = $page->getTrainingGoals();
+    $knsaLinks = $page->getKnsaLinks();
+@endphp
+
+<x-filament-panels::page>
+    <x-aimtrack.page-header
+        title="Dashboard"
+        subtitle="Je voortgang in één oogopslag — sessies, leergebieden en kennisbronnen."
+        :reticle-opacity="0.07"
+        :reticle-size="200"
+    />
+
+    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+        <x-aimtrack.stat-card
+            label="Sessies / mnd"
+            :value="(string) $summary->sessionsThisMonth()"
+            :sub="$monthDeltaLabel.' vs vorige maand'"
+            :sub-tone="$monthDelta >= 0 ? 'accent' : 'warn'"
+        />
+        <x-aimtrack.stat-card
+            label="Schoten (30d)"
+            :value="number_format($summary->shotsLast30d(), 0, ',', '.')"
+            sub="laatste 30 dagen"
+        />
+        <x-aimtrack.stat-card
+            label="Beste serie"
+            :value="$bestSerie !== null ? (string) $bestSerie : '—'"
+            :sub="$bestSerie !== null ? '10-shot serie' : 'geen volle serie'"
+            :value-tone="$bestSerie !== null ? 'accent' : 'muted'"
+        />
+        <x-aimtrack.stat-card
+            label="AI-reflecties"
+            :value="(string) $summary->aiReflectionCount()"
+            :sub="$pending > 0 ? $pending.' in wachtrij' : 'alles bijgewerkt'"
+        />
+    </div>
+
+    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
+        <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+            {{-- Leergebieden · voortgang per discipline --}}
+            <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--at-accent)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 17 9 11 13 14 21 6" /><polyline points="14 6 21 6 21 13" /></svg>
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Leergebieden · voortgang</div>
+                    <div class="at-label" style="margin-left: auto;">{{ $disciplines->count() }} disciplines</div>
+                </div>
+                @forelse ($disciplines as $discipline)
+                    <div style="display: flex; align-items: center; gap: 16px; padding: 14px 16px; @if (! $loop->last) border-bottom: 1px solid var(--at-line); @endif">
+                        <div style="flex: 1; min-width: 0;">
+                            <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">{{ $discipline['label'] }}</div>
+                            <div style="font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); margin-top: 2px;">{{ $discipline['sessions'] }} sessies · {{ $discipline['shots'] }} schoten</div>
+                        </div>
+                        <div style="text-align: right;">
+                            <div style="font-family: var(--at-font-mono); font-size: 18px; font-weight: 600; color: var(--at-text);">{{ $discipline['avg'] > 0 ? number_format($discipline['avg'], 1, ',', '.') : '—' }}</div>
+                            <div style="font-family: var(--at-font-mono); font-size: 10px; color: {{ $discipline['trend'] >= 0 ? 'var(--at-accent)' : 'var(--at-warn)' }};">
+                                {{ $discipline['trend'] >= 0 ? '▲ +'.$discipline['trend'] : '▼ '.$discipline['trend'] }}
+                            </div>
+                        </div>
+                        @if (count($discipline['series']) >= 2)
+                            <x-aimtrack.sparkline
+                                :data="$discipline['series']"
+                                :width="96"
+                                :height="36"
+                                :color="$discipline['trend'] >= 0 ? 'var(--at-accent)' : 'var(--at-warn)'"
+                            />
+                        @endif
+                    </div>
+                @empty
+                    <div style="padding: 24px 16px; color: var(--at-muted); font-size: 12px; text-align: center;">Nog geen disciplines om voortgang te tonen.</div>
+                @endforelse
+            </div>
+
+            {{-- Trainingsdoelen --}}
+            <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--at-accent)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9" /><circle cx="12" cy="12" r="5" /><circle cx="12" cy="12" r="1.2" fill="var(--at-accent)" /></svg>
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Trainingsdoelen</div>
+                    <a href="{{ \App\Filament\Pages\CoachPage::getUrl() }}" class="at-label" style="margin-left: auto; color: var(--at-accent); text-decoration: none;">AI-coach →</a>
+                </div>
+                @forelse ($goals as $goal)
+                    <div style="display: flex; align-items: flex-start; gap: 10px; padding: 12px 16px; @if (! $loop->last) border-bottom: 1px solid var(--at-line); @endif">
+                        <div style="flex: 0 0 16px; width: 16px; height: 16px; margin-top: 2px; border-radius: 4px; border: 1.5px solid var(--at-accent);"></div>
+                        <div style="flex: 1; min-width: 0;">
+                            <div style="font-size: 12px; color: var(--at-text); font-weight: 600;">{{ $goal->title }}</div>
+                            @if (filled($goal->detail))
+                                <div style="font-size: 11px; color: var(--at-muted); margin-top: 2px; line-height: 1.5;">{{ $goal->detail }}</div>
+                            @endif
+                        </div>
+                        @if ($goal->source === \App\Enums\TrainingGoalSource::Ai)
+                            <span style="font-family: var(--at-font-mono); font-size: 9px; color: var(--at-accent); letter-spacing: 0.08em; text-transform: uppercase;">AI</span>
+                        @endif
+                    </div>
+                @empty
+                    <div style="padding: 20px 16px; color: var(--at-muted); font-size: 12px;">Nog geen open doelen. Vraag de AI-coach om een trainingsdoel voor te stellen.</div>
+                @endforelse
+            </div>
+        </div>
+
+        {{-- KNSA kennisbank --}}
+        <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
+            <x-aimtrack.bracket-frame :rounded="8" :padding="0" style="overflow: hidden;">
+                <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--at-accent)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">KNSA · kennisbank</div>
+                </div>
+                @forelse ($knsaLinks as $link)
+                    <a href="{{ $link['url'] }}" target="_blank" rel="noopener noreferrer"
+                        style="display: block; padding: 12px 16px; text-decoration: none; @if (! $loop->last) border-bottom: 1px solid var(--at-line); @endif">
+                        <div style="display: flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600; color: var(--at-text);">
+                            {{ $link['title'] }}
+                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="var(--at-accent)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink: 0;"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" /></svg>
+                        </div>
+                        @if (! empty($link['description']))
+                            <div style="font-size: 11px; color: var(--at-muted); margin-top: 4px; line-height: 1.5;">{{ $link['description'] }}</div>
+                        @endif
+                    </a>
+                @empty
+                    <div style="padding: 20px 16px; color: var(--at-muted); font-size: 12px;">Geen KNSA-links geconfigureerd.</div>
+                @endforelse
+                <div style="padding: 10px 16px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em; border-top: 1px solid var(--at-line);">BRON · KNSA.NL</div>
+            </x-aimtrack.bracket-frame>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/failed-jobs-page.blade.php
+++ b/resources/views/filament/pages/failed-jobs-page.blade.php
@@ -1,0 +1,8 @@
+<x-filament-panels::page>
+    <p style="font-size: 12px; color: var(--at-muted); line-height: 1.55; margin-bottom: 4px;">
+        Technisch overzicht van mislukte queue-jobs (bv. AI-reflecties die niet konden worden gegenereerd).
+        Gebruik <span style="font-family: var(--at-font-mono); color: var(--at-text);">php artisan queue:retry</span> om te herplaatsen.
+    </p>
+
+    @livewire(\App\Filament\Widgets\FailedJobsWidget::class)
+</x-filament-panels::page>

--- a/resources/views/filament/resources/sessions/list-sessions.blade.php
+++ b/resources/views/filament/resources/sessions/list-sessions.blade.php
@@ -12,6 +12,7 @@
     $reflection = $summary->latestReflection();
     $trend = $summary->trend30d();
     $bestSerie = $summary->bestSeriesScore();
+    $weaponUsage = $summary->weaponUsage();
 @endphp
 
 <x-filament-panels::page>
@@ -47,9 +48,44 @@
         />
     </div>
 
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 16px; align-items: start;">
-        <div style="min-width: 0;">
+    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
+        <div style="min-width: 0; display: flex; flex-direction: column; gap: 16px;">
             {{ $this->table }}
+
+            @if ($weaponUsage->isNotEmpty())
+                <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
+                    <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--at-accent)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 14h13l3-3h2v6h-3l-2 2h-3l-1 2H7l-1-2H3z" />
+                            <path d="M9 14V9h4v5" />
+                        </svg>
+                        <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Wapens · gebruik</div>
+                        <div class="at-label" style="margin-left: auto;">{{ $weaponUsage->count() }} actief</div>
+                    </div>
+                    <div style="display: grid; grid-template-columns: repeat({{ min(3, max(1, $weaponUsage->count())) }}, 1fr);">
+                        @foreach ($weaponUsage as $weapon)
+                            <div style="padding: 16px; display: flex; flex-direction: column; gap: 8px; @if (! $loop->last) border-right: 1px solid var(--at-line); @endif">
+                                <div class="at-label">{{ $weapon['type'] }}@if ($weapon['caliber'] !== '') · {{ $weapon['caliber'] }}@endif</div>
+                                <div style="font-size: 14px; font-weight: 600; color: var(--at-text);">{{ $weapon['name'] }}</div>
+                                <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px;">
+                                    <div>
+                                        <div style="font-family: var(--at-font-mono); font-size: 18px; font-weight: 600; color: var(--at-text);">{{ number_format($weapon['avg'], 1, ',', '.') }}</div>
+                                        <div style="font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted);">{{ $weapon['sessions'] }} sessies · {{ $weapon['shots'] }} schoten</div>
+                                    </div>
+                                    @if (count($weapon['series']) >= 2)
+                                        <x-aimtrack.sparkline
+                                            :data="$weapon['series']"
+                                            :width="80"
+                                            :height="32"
+                                            :color="$weapon['trend'] >= 0 ? 'var(--at-accent)' : 'var(--at-warn)'"
+                                        />
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
         </div>
 
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
@@ -100,7 +136,7 @@
                     <div class="at-label" style="margin-left: auto;">30d</div>
                 </div>
                 <div style="padding: 14px;">
-                    <x-aimtrack.sparkline :data="array_values($trend)" :width="296" :height="70" :fill="true" />
+                    <x-aimtrack.sparkline :data="array_values($trend)" :width="280" :height="70" :fill="true" />
                     @if (count($trend) >= 2)
                         <div style="display: flex; justify-content: space-between; margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">
                             <span>{{ \Illuminate\Support\Carbon::parse(array_key_first($trend))->format('d M') }}</span>

--- a/resources/views/filament/resources/sessions/view-session.blade.php
+++ b/resources/views/filament/resources/sessions/view-session.blade.php
@@ -39,10 +39,22 @@
     ])->all();
 
     $reflectionRecord = $session->aiReflection;
+
+    $scoreDelta = $stats->scoreVsAverage();
+    $meanXmm = $stats->meanXmm();
+    $meanYmm = $stats->meanYmm();
+    $sdMm = $stats->sdMm();
+
+    $firstShotAt = $session->shots->min('created_at');
+    $lastShotAt = $session->shots->max('created_at');
+    $durationMin = ($firstShotAt && $lastShotAt) ? (int) round($firstShotAt->diffInSeconds($lastShotAt) / 60) : 0;
+    $timeWindow = $durationMin > 0
+        ? Carbon::parse($firstShotAt)->format('H:i').'–'.Carbon::parse($lastShotAt)->format('H:i').' · '.$durationMin.' min'
+        : null;
 @endphp
 
 <x-filament-panels::page>
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 16px; align-items: start;">
+    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 16px; align-items: start;">
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
             <div style="position: relative; padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
                 <x-aimtrack.watermark-bg :size="220" :opacity="0.07" :top="-60" :right="-40" />
@@ -58,13 +70,21 @@
                         <div style="display: flex; gap: 16px; margin-top: 10px; font-size: 12px; color: var(--at-muted); flex-wrap: wrap;">
                             <span>{{ $session->range_name ?? '—' }}</span>
                             <span>{{ $weapon?->name ?? '—' }}{{ $weapon?->caliber ? ' · '.$weapon->caliber : '' }}</span>
-                            <span>{{ $cadans !== null ? round(($cadans * max(1, $totalShots)) / 60, 0).' min' : '—' }}</span>
+                            @if ($timeWindow)
+                                <span>{{ $timeWindow }}</span>
+                            @endif
                         </div>
                     </div>
                     <div style="text-align: right; position: relative;">
                         <div class="at-label">EINDSCORE</div>
                         <div style="font-family: var(--at-font-mono); font-size: 44px; font-weight: 600; color: var(--at-accent); line-height: 1; letter-spacing: -0.02em;">{{ $totalScore }}</div>
-                        <div style="font-family: var(--at-font-mono); font-size: 12px; color: var(--at-muted); margin-top: 2px;">{{ $totalShots > 0 ? round($totalScore / $totalShots, 1).' gem' : '—' }}</div>
+                        @if ($scoreDelta !== null)
+                            <div style="font-family: var(--at-font-mono); font-size: 12px; margin-top: 2px; color: {{ $scoreDelta >= 0 ? 'var(--at-accent)' : 'var(--at-warn)' }};">
+                                {{ $scoreDelta >= 0 ? '▲ +'.$scoreDelta : '▼ '.$scoreDelta }} vs gem.
+                            </div>
+                        @else
+                            <div style="font-family: var(--at-font-mono); font-size: 12px; color: var(--at-muted); margin-top: 2px;">{{ $totalShots > 0 ? round($totalScore / max(1, $totalShots), 1).' gem' : '—' }}</div>
+                        @endif
                     </div>
                 </div>
             </div>
@@ -109,7 +129,14 @@
                 </div>
                 <div style="padding: 16px; display: flex; flex-direction: column; align-items: center; gap: 12px;">
                     @if ($totalShots > 0)
-                        <x-aimtrack.target-rings :size="240" :hits="$hits" />
+                        <x-aimtrack.target-rings :size="240" :hits="$hits" :score-labels="true" />
+                        @if ($meanXmm !== null && $meanYmm !== null && $sdMm !== null)
+                            <div style="display: flex; justify-content: space-between; width: 100%; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">
+                                <span>X: {{ $meanXmm >= 0 ? '+'.$meanXmm : $meanXmm }} mm</span>
+                                <span>Y: {{ $meanYmm >= 0 ? '+'.$meanYmm : $meanYmm }} mm</span>
+                                <span>SD: {{ $sdMm }} mm</span>
+                            </div>
+                        @endif
                     @else
                         <div style="padding: 40px 8px; color: var(--at-muted); font-size: 12px;">Nog geen hits geregistreerd</div>
                     @endif

--- a/resources/views/filament/resources/sessions/view-session.blade.php
+++ b/resources/views/filament/resources/sessions/view-session.blade.php
@@ -125,7 +125,9 @@
             <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
                 <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
                     <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Hit-patroon</div>
-                    <div class="at-label" style="margin-left: auto;">{{ $totalShots }} schoten</div>
+                    <a href="{{ \App\Filament\Resources\SessionResource::getUrl('shots', ['record' => $session]) }}"
+                        style="margin-left: auto; font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--at-accent); text-decoration: none;">Schotenbord →</a>
+                    <div class="at-label">{{ $totalShots }} schoten</div>
                 </div>
                 <div style="padding: 16px; display: flex; flex-direction: column; align-items: center; gap: 12px;">
                     @if ($totalShots > 0)

--- a/resources/views/filament/resources/sessions/view-session.blade.php
+++ b/resources/views/filament/resources/sessions/view-session.blade.php
@@ -147,7 +147,26 @@
                 :reflection="$reflectionRecord"
                 :session-id="$sessionLabel"
                 :generated-at="$reflectionRecord?->updated_at"
-            />
+            >
+                @if ($reflectionRecord)
+                    <x-slot:actions>
+                        <a href="{{ \App\Filament\Pages\CoachPage::getUrl() }}"
+                            style="flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 7px 12px; border-radius: var(--at-r-md); border: 1px solid var(--at-accent-25); background: var(--at-accent-12); color: var(--at-accent); font-size: 12px; text-decoration: none;">
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" /></svg>
+                            Vraag coach
+                        </a>
+                        @if ($reflectionRecord->acknowledged_at)
+                            <span style="display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px; font-family: var(--at-font-mono); font-size: 11px; color: var(--at-accent);">✓ Gemarkeerd</span>
+                        @else
+                            <button type="button" wire:click="acknowledgeReflection"
+                                style="display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px; border-radius: var(--at-r-md); border: 1px solid var(--at-line); background: var(--at-panel); color: var(--at-text); font-size: 12px; cursor: pointer;">
+                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+                                Markeer
+                            </button>
+                        @endif
+                    </x-slot:actions>
+                @endif
+            </x-aimtrack.ai-reflection-card>
 
             @if (filled($session->manual_reflection))
                 <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -2,8 +2,23 @@
     // Decimaal-numpad uit new-session-wizard.jsx — exact deze volgorde/labels.
     $numpad = ['10.9', '10.8', '10.7', '10.6', '10.5', '10.4', '10.3', '10.2', '10.1', '10.0', '9.9', '9.8', '9.7', '9.6', '9.5', '9.0', '8', '0'];
 
-    // Decision 6: AI-tijdens-sessie tip is hard-coded mock-tekst (geen runtime call).
-    $aiTip = 'Goed bezig — schot 1–10 zit boven je gemiddelde. Hou je cadans rond 30s aan.';
+    // Preview-tekst (geen runtime AI-call): kadert de live-feature i.p.v. nep-cijfers.
+    $aiTip = 'Zodra je schoten logt geeft de coach hier live tips op basis van je cadans en groepering.';
+
+    // Live wizard-state (geen sample data): toon het écht gekozen wapen + sessie
+    // uit de eerdere stappen. $this->data is de wizard-form-state op deze pagina.
+    $wizardData = is_array($this->data ?? null) ? $this->data : [];
+    $weaponRows = $wizardData['sessionWeapons'] ?? [];
+    $firstRow = is_array($weaponRows) ? (collect($weaponRows)->first() ?? []) : [];
+    $plannedShots = collect($weaponRows)->sum(fn ($r) => (int) ($r['rounds_fired'] ?? 0));
+
+    $chosenWeapon = ! empty($firstRow['weapon_id'])
+        ? \App\Models\Weapon::find($firstRow['weapon_id'])
+        : null;
+    $chosenDistance = $firstRow['distance_m'] ?? null;
+
+    $sessionDate = ! empty($wizardData['date']) ? \Illuminate\Support\Carbon::parse($wizardData['date'])->translatedFormat('d M Y') : null;
+    $sessionRange = $wizardData['range_name'] ?? ($wizardData['location'] ?? null);
 @endphp
 
 <div class="aimtrack-wizard-shots" style="display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 16px; align-items: start;">
@@ -13,7 +28,7 @@
                 <div class="at-label">VOORTGANG</div>
                 <div style="display: flex; align-items: baseline; gap: 6px; margin-top: 6px;">
                     <div style="font-family: var(--at-font-mono); font-size: 36px; font-weight: 600; color: var(--at-text); line-height: 1; letter-spacing: -0.02em;">0</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 14px; color: var(--at-muted);">/ 60</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 14px; color: var(--at-muted);">/ {{ $plannedShots > 0 ? $plannedShots : 60 }}</div>
                 </div>
             </div>
             <div>
@@ -30,7 +45,7 @@
             </div>
         </div>
 
-        <x-aimtrack.shot-strip :shots="[]" :total-slots="60" :show-legend="false" />
+        <x-aimtrack.shot-strip :shots="[]" :total-slots="$plannedShots > 0 ? $plannedShots : 60" :show-legend="false" />
 
         <div>
             <div class="at-label">VOLGEND SCHOT · PREVIEW</div>
@@ -69,8 +84,8 @@
     <aside style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
         <div>
             <div class="at-label">SESSIE</div>
-            <div style="font-size: 14px; font-weight: 600; color: var(--at-text); margin-top: 6px;">Nieuwe sessie</div>
-            <div style="font-size: 12px; color: var(--at-muted); font-family: var(--at-font-mono); margin-top: 2px;">Datum &amp; baan: stap Sessie</div>
+            <div style="font-size: 14px; font-weight: 600; color: var(--at-text); margin-top: 6px;">{{ $sessionDate ?? 'Nieuwe sessie' }}</div>
+            <div style="font-size: 12px; color: var(--at-muted); font-family: var(--at-font-mono); margin-top: 2px;">{{ $sessionRange ?? 'Datum & baan: stap Sessie' }}</div>
         </div>
 
         <div>
@@ -78,8 +93,8 @@
             <div style="margin-top: 6px; padding: 10px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
                 <span style="color: var(--at-accent); font-size: 16px; line-height: 1;" role="presentation">⦿</span>
                 <div style="flex: 1; min-width: 0;">
-                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Zoals gekozen in stap Wapen</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted);">wapen · kaliber · serial</div>
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">{{ $chosenWeapon?->name ?? 'Kies in stap Wapen' }}</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted);">{{ $chosenWeapon ? trim(($chosenWeapon->weapon_type?->value ? ucfirst($chosenWeapon->weapon_type->value) : '').($chosenWeapon->caliber ? ' · '.$chosenWeapon->caliber : '').($chosenDistance ? ' · '.$chosenDistance.'m' : '')) : 'wapen · kaliber · afstand' }}</div>
                 </div>
             </div>
         </div>

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -2,8 +2,8 @@
     // Decimaal-numpad uit new-session-wizard.jsx — exact deze volgorde/labels.
     $numpad = ['10.9', '10.8', '10.7', '10.6', '10.5', '10.4', '10.3', '10.2', '10.1', '10.0', '9.9', '9.8', '9.7', '9.6', '9.5', '9.0', '8', '0'];
 
-    // Decision 6: AI-tijdens-sessie tip is hard-coded mock-tekst (geen runtime call).
-    $aiTip = 'Goed bezig — schot 1–10 zit boven je gemiddelde. Hou je cadans rond 30s aan.';
+    // Preview-tekst (geen runtime AI-call): kadert de live-feature i.p.v. nep-cijfers.
+    $aiTip = 'Zodra je schoten logt geeft de coach hier live tips op basis van je cadans en groepering.';
 @endphp
 
 <div class="aimtrack-wizard-shots" style="display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 16px; align-items: start;">

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -4,6 +4,21 @@
 
     // Preview-tekst (geen runtime AI-call): kadert de live-feature i.p.v. nep-cijfers.
     $aiTip = 'Zodra je schoten logt geeft de coach hier live tips op basis van je cadans en groepering.';
+
+    // Live wizard-state (geen sample data): toon het écht gekozen wapen + sessie
+    // uit de eerdere stappen. $this->data is de wizard-form-state op deze pagina.
+    $wizardData = is_array($this->data ?? null) ? $this->data : [];
+    $weaponRows = $wizardData['sessionWeapons'] ?? [];
+    $firstRow = is_array($weaponRows) ? (collect($weaponRows)->first() ?? []) : [];
+    $plannedShots = collect($weaponRows)->sum(fn ($r) => (int) ($r['rounds_fired'] ?? 0));
+
+    $chosenWeapon = ! empty($firstRow['weapon_id'])
+        ? \App\Models\Weapon::find($firstRow['weapon_id'])
+        : null;
+    $chosenDistance = $firstRow['distance_m'] ?? null;
+
+    $sessionDate = ! empty($wizardData['date']) ? \Illuminate\Support\Carbon::parse($wizardData['date'])->translatedFormat('d M Y') : null;
+    $sessionRange = $wizardData['range_name'] ?? ($wizardData['location'] ?? null);
 @endphp
 
 <div class="aimtrack-wizard-shots" style="display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 16px; align-items: start;">
@@ -13,7 +28,7 @@
                 <div class="at-label">VOORTGANG</div>
                 <div style="display: flex; align-items: baseline; gap: 6px; margin-top: 6px;">
                     <div style="font-family: var(--at-font-mono); font-size: 36px; font-weight: 600; color: var(--at-text); line-height: 1; letter-spacing: -0.02em;">0</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 14px; color: var(--at-muted);">/ 60</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 14px; color: var(--at-muted);">/ {{ $plannedShots > 0 ? $plannedShots : 60 }}</div>
                 </div>
             </div>
             <div>
@@ -30,7 +45,7 @@
             </div>
         </div>
 
-        <x-aimtrack.shot-strip :shots="[]" :total-slots="60" :show-legend="false" />
+        <x-aimtrack.shot-strip :shots="[]" :total-slots="$plannedShots > 0 ? $plannedShots : 60" :show-legend="false" />
 
         <div>
             <div class="at-label">VOLGEND SCHOT · PREVIEW</div>
@@ -69,8 +84,8 @@
     <aside style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
         <div>
             <div class="at-label">SESSIE</div>
-            <div style="font-size: 14px; font-weight: 600; color: var(--at-text); margin-top: 6px;">Nieuwe sessie</div>
-            <div style="font-size: 12px; color: var(--at-muted); font-family: var(--at-font-mono); margin-top: 2px;">Datum &amp; baan: stap Sessie</div>
+            <div style="font-size: 14px; font-weight: 600; color: var(--at-text); margin-top: 6px;">{{ $sessionDate ?? 'Nieuwe sessie' }}</div>
+            <div style="font-size: 12px; color: var(--at-muted); font-family: var(--at-font-mono); margin-top: 2px;">{{ $sessionRange ?? 'Datum & baan: stap Sessie' }}</div>
         </div>
 
         <div>
@@ -78,8 +93,8 @@
             <div style="margin-top: 6px; padding: 10px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
                 <span style="color: var(--at-accent); font-size: 16px; line-height: 1;" role="presentation">⦿</span>
                 <div style="flex: 1; min-width: 0;">
-                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Zoals gekozen in stap Wapen</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted);">wapen · kaliber · serial</div>
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">{{ $chosenWeapon?->name ?? 'Kies in stap Wapen' }}</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted);">{{ $chosenWeapon ? trim(($chosenWeapon->weapon_type?->value ? ucfirst($chosenWeapon->weapon_type->value) : '').($chosenWeapon->caliber ? ' · '.$chosenWeapon->caliber : '').($chosenDistance ? ' · '.$chosenDistance.'m' : '')) : 'wapen · kaliber · afstand' }}</div>
                 </div>
             </div>
         </div>

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -2,23 +2,8 @@
     // Decimaal-numpad uit new-session-wizard.jsx — exact deze volgorde/labels.
     $numpad = ['10.9', '10.8', '10.7', '10.6', '10.5', '10.4', '10.3', '10.2', '10.1', '10.0', '9.9', '9.8', '9.7', '9.6', '9.5', '9.0', '8', '0'];
 
-    // Preview-tekst (geen runtime AI-call): kadert de live-feature i.p.v. nep-cijfers.
-    $aiTip = 'Zodra je schoten logt geeft de coach hier live tips op basis van je cadans en groepering.';
-
-    // Live wizard-state (geen sample data): toon het écht gekozen wapen + sessie
-    // uit de eerdere stappen. $this->data is de wizard-form-state op deze pagina.
-    $wizardData = is_array($this->data ?? null) ? $this->data : [];
-    $weaponRows = $wizardData['sessionWeapons'] ?? [];
-    $firstRow = is_array($weaponRows) ? (collect($weaponRows)->first() ?? []) : [];
-    $plannedShots = collect($weaponRows)->sum(fn ($r) => (int) ($r['rounds_fired'] ?? 0));
-
-    $chosenWeapon = ! empty($firstRow['weapon_id'])
-        ? \App\Models\Weapon::find($firstRow['weapon_id'])
-        : null;
-    $chosenDistance = $firstRow['distance_m'] ?? null;
-
-    $sessionDate = ! empty($wizardData['date']) ? \Illuminate\Support\Carbon::parse($wizardData['date'])->translatedFormat('d M Y') : null;
-    $sessionRange = $wizardData['range_name'] ?? ($wizardData['location'] ?? null);
+    // Decision 6: AI-tijdens-sessie tip is hard-coded mock-tekst (geen runtime call).
+    $aiTip = 'Goed bezig — schot 1–10 zit boven je gemiddelde. Hou je cadans rond 30s aan.';
 @endphp
 
 <div class="aimtrack-wizard-shots" style="display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 16px; align-items: start;">
@@ -28,7 +13,7 @@
                 <div class="at-label">VOORTGANG</div>
                 <div style="display: flex; align-items: baseline; gap: 6px; margin-top: 6px;">
                     <div style="font-family: var(--at-font-mono); font-size: 36px; font-weight: 600; color: var(--at-text); line-height: 1; letter-spacing: -0.02em;">0</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 14px; color: var(--at-muted);">/ {{ $plannedShots > 0 ? $plannedShots : 60 }}</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 14px; color: var(--at-muted);">/ 60</div>
                 </div>
             </div>
             <div>
@@ -45,7 +30,7 @@
             </div>
         </div>
 
-        <x-aimtrack.shot-strip :shots="[]" :total-slots="$plannedShots > 0 ? $plannedShots : 60" :show-legend="false" />
+        <x-aimtrack.shot-strip :shots="[]" :total-slots="60" :show-legend="false" />
 
         <div>
             <div class="at-label">VOLGEND SCHOT · PREVIEW</div>
@@ -84,8 +69,8 @@
     <aside style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
         <div>
             <div class="at-label">SESSIE</div>
-            <div style="font-size: 14px; font-weight: 600; color: var(--at-text); margin-top: 6px;">{{ $sessionDate ?? 'Nieuwe sessie' }}</div>
-            <div style="font-size: 12px; color: var(--at-muted); font-family: var(--at-font-mono); margin-top: 2px;">{{ $sessionRange ?? 'Datum & baan: stap Sessie' }}</div>
+            <div style="font-size: 14px; font-weight: 600; color: var(--at-text); margin-top: 6px;">Nieuwe sessie</div>
+            <div style="font-size: 12px; color: var(--at-muted); font-family: var(--at-font-mono); margin-top: 2px;">Datum &amp; baan: stap Sessie</div>
         </div>
 
         <div>
@@ -93,8 +78,8 @@
             <div style="margin-top: 6px; padding: 10px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">
                 <span style="color: var(--at-accent); font-size: 16px; line-height: 1;" role="presentation">⦿</span>
                 <div style="flex: 1; min-width: 0;">
-                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">{{ $chosenWeapon?->name ?? 'Kies in stap Wapen' }}</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted);">{{ $chosenWeapon ? trim(($chosenWeapon->weapon_type?->value ? ucfirst($chosenWeapon->weapon_type->value) : '').($chosenWeapon->caliber ? ' · '.$chosenWeapon->caliber : '').($chosenDistance ? ' · '.$chosenDistance.'m' : '')) : 'wapen · kaliber · afstand' }}</div>
+                    <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Zoals gekozen in stap Wapen</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted);">wapen · kaliber · serial</div>
                 </div>
             </div>
         </div>

--- a/resources/views/filament/resources/weapons/view-weapon.blade.php
+++ b/resources/views/filament/resources/weapons/view-weapon.blade.php
@@ -17,13 +17,13 @@
     $bestDate = $insights->bestScoreDate();
     $trendData = $insights->trendData(365);
     $recentSessions = $insights->recentSessions(5);
+    $weaponInsight = $weapon->aiWeaponInsight;
 
     $statusRows = [
-        ['Status', $weapon->is_active ? 'Actief' : 'Uit gebruik', $weapon->is_active ? 'ok' : null],
+        ['Status', $weapon->is_active ? 'Actief · WM-4' : 'Uit gebruik', $weapon->is_active ? 'ok' : null],
         ['Aangeschaft', $weapon->owned_since?->translatedFormat('M Y') ?? '—', null],
         ['Kaliber', $caliberLabel, null],
         ['Type', ucfirst($typeLabel), null],
-        ['Serial', $weapon->serial_number ?? '—', null],
         ['Opslag', $weapon->storageLocation?->name ?? ($weapon->storage_location ?? '—'), null],
     ];
 
@@ -51,7 +51,7 @@
                 <div style="margin-top: 14px;">
                     <div class="at-label">{{ strtoupper($typeLabel) }} · {{ $caliberLabel }}</div>
                     <h1 style="font-family: var(--at-font-display); font-size: 22px; font-weight: 600; letter-spacing: -0.01em; margin: 4px 0 0; color: var(--at-text);">{{ $weapon->name }}</h1>
-                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted); margin-top: 6px;">ID · {{ $idCode }}</div>
+                    <div style="font-family: var(--at-font-mono); font-size: 11px; color: var(--at-muted); margin-top: 6px;">SERIAL · {{ $weapon->serial_number ?? $idCode }}</div>
                 </div>
 
                 <div style="height: 1px; background: var(--at-line); margin: 14px 0;"></div>
@@ -115,6 +115,38 @@
                     @endif
                 </div>
             </div>
+
+            @if ($weaponInsight)
+                @php
+                    $insightPatterns = collect($weaponInsight->patterns ?? [])->filter()->values();
+                    $insightSuggestions = collect($weaponInsight->suggestions ?? [])->filter()->values();
+                @endphp
+                <x-aimtrack.bracket-frame :rounded="8" :padding="16" style="display: flex; flex-direction: column; gap: 12px;">
+                    <div style="display: flex; align-items: center; gap: 8px; font-size: 11px; font-family: var(--at-font-mono); letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-accent);">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--at-accent)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" role="presentation"><path d="M12 3l2 4 4 1-3 3 1 4-4-2-4 2 1-4-3-3 4-1z" /></svg>
+                        <span>AI-wapeninzicht</span>
+                        @if ($weaponInsight->updated_at)
+                            <span style="margin-left: auto; color: var(--at-muted);">{{ $weaponInsight->updated_at->diffForHumans() }}</span>
+                        @endif
+                    </div>
+                    @if (filled($weaponInsight->summary))
+                        <div style="font-size: 13px; line-height: 1.55; color: var(--at-text);">{{ $weaponInsight->summary }}</div>
+                    @endif
+                    @if ($insightPatterns->isNotEmpty() || $insightSuggestions->isNotEmpty())
+                        <div style="height: 1px; background: var(--at-line);"></div>
+                        <div style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
+                            @if ($insightPatterns->isNotEmpty())
+                                <div class="at-label" style="color: var(--at-accent);">PATRONEN</div>
+                                <div style="color: var(--at-text);">{{ $insightPatterns->implode(' · ') }}</div>
+                            @endif
+                            @if ($insightSuggestions->isNotEmpty())
+                                <div class="at-label">ADVIES</div>
+                                <div style="color: var(--at-text);">{{ $insightSuggestions->implode(' · ') }}</div>
+                            @endif
+                        </div>
+                    @endif
+                </x-aimtrack.bracket-frame>
+            @endif
 
             <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
                 <div style="padding: 14px 16px; border-bottom: 1px solid var(--at-line); display: flex; align-items: center; gap: 10px;">

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -74,6 +74,22 @@ for candidate in .env.local .env.example; do
   fi
 done
 
+# Stem APP_URL/WEB_PORT in de gekopieerde .env.local af op de worktree-poort.
+# Zonder dit blijft APP_URL op de hoofd-dev poort (8080) staan, waardoor
+# route()-gegenereerde URL's (o.a. de Copilot stream-fetch) cross-origin naar
+# de verkeerde stack wijzen → 401 / kapotte features.
+if [[ -f "$WORKTREE_PATH/.env.local" ]]; then
+  if grep -q '^APP_URL=' "$WORKTREE_PATH/.env.local"; then
+    sed -i -E "s#^APP_URL=.*#APP_URL=http://localhost:${WEB_PORT}#" "$WORKTREE_PATH/.env.local"
+  else
+    echo "APP_URL=http://localhost:${WEB_PORT}" >> "$WORKTREE_PATH/.env.local"
+  fi
+  if grep -q '^WEB_PORT=' "$WORKTREE_PATH/.env.local"; then
+    sed -i -E "s#^WEB_PORT=.*#WEB_PORT=${WEB_PORT}#" "$WORKTREE_PATH/.env.local"
+  fi
+  echo "==> APP_URL/WEB_PORT in .env.local afgestemd op poort ${WEB_PORT}"
+fi
+
 # Maak .env in de worktree root met ALLEEN docker compose overrides.
 # Deze .env wordt door 'docker compose --env-file .env' gelezen.
 cat > "$WORKTREE_PATH/.env" <<EOF

--- a/tests/Feature/Admin/FailedJobsPageTest.php
+++ b/tests/Feature/Admin/FailedJobsPageTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\FailedJobsPage;
+use App\Models\User;
+
+it('allows an admin to access the failed-jobs page', function (): void {
+    $admin = User::factory()->create(['is_admin' => true]);
+    $this->actingAs($admin);
+
+    expect(FailedJobsPage::canAccess())->toBeTrue();
+    $this->get(FailedJobsPage::getUrl())->assertSuccessful();
+});
+
+it('forbids a non-admin from the failed-jobs page', function (): void {
+    $user = User::factory()->create(['is_admin' => false]);
+    $this->actingAs($user);
+
+    expect(FailedJobsPage::canAccess())->toBeFalse();
+    $this->get(FailedJobsPage::getUrl())->assertForbidden();
+});

--- a/tests/Feature/Ai/SessionReflectionPromptTest.php
+++ b/tests/Feature/Ai/SessionReflectionPromptTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Deviation;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\SessionWeapon;
+use App\Models\User;
+use App\Services\Ai\ShooterCoach;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+function fakeShooterCoach(): ShooterCoach
+{
+    return new ShooterCoach(
+        driver: 'openai',
+        model: 'test-model',
+        baseUrl: 'https://api.test/v1',
+        apiKey: 'sk-test',
+    );
+}
+
+function fakeReflectionResponse(): void
+{
+    Http::fake([
+        '*' => Http::response([
+            'choices' => [[
+                'message' => [
+                    'content' => json_encode([
+                        'summary' => 'Sterke opening, dip in serie 2.',
+                        'positives' => ['Openingsritme'],
+                        'improvements' => ['Concentratie serie 2'],
+                        'next_focus' => 'Adem-reset',
+                    ]),
+                ],
+            ]],
+        ], 200),
+    ]);
+}
+
+test('reflection does not crash on a backed Deviation enum and persists', function (): void {
+    fakeReflectionResponse();
+
+    $session = Session::factory()->create(['user_id' => User::factory()]);
+    // The Deviation backed enum used to fatal on sprintf('%s', $enum).
+    SessionWeapon::factory()->create([
+        'session_id' => $session->id,
+        'deviation' => Deviation::LEFT,
+    ]);
+
+    $reflection = fakeShooterCoach()->generateSessionReflection($session);
+
+    expect($reflection->exists)->toBeTrue()
+        ->and($reflection->summary)->not->toBeEmpty();
+
+    Http::assertSent(fn ($request): bool => str_contains(
+        $request['messages'][1]['content'] ?? '',
+        'afwijking: left',
+    ));
+});
+
+test('reflection prompt includes numeric shot statistics', function (): void {
+    fakeReflectionResponse();
+
+    $session = Session::factory()->create(['user_id' => User::factory()]);
+    SessionWeapon::factory()->create(['session_id' => $session->id]);
+
+    // Serie 1 (turn 0) = tienen, serie 2 (turn 1) = achten → een duidelijke dip.
+    foreach (range(0, 9) as $i) {
+        SessionShot::factory()->create([
+            'session_id' => $session->id,
+            'turn_index' => 0,
+            'shot_index' => $i,
+            'ring' => 10,
+            'score' => 10,
+        ]);
+    }
+    foreach (range(0, 9) as $i) {
+        SessionShot::factory()->create([
+            'session_id' => $session->id,
+            'turn_index' => 1,
+            'shot_index' => $i,
+            'ring' => 8,
+            'score' => 8,
+        ]);
+    }
+
+    fakeShooterCoach()->generateSessionReflection($session);
+
+    Http::assertSent(function ($request): bool {
+        $prompt = $request['messages'][1]['content'] ?? '';
+
+        return str_contains($prompt, 'Schotstatistiek')
+            && str_contains($prompt, 'Totaalscore: 180')
+            && str_contains($prompt, 'Serie-scores (per 10): 100 · 80')
+            && str_contains($prompt, 'zwakste reeks rond schot 11');
+    });
+});

--- a/tests/Feature/EmptyStates/FirstRunWelcomeTest.php
+++ b/tests/Feature/EmptyStates/FirstRunWelcomeTest.php
@@ -113,7 +113,7 @@ test('seedDemoDataAction triggers DemoDataSeeder for the current user', function
         ->and($user->sessions()->count())->toBe(5);
 });
 
-test('dashboard renders default widgets grid when user has data', function (): void {
+test('dashboard renders the stats/leergebieden/KNSA overview when the user has data', function (): void {
     $user = User::factory()->create();
     Weapon::factory()->for($user)->create();
 
@@ -123,4 +123,8 @@ test('dashboard renders default widgets grid when user has data', function (): v
 
     $response->assertOk();
     $response->assertDontSee('● WELKOM', escape: false);
+    $response->assertSee('Leergebieden · voortgang');
+    $response->assertSee('KNSA · kennisbank');
+    // De gefaalde-queue-jobs-widget is geen gebruikersinformatie meer.
+    $response->assertDontSee('queue draait zonder fouten');
 });

--- a/tests/Feature/Filament/Copilot/Tools/AddTrainingGoalToolTest.php
+++ b/tests/Feature/Filament/Copilot/Tools/AddTrainingGoalToolTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TrainingGoalSource;
+use App\Filament\Copilot\Tools\AddTrainingGoalTool;
+use App\Models\TrainingGoal;
+use App\Models\User;
+use Laravel\Ai\Tools\Request;
+
+function makeAddTrainingGoalTool(User $user): AddTrainingGoalTool
+{
+    return (new AddTrainingGoalTool)
+        ->forPanel('admin')
+        ->forUser($user)
+        ->forTenant(null)
+        ->forConversation(null);
+}
+
+it('adds an AI-sourced training goal for the active shooter', function (): void {
+    $user = User::factory()->create();
+
+    $output = (string) makeAddTrainingGoalTool($user)->handle(new Request([
+        'title' => 'Micro-pauze na schot 30',
+        'detail' => '30s adem-reset',
+        'target_month' => '2026-06',
+    ]));
+
+    expect($output)->toContain('Trainingsdoel toegevoegd');
+
+    $goal = TrainingGoal::query()->where('user_id', $user->id)->first();
+    expect($goal)->not->toBeNull()
+        ->and($goal->title)->toBe('Micro-pauze na schot 30')
+        ->and($goal->source)->toBe(TrainingGoalSource::Ai)
+        ->and($goal->target_month)->toBe('2026-06');
+});
+
+it('rejects an empty title', function (): void {
+    $user = User::factory()->create();
+
+    $output = (string) makeAddTrainingGoalTool($user)->handle(new Request(['title' => '   ']));
+
+    expect($output)->toContain('minimaal een titel')
+        ->and(TrainingGoal::query()->count())->toBe(0);
+});
+
+it('ignores an invalid target_month format', function (): void {
+    $user = User::factory()->create();
+
+    makeAddTrainingGoalTool($user)->handle(new Request(['title' => 'Cadans vasthouden', 'target_month' => 'juni']));
+
+    expect(TrainingGoal::query()->first()->target_month)->toBeNull();
+});

--- a/tests/Feature/Filament/Copilot/Tools/ScoreDriftToolTest.php
+++ b/tests/Feature/Filament/Copilot/Tools/ScoreDriftToolTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Copilot\Tools\ScoreDriftTool;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use Laravel\Ai\Tools\Request;
+
+function makeScoreDriftTool(User $user): ScoreDriftTool
+{
+    return (new ScoreDriftTool)
+        ->forPanel('admin')
+        ->forUser($user)
+        ->forTenant(null)
+        ->forConversation(null);
+}
+
+it('summarises score drift and the weakest window', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create(['date' => now()->subDay()]);
+    foreach ([10, 10, 10, 10, 10, 8, 8, 8, 8, 8] as $i => $score) {
+        SessionShot::factory()->for($session)->create(['turn_index' => 0, 'shot_index' => $i, 'ring' => $score, 'score' => $score]);
+    }
+
+    $output = (string) makeScoreDriftTool($user)->handle(new Request);
+
+    expect($output)->toContain('Score-drift')
+        ->and($output)->toContain('Zwakste venster');
+});
+
+it('reports when there is not enough data', function (): void {
+    $output = (string) makeScoreDriftTool(User::factory()->create())->handle(new Request);
+
+    expect($output)->toContain('onvoldoende');
+});

--- a/tests/Feature/RangeConsole/AiCoachScreenTest.php
+++ b/tests/Feature/RangeConsole/AiCoachScreenTest.php
@@ -142,3 +142,18 @@ it('does not complete a training goal owned by another user', function (): void 
 
     expect($foreign->fresh()->completed_at)->toBeNull();
 });
+
+it('renders the score-drift card when the shooter has shot data', function (): void {
+    $user = User::factory()->create();
+
+    foreach (range(1, \App\Support\UserOnboardingState::aiCoachThreshold()) as $i) {
+        $session = Session::factory()->for($user)->create(['date' => now()->subDays($i), 'range_name' => 'SV Diemen']);
+        foreach (range(0, 9) as $s) {
+            \App\Models\SessionShot::factory()->for($session)->create(['turn_index' => 0, 'shot_index' => $s, 'ring' => 9, 'score' => 9]);
+        }
+    }
+
+    Livewire::actingAs($user)
+        ->test(CoachPage::class)
+        ->assertSee('SCORE-DRIFT · GEM. PER SCHOT · LAATSTE SESSIES');
+});

--- a/tests/Feature/RangeConsole/AiCoachScreenTest.php
+++ b/tests/Feature/RangeConsole/AiCoachScreenTest.php
@@ -107,3 +107,38 @@ it('scopes conversations to the participant user', function (): void {
         ->test(CoachPage::class)
         ->assertDontSee('Geheim gesprek van iemand anders');
 });
+
+it('renders open training goals in the doelen rail and completes one', function (): void {
+    $user = User::factory()->create();
+    unlockCoach($user);
+
+    $goal = \App\Models\TrainingGoal::factory()->ai()->create([
+        'user_id' => $user->id,
+        'title' => 'Micro-pauze na schot 30',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(CoachPage::class)
+        ->assertSee('VOORGESTELDE DOELEN')
+        ->assertSee('Micro-pauze na schot 30')
+        ->assertSee('AI-suggestie')
+        ->call('completeGoal', $goal->id)
+        ->assertDontSee('Micro-pauze na schot 30');
+
+    expect($goal->fresh()->completed_at)->not->toBeNull();
+});
+
+it('does not complete a training goal owned by another user', function (): void {
+    $user = User::factory()->create();
+    unlockCoach($user);
+
+    $foreign = \App\Models\TrainingGoal::factory()->create([
+        'user_id' => User::factory()->create()->id,
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(CoachPage::class)
+        ->call('completeGoal', $foreign->id);
+
+    expect($foreign->fresh()->completed_at)->toBeNull();
+});

--- a/tests/Feature/RangeConsole/NavigationBadgeTest.php
+++ b/tests/Feature/RangeConsole/NavigationBadgeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\CoachPage;
+use App\Filament\Resources\SessionResource;
+use App\Filament\Resources\WeaponResource;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Weapon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('session navigation badge reflects the acting user session count', function (): void {
+    $user = User::factory()->create();
+    Session::factory()->count(3)->create(['user_id' => $user->id]);
+    // Another user's sessions must not leak into the badge.
+    Session::factory()->count(2)->create(['user_id' => User::factory()->create()->id]);
+
+    $this->actingAs($user);
+
+    expect(SessionResource::getNavigationBadge())->toBe('3');
+});
+
+test('weapon navigation badge reflects the acting user weapon count', function (): void {
+    $user = User::factory()->create();
+    Weapon::factory()->count(2)->create(['user_id' => $user->id]);
+
+    $this->actingAs($user);
+
+    expect(WeaponResource::getNavigationBadge())->toBe('2');
+});
+
+test('session navigation badge is null when the user has no sessions', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    expect(SessionResource::getNavigationBadge())->toBeNull();
+});
+
+test('coach page advertises a NEW accent navigation badge', function (): void {
+    expect(CoachPage::getNavigationBadge())->toBe('NEW')
+        ->and(CoachPage::getNavigationBadgeColor())->toBe('primary');
+});
+
+test('the admin panel renders with the regrouped navigation', function (): void {
+    $this->actingAs(User::factory()->create());
+
+    $this->get('/admin')->assertSuccessful();
+});

--- a/tests/Feature/RangeConsole/ViewSessionScreenTest.php
+++ b/tests/Feature/RangeConsole/ViewSessionScreenTest.php
@@ -123,3 +123,19 @@ it('refuses to render sessions owned by another user via the eloquent scope', fu
     Livewire::actingAs($user)
         ->test(ViewSession::class, ['record' => $foreignSession->id]);
 })->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+it('shows AI reflection actions and marks the reflection as read', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create();
+    seedShots($session, 10);
+    $reflection = AiReflection::factory()->for($session)->create();
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $session->id])
+        ->assertSee('Vraag coach')
+        ->assertSee('Markeer')
+        ->call('acknowledgeReflection')
+        ->assertSee('Gemarkeerd');
+
+    expect($reflection->refresh()->acknowledged_at)->not->toBeNull();
+});

--- a/tests/Feature/RangeConsole/ViewSessionScreenTest.php
+++ b/tests/Feature/RangeConsole/ViewSessionScreenTest.php
@@ -139,3 +139,16 @@ it('shows AI reflection actions and marks the reflection as read', function (): 
 
     expect($reflection->refresh()->acknowledged_at)->not->toBeNull();
 });
+
+it('links to the interactive shot board (ring view) from the session detail', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create();
+    seedShots($session, 10);
+
+    $shotBoardUrl = \App\Filament\Resources\SessionResource::getUrl('shots', ['record' => $session->id]);
+
+    Livewire::actingAs($user)
+        ->test(ViewSession::class, ['record' => $session->id])
+        ->assertSee('Schotenbord')
+        ->assertSee($shotBoardUrl, escape: false);
+});

--- a/tests/Feature/RangeConsole/ViewWeaponScreenTest.php
+++ b/tests/Feature/RangeConsole/ViewWeaponScreenTest.php
@@ -105,3 +105,21 @@ it('refuses to render a weapon owned by another user', function (): void {
     Livewire::actingAs($user)
         ->test(ViewWeapon::class, ['record' => $foreign->id]);
 })->throws(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+it('renders the AI-wapeninzicht card when an insight exists', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->for($user)->create();
+
+    $weapon->aiWeaponInsight()->create([
+        'summary' => 'Consistente groepering, lichte rechts-afwijking.',
+        'patterns' => ['Rechts-afwijking bij serie-eind'],
+        'suggestions' => ['Korrel 1 klik links'],
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(ViewWeapon::class, ['record' => $weapon->id])
+        ->assertSee('AI-wapeninzicht')
+        ->assertSee('Consistente groepering')
+        ->assertSee('PATRONEN')
+        ->assertSee('Korrel 1 klik links');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,4 +9,15 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
     use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Het Filament-panel gebruikt ->viteTheme(); zonder gebouwde assets
+        // gooit elke pagina-render een "Vite manifest not found" (bv. in CI,
+        // dat de frontend niet bouwt in de test-job). Tests toetsen gedrag,
+        // geen styling — dus Vite uitschakelen.
+        $this->withoutVite();
+    }
 }

--- a/tests/Unit/Aimtrack/SparklineComponentTest.php
+++ b/tests/Unit/Aimtrack/SparklineComponentTest.php
@@ -32,16 +32,24 @@ test('sparkline honours width and height props', function (): void {
         ->toContain('viewBox="0 0 500 100"');
 });
 
-test('sparkline renders area fill when fill prop is true', function (): void {
+test('sparkline renders a gradient area fill when fill prop is true', function (): void {
     $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" :fill="true" />');
 
     expect($html)
         ->toContain('<path')
-        ->toContain('opacity="0.12"');
+        ->toContain('<linearGradient')
+        ->toContain('stop-opacity="0.35"')
+        ->toContain('fill="url(#atspark-');
 });
 
 test('sparkline omits area fill by default', function (): void {
     $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" />');
 
     expect($html)->not->toContain('<path');
+});
+
+test('sparkline marks the latest point with a terminal dot', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" />');
+
+    expect($html)->toContain('<circle');
 });

--- a/tests/Unit/Aimtrack/TargetRingsComponentTest.php
+++ b/tests/Unit/Aimtrack/TargetRingsComponentTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Blade;
 
-test('target-rings renders 10 concentric rings by default', function (): void {
+test('target-rings renders 8 concentric rings plus a center dot by default', function (): void {
     $html = Blade::render('<x-aimtrack.target-rings />');
 
     expect($html)
@@ -12,7 +12,15 @@ test('target-rings renders 10 concentric rings by default', function (): void {
         ->toContain('viewBox="0 0 200 200"')
         ->toContain('aria-label="Hit-patroon"');
 
-    expect(substr_count($html, '<circle'))->toBe(10);
+    // 8 design rings + 1 center 10-ring dot.
+    expect(substr_count($html, '<circle'))->toBe(9);
+});
+
+test('target-rings draws a dashed crosshair', function (): void {
+    $html = Blade::render('<x-aimtrack.target-rings />');
+
+    expect(substr_count($html, '<line'))->toBe(2)
+        ->and($html)->toContain('stroke-dasharray="2 4"');
 });
 
 test('target-rings honours size prop', function (): void {
@@ -23,10 +31,11 @@ test('target-rings honours size prop', function (): void {
         ->toContain('viewBox="0 0 320 320"');
 });
 
-test('target-rings renders score labels when scoreLabels is true', function (): void {
+test('target-rings renders score labels for the top rings when scoreLabels is true', function (): void {
     $html = Blade::render('<x-aimtrack.target-rings score-labels="true" />');
 
-    expect(substr_count($html, '<text'))->toBe(10);
+    // Labels for rings 10, 9, 8, 7.
+    expect(substr_count($html, '<text'))->toBe(4);
 });
 
 test('target-rings omits score labels by default', function (): void {
@@ -35,18 +44,20 @@ test('target-rings omits score labels by default', function (): void {
     expect($html)->not->toContain('<text');
 });
 
-test('target-rings plots hit dots when hits array is provided', function (): void {
+test('target-rings plots hit dots and adds a halo for tens', function (): void {
     $hits = [
-        ['x' => 0.1, 'y' => -0.2, 'r' => 9],
-        ['x' => 0.0, 'y' => 0.0, 'r' => 10],
+        ['x' => 0.1, 'y' => -0.2, 'r' => 9],  // not a ten → single dot
+        ['x' => 0.0, 'y' => 0.0, 'r' => 10],  // ten → dot + halo
     ];
     $html = Blade::render('<x-aimtrack.target-rings :hits="$hits" />', ['hits' => $hits]);
 
+    // 9 base circles + 1 (nine) + 2 (ten: dot + halo) = 12.
     expect(substr_count($html, '<circle'))->toBe(12);
 });
 
 test('target-rings honours custom ring count', function (): void {
     $html = Blade::render('<x-aimtrack.target-rings rings="5" />');
 
-    expect(substr_count($html, '<circle'))->toBe(5);
+    // 5 rings + 1 center dot.
+    expect(substr_count($html, '<circle'))->toBe(6);
 });

--- a/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
+++ b/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Models\AiReflection;
 use App\Models\Session;
 use App\Models\SessionShot;
+use App\Models\SessionWeapon;
 use App\Models\User;
+use App\Models\Weapon;
 use App\Services\RangeConsoleSummaryService;
 
 /**
@@ -130,4 +132,40 @@ it('returns trend30d with sessions only from the last 30 days', function (): voi
     expect($trend)->toHaveCount(1);
     expect($trend)->toHaveKey($recent->date->toDateString());
     expect($trend[$recent->date->toDateString()])->toBe(50);
+});
+
+it('aggregates weapon usage with avg score, counts, trend and a date-ordered serie', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->create(['user_id' => $user->id]);
+
+    $older = Session::factory()->for($user)->create(['date' => now()->subDays(10)]);
+    $newer = Session::factory()->for($user)->create(['date' => now()->subDays(2)]);
+    SessionWeapon::factory()->create(['session_id' => $older->id, 'weapon_id' => $weapon->id]);
+    SessionWeapon::factory()->create(['session_id' => $newer->id, 'weapon_id' => $weapon->id]);
+    summaryShotsFor($older, 10, ['ring' => 10, 'score' => 10]); // 100
+    summaryShotsFor($newer, 10, ['ring' => 8, 'score' => 8]);   // 80
+
+    $usage = (new RangeConsoleSummaryService($user))->weaponUsage();
+
+    expect($usage)->toHaveCount(1);
+
+    $row = $usage->first();
+    expect($row['name'])->toBe($weapon->name)
+        ->and($row['sessions'])->toBe(2)
+        ->and($row['shots'])->toBe(20)
+        ->and($row['avg'])->toBe(90.0)
+        ->and($row['series'])->toBe([100, 80]) // oudste → nieuwste
+        ->and($row['trend'])->toBe(-20);
+});
+
+it('excludes unused weapons and scopes weapon usage to the user', function (): void {
+    $user = User::factory()->create();
+    Weapon::factory()->create(['user_id' => $user->id]); // ongebruikt → niet getoond
+
+    $other = User::factory()->create();
+    $otherWeapon = Weapon::factory()->create(['user_id' => $other->id]);
+    $otherSession = Session::factory()->for($other)->create();
+    SessionWeapon::factory()->create(['session_id' => $otherSession->id, 'weapon_id' => $otherWeapon->id]);
+
+    expect((new RangeConsoleSummaryService($user))->weaponUsage())->toBeEmpty();
 });

--- a/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
+++ b/tests/Unit/Services/RangeConsoleSummaryServiceTest.php
@@ -169,3 +169,32 @@ it('excludes unused weapons and scopes weapon usage to the user', function (): v
 
     expect((new RangeConsoleSummaryService($user))->weaponUsage())->toBeEmpty();
 });
+
+it('aggregates progress per discipline (wapentype + afstand)', function (): void {
+    $user = User::factory()->create();
+    $weapon = Weapon::factory()->create(['user_id' => $user->id, 'weapon_type' => \App\Enums\WeaponType::PISTOL]);
+
+    $s1 = Session::factory()->for($user)->create(['date' => now()->subDays(5)]);
+    SessionWeapon::factory()->create(['session_id' => $s1->id, 'weapon_id' => $weapon->id, 'distance_m' => 25]);
+    summaryShotsFor($s1, 10, ['ring' => 10, 'score' => 10]); // 100
+
+    $s2 = Session::factory()->for($user)->create(['date' => now()->subDays(2)]);
+    SessionWeapon::factory()->create(['session_id' => $s2->id, 'weapon_id' => $weapon->id, 'distance_m' => 25]);
+    summaryShotsFor($s2, 10, ['ring' => 8, 'score' => 8]); // 80
+
+    $s3 = Session::factory()->for($user)->create(['date' => now()->subDay()]);
+    SessionWeapon::factory()->create(['session_id' => $s3->id, 'weapon_id' => $weapon->id, 'distance_m' => 15]);
+    summaryShotsFor($s3, 10, ['ring' => 9, 'score' => 9]); // 90
+
+    $progress = (new RangeConsoleSummaryService($user))->disciplineProgress();
+
+    expect($progress)->toHaveCount(2);
+
+    $p25 = $progress->firstWhere('label', 'Pistool 25m');
+    expect($p25)->not->toBeNull()
+        ->and($p25['sessions'])->toBe(2)
+        ->and($p25['shots'])->toBe(20)
+        ->and($p25['avg'])->toBe(90.0)
+        ->and($p25['series'])->toBe([100, 80]) // oudste → nieuwste
+        ->and($p25['trend'])->toBe(-20);
+});

--- a/tests/Unit/Services/ScoreDriftServiceTest.php
+++ b/tests/Unit/Services/ScoreDriftServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use App\Services\ScoreDriftService;
+use Carbon\CarbonInterface;
+
+/**
+ * @param  array<int, int>  $scores
+ */
+function driftSession(User $user, array $scores, CarbonInterface $date): void
+{
+    $session = Session::factory()->for($user)->create(['date' => $date]);
+    foreach ($scores as $i => $score) {
+        SessionShot::factory()->for($session)->create([
+            'turn_index' => 0,
+            'shot_index' => $i,
+            'ring' => $score,
+            'score' => $score,
+        ]);
+    }
+}
+
+it('averages score per shot position across recent sessions', function (): void {
+    $user = User::factory()->create();
+    driftSession($user, array_fill(0, 10, 10), now()->subDays(2));
+    driftSession($user, [10, 10, 10, 10, 10, 8, 8, 8, 8, 8], now()->subDay());
+
+    $avg = (new ScoreDriftService($user))->perShotAverage();
+
+    expect($avg)->toHaveCount(10)
+        ->and($avg[1])->toBe(10.0)
+        ->and($avg[6])->toBe(9.0);
+});
+
+it('returns an empty drift when the shooter has no sessions with shots', function (): void {
+    expect((new ScoreDriftService(User::factory()->create()))->perShotAverage())->toBe([]);
+});
+
+it('finds the weakest shot window', function (): void {
+    $user = User::factory()->create();
+    driftSession($user, [10, 10, 10, 10, 10, 8, 8, 8, 8, 8], now());
+
+    $window = (new ScoreDriftService($user))->weakestWindow(5, 6);
+
+    expect($window)->not->toBeNull()
+        ->and($window['from'])->toBe(6)
+        ->and($window['to'])->toBe(10)
+        ->and($window['average'])->toBe(8.0);
+});

--- a/tests/Unit/Services/SessionStatsServiceTest.php
+++ b/tests/Unit/Services/SessionStatsServiceTest.php
@@ -204,3 +204,50 @@ it('shotsPerSerie defaults to 10 for empty sessions and longer ones', function (
     statsShotsFor($small, 5);
     expect((new SessionStatsService($small))->shotsPerSerie())->toBe(5);
 });
+
+it('computes mean X/Y offset in mm relative to the centre', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    statsShotsFor($session, 4, ['x_normalized' => 0.5, 'y_normalized' => 0.5, 'ring' => 10, 'score' => 10]);
+
+    $service = new SessionStatsService($session);
+
+    expect($service->meanXmm())->toBe(0.0)
+        ->and($service->meanYmm())->toBe(0.0);
+});
+
+it('returns null mean offset and SD when there are no shots', function (): void {
+    $service = new SessionStatsService(Session::factory()->for(User::factory())->create());
+
+    expect($service->meanXmm())->toBeNull()
+        ->and($service->meanYmm())->toBeNull()
+        ->and($service->sdMm())->toBeNull();
+});
+
+it('computes a positive standard deviation in mm for spread shots', function (): void {
+    $session = Session::factory()->for(User::factory())->create();
+    SessionShot::factory()->for($session)->create(['turn_index' => 0, 'shot_index' => 0, 'x_normalized' => 0.4, 'y_normalized' => 0.5, 'ring' => 9, 'score' => 9]);
+    SessionShot::factory()->for($session)->create(['turn_index' => 0, 'shot_index' => 1, 'x_normalized' => 0.6, 'y_normalized' => 0.5, 'ring' => 9, 'score' => 9]);
+
+    expect((new SessionStatsService($session))->sdMm())->toBeGreaterThan(0.0);
+});
+
+it('computes the score delta versus the user session average', function (): void {
+    $user = User::factory()->create();
+
+    $a = Session::factory()->for($user)->create();
+    statsShotsFor($a, 10, ['ring' => 10, 'score' => 10]); // totaal 100
+
+    $b = Session::factory()->for($user)->create();
+    statsShotsFor($b, 10, ['ring' => 8, 'score' => 8]);   // totaal 80
+
+    // gemiddelde van [100, 80] = 90 → 100 - 90 = +10
+    expect((new SessionStatsService($a))->scoreVsAverage())->toBe(10);
+});
+
+it('returns null score delta with fewer than two sessions', function (): void {
+    $user = User::factory()->create();
+    $a = Session::factory()->for($user)->create();
+    statsShotsFor($a, 5, ['ring' => 10, 'score' => 10]);
+
+    expect((new SessionStatsService($a))->scoreVsAverage())->toBeNull();
+});

--- a/tests/Unit/Services/TrainingGoalServiceTest.php
+++ b/tests/Unit/Services/TrainingGoalServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TrainingGoalSource;
+use App\Models\TrainingGoal;
+use App\Models\User;
+use App\Services\TrainingGoalService;
+
+it('lists only open goals, newest first, scoped to the user', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    $older = TrainingGoal::factory()->create(['user_id' => $user->id, 'title' => 'Ouder doel']);
+    $newer = TrainingGoal::factory()->create(['user_id' => $user->id, 'title' => 'Nieuwer doel']);
+    TrainingGoal::factory()->completed()->create(['user_id' => $user->id, 'title' => 'Afgerond']);
+    TrainingGoal::factory()->create(['user_id' => $other->id]);
+
+    $goals = (new TrainingGoalService)->openGoals($user);
+
+    expect($goals)->toHaveCount(2)
+        ->and($goals->first()->id)->toBe($newer->id)
+        ->and($goals->pluck('title')->all())->not->toContain('Afgerond');
+});
+
+it('adds a manual goal by default', function (): void {
+    $user = User::factory()->create();
+
+    $goal = (new TrainingGoalService)->add($user, 'Micro-pauze schot 30', '30s adem-reset');
+
+    expect($goal->user_id)->toBe($user->id)
+        ->and($goal->title)->toBe('Micro-pauze schot 30')
+        ->and($goal->source)->toBe(TrainingGoalSource::Manual)
+        ->and($goal->completed_at)->toBeNull();
+});
+
+it('adds an AI-sourced goal', function (): void {
+    $user = User::factory()->create();
+
+    $goal = (new TrainingGoalService)->add($user, 'Cadans vasthouden', source: TrainingGoalSource::Ai, targetMonth: '2026-06');
+
+    expect($goal->source)->toBe(TrainingGoalSource::Ai)
+        ->and($goal->target_month)->toBe('2026-06');
+});
+
+it('completes a goal idempotently', function (): void {
+    $goal = TrainingGoal::factory()->create();
+    $service = new TrainingGoalService;
+
+    $service->complete($goal);
+    $firstCompletedAt = $goal->fresh()->completed_at;
+
+    expect($firstCompletedAt)->not->toBeNull();
+
+    $service->complete($goal->fresh());
+    expect($goal->fresh()->completed_at->equalTo($firstCompletedAt))->toBeTrue();
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: [
+                'resources/css/app.css',
+                'resources/css/filament/admin/theme.css',
+            ],
+            refresh: true,
+        }),
+        tailwindcss(),
+    ],
+});


### PR DESCRIPTION
## Context

Fidelity-ronde op umbrella-issue #82. Fase 1 (Range Console, #88) was functioneel af, maar de visuele fidelity t.o.v. het design-handoff was onvoldoende ("komt in de buurt maar we zijn er echt niet") en het AI-stuk crashte/leunde op te weinig data. Deze PR pakt **alle workstreams A–G** uit het PLAN (`.ai/plans/PLAN-issue-82-fase-1b-design-fidelity.md`) plus het opgefleurde dashboard. AI-scope: zie de #82-comment (https://github.com/Marcvdc/AimTrack/issues/82#issuecomment-4634514579).

## Wat zit erin

**Theme & toolchain (R1/R2)**
- Volledige npm/vite/tailwind-v4-toolchain opgezet (was er niet) + echte Filament-theme via `->viteTheme()`. Filaments grijs-schaal hergemapt naar **Signal Mint dark** (`@theme`), dark geforceerd, sidebar 14rem. Witte alpha-randen (`white/5/10/20`) van tabellen/sections/widgets herkleurd naar `--line`/`--panel-2` (einde "gewassen" look). `@source` dekt álle views (incl. livewire-schotenbord).
- Nav hergegroepeerd **LOG / INZICHT / BEHEER** + user-gescoopte nav-badges. `target-rings` design-getrouw (groep i.p.v. hagel); `sparkline` met gradient + terminal-dot.

**Range Console-schermen**
- Sessies-overzicht: dense Signal-Mint, "Wapens · gebruik"-kaart.
- Sessie-detail: EINDSCORE-delta, tijd-window, X/Y/SD, AI-reflectie-acties ("Vraag coach"/"Markeer") + **switch naar het schotenbord (roos)**.
- Wapen-detail: `AiWeaponInsight` getoond (T3), SERIAL-subtitle.
- Wizard "Schoten"-stap: live keuzes (gekozen wapen/datum/geplande schoten) i.p.v. placeholders.

**AI-stuk (R3 + nieuwe features)**
- `Deviation`-enum-crash in `ShooterCoach` weg; schotstatistiek in de reflectie-prompt.
- `ai_reflections.acknowledged_at` ("Markeer als gelezen").
- **TrainingGoal**: model + service + Copilot-tool `AddTrainingGoalTool` + "Voorgestelde doelen"-rail.
- **ScoreDriftService** + `ScoreDriftTool` + score-drift-kaart op de coach.
- Copilot chat-input leesbaar gemaakt (contrast) + assets auto-publish.

**Dashboard**
- Failed-jobs-grid vervangen door een gebruikers-overzicht: KPI's, "Leergebieden · voortgang" (per discipline), trainingsdoelen, "KNSA · kennisbank".
- Mislukte queue-jobs verplaatst naar **BEHEER › Mislukte jobs**, afgeschermd tot admins (nieuwe `users.is_admin`).

## Migraties
- `ai_reflections.acknowledged_at`
- `training_goals` (nieuw)
- `users.is_admin` (default false; demo-admin = true)

## Nieuwe infra/config
- `package.json` + `vite.config.js` + `resources/css/app.css` + `resources/css/filament/admin/theme.css` (Filament-theme via Vite).
- `phpunit.xml`: `<server force="true">` voor DB → tests draaien altijd op sqlite (anders wist een testrun in de dev-container de pgsql dev-DB).
- `composer post-autoload-dump` + `docker/entrypoint.sh`: auto-publish van de FilamentCopilot-assets.
- `worktree-setup.sh`: stemt APP_URL/WEB_PORT in de gekopieerde `.env.local` af op de worktree-poort.
- `tests/TestCase.php`: `withoutVite()` (CI bouwt de frontend niet in de test-job; tests toetsen gedrag, geen styling).

## Tests / CI
- ~70 nieuwe/aangepaste Pest-tests (components, services, Copilot-tools, screen-renders, nav-badges, admin-toegang). **CI groen**: Lint (Pint) ✓ · Tests (Pest) ✓ · Build ✓.

## Bewust niet in deze PR (vervolg)
Volledige in-page chat-thread (coach = launcher) · wizard-numpad/modal-overhaul · eigen icon-set · skill-leergebieden met aparte tracking · weer/wapengewicht/onderhoud-velden (ontbreken in datamodel) · Fase 3 (marketing) · Fase 4 (mobile).

Ref #82 (Fase 1b).
