### PR TITLE
fix(ci): image-build groen + multi-arch image voor staging/prod (#99)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Build-context parity tussen lokale en CI-build, en een kleinere/snellere context.
+# vendor/ en node_modules/ worden in de image-stages opnieuw opgebouwd
+# (composer install --no-dev resp. npm ci); .git/ en .env* horen niet in de image.
+# public/build wordt door de frontend-stage (vite) gegenereerd.
+
+# Version control
+.git
+.gitignore
+.gitattributes
+
+# Dependencies (worden in de image opnieuw opgebouwd)
+/vendor
+/node_modules
+
+# Secrets / lokale env (runtime-geïnjecteerd via compose env_file)
+.env
+.env.*
+
+# Gegenereerde frontend-assets
+/public/build
+/public/hot
+
+# Logs en OS-rommel
+*.log
+.DS_Store
+Thumbs.db

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -53,6 +53,9 @@ jobs:
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "registry_image=ghcr.io/${OWNER}/aimtrack" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -70,6 +73,7 @@ jobs:
           file: Dockerfile
           push: true
           provenance: false
+          platforms: linux/amd64,linux/arm64
           build-args: |
             PHP_VERSION=8.4
             APP_ENV=production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,6 +31,9 @@ jobs:
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
           echo "registry_image=ghcr.io/${OWNER}/aimtrack" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,6 +51,7 @@ jobs:
           file: Dockerfile
           push: true
           provenance: false
+          platforms: linux/amd64,linux/arm64
           build-args: |
             PHP_VERSION=8.4
             APP_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,18 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/html
 
+FROM base AS vendor
+COPY composer.json composer.lock* ./
+RUN composer install --no-dev --prefer-dist --no-progress --optimize-autoloader --no-scripts
+
 FROM node:20-bookworm AS frontend
 WORKDIR /app
 COPY . .
+# De Filament theme (resources/css/filament/admin/theme.css) importeert CSS uit
+# vendor/filament/...; bij een verse CI-checkout bestaat vendor/ nog niet, dus
+# kopieer 'm uit de vendor-stage vóór de vite/Tailwind-build. De vendor-stage
+# staat daarom bewust vóór deze stage (BuildKit vereist eerdere definitie).
+COPY --from=vendor /var/www/html/vendor ./vendor
 RUN mkdir -p /opt/artifacts/public-build \
     && if [ -f package.json ]; then \
          npm ci --no-progress --fund=false --audit=false; \
@@ -51,10 +60,6 @@ FROM base AS dev
 COPY composer.json composer.lock* ./
 RUN composer install --prefer-dist --no-progress --no-scripts
 COPY . .
-
-FROM base AS vendor
-COPY composer.json composer.lock* ./
-RUN composer install --no-dev --prefer-dist --no-progress --optimize-autoloader --no-scripts
 
 FROM base AS production
 ENV APP_ENV=production \


### PR DESCRIPTION
## Wat

Repareert de GHCR-flow ("CI bouwt → host pullt") zodat de image betrouwbaar gebouwd én gepulld kan worden.

- **Fix A — `Dockerfile`**: de `vendor`-stage is vóór de `frontend`-stage geplaatst en de `frontend`-stage kopieert `vendor/` (`COPY --from=vendor`) vóór `npm run build`. De Filament `resources/css/filament/admin/theme.css` doet `@import '.../vendor/filament/filament/resources/css/theme.css'`; bij een verse CI-checkout bestaat `vendor/` nog niet → de vite/Tailwind-build faalde. (NB: enkel de `COPY`-regel toevoegen volstond niet — BuildKit weigert `COPY --from=` een stage die later is gedefinieerd, vandaar de stage-reorder.)
- **Fix B — `deploy-staging.yml` + `deploy-production.yml`**: `docker/setup-qemu-action@v3` + `platforms: linux/amd64,linux/arm64` op `build-push-action`. Eerst kreeg de image de arch van de cloud-runner (amd64) terwijl de host ARM64 is → `exec format error`. Nu een multi-arch manifest; de host pullt automatisch de juiste variant (huidige host = arm64-Pi, kan wijzigen).
- **`.dockerignore`** (nieuw): build-context parity tussen lokaal en CI (`vendor`, `node_modules`, `.git`, `.env*`, `public/build`).

De pull-only deploy op de host was al in orde: `compose.staging/prod.yml` gebruiken `image:` (geen `build:`) en `scripts/remote_deploy.sh` doet `docker compose pull && up -d` + `migrate` — daar is niets aan gewijzigd.

## Waarom

Closes #99. De workflow *Deploy - Staging* faalde in *Build and push image* (frontend-stage), dus er werd nooit een image naar GHCR gepusht; en zelfs bij succes matchte de amd64-image de arm64-host niet. Hangt samen met #90 (Production-deploy faalt door `secrets` in `if:` — andere oorzaak, **buiten scope** van deze PR).

## Hoe getest

- **Lokale `docker build --target production`** op een verse worktree (= schone CI-checkout, geen `vendor/`/`node_modules/`): **slaagt**. De eerder falende stap draait nu door: `vite v6.4.3 building for production… ✓ modules transformed → public/build/assets/theme-*.css (619 kB) → ✓ built`. Image wordt geëxporteerd.
- Beide workflows gevalideerd als geldige YAML.
- Volledige **arm64**-helft van de multi-arch build (traag onder QEMU) en de host-side checks (AC #1 `uname -m` → `aarch64`, AC #5 Filament-admin laadt met thema) worden bevestigd door de echte *Deploy - Staging*-run na merge naar `staging`.