### PR TITLE
feat(sessions): schotenbord opknappen + wizard-opties echt maken (#100)

### DIFF
--- a/app/Filament/Resources/SessionResource/Pages/CreateSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/CreateSession.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\SessionResource\Pages;
 
 use App\Filament\Resources\SessionResource;
+use App\Models\User;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Resources\Pages\CreateRecord\Concerns\HasWizard;
 use Filament\Schemas\Components\View as ViewComponent;
@@ -16,6 +17,50 @@ class CreateSession extends CreateRecord
     use HasWizard;
 
     protected static string $resource = SessionResource::class;
+
+    /**
+     * Per-gebruiker bordvoorkeuren, getoond als echte toggles in de
+     * "Schoten"-stap. Gespiegeld vanuit User::preferences zodat de blade
+     * de actuele stand toont en togglePreference() direct persisteert.
+     *
+     * @var array<string, bool>
+     */
+    public array $boardPreferences = [];
+
+    public function mount(): void
+    {
+        parent::mount();
+
+        $this->loadBoardPreferences();
+    }
+
+    /**
+     * Wissel een bekende bordvoorkeur en persisteer 'm op de gebruiker.
+     */
+    public function togglePreference(string $key): void
+    {
+        $user = auth()->user();
+
+        if (! $user || ! array_key_exists($key, User::PREFERENCE_DEFAULTS)) {
+            return;
+        }
+
+        $value = ! $user->preference($key);
+
+        $user->setPreference($key, $value);
+        $this->boardPreferences[$key] = $value;
+    }
+
+    private function loadBoardPreferences(): void
+    {
+        $user = auth()->user();
+
+        $this->boardPreferences = collect(array_keys(User::PREFERENCE_DEFAULTS))
+            ->mapWithKeys(fn (string $key): array => [
+                $key => (bool) $user?->preference($key),
+            ])
+            ->all();
+    }
 
     /**
      * Range Console nieuwe-sessie wizard — 4 stappen conform

--- a/app/Filament/Resources/SessionResource/Pages/ManageSessionShots.php
+++ b/app/Filament/Resources/SessionResource/Pages/ManageSessionShots.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\SessionResource\Pages;
 
 use App\Filament\Resources\SessionResource;
+use App\Jobs\GenerateSessionReflectionJob;
 use App\Livewire\SessionShotBoard;
+use App\Support\Features\AimtrackFeatureToggle;
 use Filament\Actions\Action;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\Concerns\InteractsWithRecord;
 use Filament\Resources\Pages\Page;
 
@@ -36,11 +39,39 @@ class ManageSessionShots extends Page
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('finish')
+                ->label('Sessie afronden')
+                ->icon('heroicon-m-check-circle')
+                ->color('primary')
+                ->action(fn () => $this->finishSession()),
             Action::make('back')
                 ->label('Terug naar sessie')
                 ->icon('heroicon-m-arrow-uturn-left')
+                ->color('gray')
                 ->url($this->getResource()::getUrl('edit', ['record' => $this->record])),
         ];
+    }
+
+    /**
+     * Rond de sessie af. Staat de voorkeur "auto AI-reflectie" aan én is
+     * AI ingeschakeld, dan wordt de reflectie ingepland. Daarna terug naar
+     * de sessie-weergave.
+     */
+    public function finishSession(): void
+    {
+        $autoReflect = (bool) auth()->user()?->preference('auto_ai_reflection');
+
+        if ($autoReflect && app(AimtrackFeatureToggle::class)->aiEnabled()) {
+            GenerateSessionReflectionJob::dispatch($this->getRecord());
+
+            Notification::make()
+                ->title('AI-reflectie ingepland')
+                ->body('Zodra de coach klaar is verschijnt de reflectie bij de sessie.')
+                ->success()
+                ->send();
+        }
+
+        $this->redirect($this->getResource()::getUrl('view', ['record' => $this->getRecord()]));
     }
 
     /**

--- a/app/Livewire/SessionShotBoard.php
+++ b/app/Livewire/SessionShotBoard.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use App\Models\Session;
 use App\Models\SessionShot;
 use App\Services\Sessions\SessionShotService;
+use App\Services\Sessions\ShotScoringService;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
@@ -12,9 +13,8 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Contracts\TranslatableContentDriver;
-use Filament\Tables\Columns\Summarizers\Average;
 use Filament\Tables\Columns\Summarizers\Count;
-use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\Summarizers\Summarizer;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
@@ -64,9 +64,15 @@ class SessionShotBoard extends Component implements HasActions, HasSchemas, HasT
 
     public bool $canEdit = false;
 
+    public bool $showRings = false;
+
+    public bool $decimalNotation = true;
+
     public ?int $pendingDeleteShotId = null;
 
     protected SessionShotService $shotService;
+
+    protected ShotScoringService $scoringService;
 
     private const TURN_COLOR_PALETTE = [
         '#0ea5e9', // sky
@@ -79,9 +85,10 @@ class SessionShotBoard extends Component implements HasActions, HasSchemas, HasT
         '#14b8a6', // teal
     ];
 
-    public function boot(SessionShotService $shotService): void
+    public function boot(SessionShotService $shotService, ShotScoringService $scoringService): void
     {
         $this->shotService = $shotService;
+        $this->scoringService = $scoringService;
     }
 
     public function mount(Session $session): void
@@ -92,6 +99,12 @@ class SessionShotBoard extends Component implements HasActions, HasSchemas, HasT
 
         if ($this->readOnly) {
             $this->canEdit = false;
+        }
+
+        $user = auth()->user();
+        if ($user) {
+            $this->showRings = (bool) $user->preference('board_show_rings');
+            $this->decimalNotation = (bool) $user->preference('decimal_notation');
         }
 
         $this->refreshData();
@@ -148,6 +161,55 @@ class SessionShotBoard extends Component implements HasActions, HasSchemas, HasT
             'turn_index' => $next,
             'turn_options' => $this->turnOptions,
         ]);
+    }
+
+    /**
+     * Wissel het tonen van de ringnummers op de roos en persisteer de
+     * voorkeur op de gebruiker (geldt voor al z'n borden).
+     */
+    public function toggleRings(): void
+    {
+        $this->showRings = ! $this->showRings;
+
+        auth()->user()?->setPreference('board_show_rings', $this->showRings);
+    }
+
+    /**
+     * Score-weergave voor de tabel: één decimaal (afgeleid uit de afstand)
+     * wanneer decimaal-notatie aan staat, anders de hele ring.
+     */
+    public function formatScore(?int $state, SessionShot $record): string
+    {
+        if ($this->decimalNotation) {
+            $decimal = $this->scoringService->decimalScore((float) $record->distance_from_center);
+
+            return '+'.number_format($decimal, 1, '.', '');
+        }
+
+        return $state ? '+'.$state : '+0';
+    }
+
+    /**
+     * Aggregeer de score-kolom voor de tabelvoet. Volgt dezelfde decimaal- vs
+     * hele-ring-weergave als de rijen (en de KPI-strook), zodat voet, rijen en
+     * paginakop niet uiteenlopen.
+     *
+     * @param  Collection<int, mixed>  $shots
+     */
+    public function summarizeScores(Collection $shots, bool $average): string
+    {
+        if ($shots->isEmpty()) {
+            return $average ? '—' : number_format(0, $this->decimalNotation ? 1 : 0, '.', '');
+        }
+
+        $values = $this->decimalNotation
+            ? $shots->map(fn ($shot): float => $this->scoringService->decimalScore((float) ($shot->distance_from_center ?? 0)))
+            : $shots->map(fn ($shot): float => (float) ($shot->score ?? 0));
+
+        $result = $average ? (float) $values->avg() : (float) $values->sum();
+        $decimals = ($average || $this->decimalNotation) ? 1 : 0;
+
+        return number_format($result, $decimals, '.', '');
     }
 
     public function recordShot(float $xNormalized, float $yNormalized): void
@@ -368,10 +430,14 @@ class SessionShotBoard extends Component implements HasActions, HasSchemas, HasT
                     ->sortable(),
                 TextColumn::make('score')
                     ->label('Score')
-                    ->formatStateUsing(fn (?int $state) => $state ? '+'.$state : '+0')
+                    ->formatStateUsing(fn (?int $state, SessionShot $record): string => $this->formatScore($state, $record))
                     ->summarize([
-                        Sum::make()->label('Totaal'),
-                        Average::make()->label('Gemiddelde')->formatStateUsing(fn ($state) => number_format((float) $state, 2)),
+                        Summarizer::make()
+                            ->label('Totaal')
+                            ->using(fn ($query): string => $this->summarizeScores(collect($query->get()), false)),
+                        Summarizer::make()
+                            ->label('Gem.')
+                            ->using(fn ($query): string => $this->summarizeScores(collect($query->get()), true)),
                     ]),
                 TextColumn::make('created_at')
                     ->label('Tijd')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,6 +11,18 @@ class User extends Authenticatable
     use HasFactory;
     use Notifiable;
 
+    /**
+     * Bekende voorkeuren + hun defaults. Dient als whitelist: onbekende keys
+     * worden door setPreference() genegeerd.
+     *
+     * @var array<string, bool>
+     */
+    public const PREFERENCE_DEFAULTS = [
+        'board_show_rings' => false,
+        'decimal_notation' => true,
+        'auto_ai_reflection' => false,
+    ];
+
     protected $fillable = [
         'name',
         'email',
@@ -33,11 +45,39 @@ class User extends Authenticatable
         'is_admin' => 'boolean',
         'anthropic_api_key' => 'encrypted',
         'ai_key_verified_at' => 'datetime',
+        'preferences' => 'array',
     ];
 
     public function isAdmin(): bool
     {
         return (bool) $this->is_admin;
+    }
+
+    /**
+     * Lees een gebruikersvoorkeur; valt terug op de default uit
+     * PREFERENCE_DEFAULTS, of null voor een onbekende key.
+     */
+    public function preference(string $key): mixed
+    {
+        $stored = $this->preferences ?? [];
+
+        return $stored[$key] ?? self::PREFERENCE_DEFAULTS[$key] ?? null;
+    }
+
+    /**
+     * Schrijf een bekende voorkeur weg. Onbekende keys worden genegeerd
+     * (whitelist via PREFERENCE_DEFAULTS).
+     */
+    public function setPreference(string $key, mixed $value): void
+    {
+        if (! array_key_exists($key, self::PREFERENCE_DEFAULTS)) {
+            return;
+        }
+
+        $preferences = $this->preferences ?? [];
+        $preferences[$key] = $value;
+        $this->preferences = $preferences;
+        $this->save();
     }
 
     public function sessions()

--- a/app/Services/Sessions/ShotScoringService.php
+++ b/app/Services/Sessions/ShotScoringService.php
@@ -31,6 +31,20 @@ class ShotScoringService
     }
 
     /**
+     * Decimaal-score (één decimaal) afgeleid uit de afstand tot het midden.
+     * Puur weergave: dezelfde lineaire schaal als scoreShot(), maar zonder de
+     * ceil()-afronding naar hele ringen. Wijzigt de opgeslagen score niet.
+     */
+    public function decimalScore(float $distanceFromCenter, array $options = []): float
+    {
+        $maxRadius = $options['max_radius'] ?? 0.5;
+        $normalizedDistance = min(max($distanceFromCenter, 0) / $maxRadius, 1);
+        $rawScore = (1 - $normalizedDistance) * self::MAX_SCORE;
+
+        return round(max(0, $rawScore), 1);
+    }
+
+    /**
      * Bereken aggregaties per sessie.
      */
     public function aggregate(Collection $shots): array

--- a/database/migrations/2026_06_07_090411_add_preferences_to_users_table.php
+++ b/database/migrations/2026_06_07_090411_add_preferences_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->json('preferences')->nullable()->after('ai_key_verified_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('preferences');
+        });
+    }
+};

--- a/resources/views/filament/resources/session-resource/pages/manage-session-shots.blade.php
+++ b/resources/views/filament/resources/session-resource/pages/manage-session-shots.blade.php
@@ -1,90 +1,62 @@
 <x-filament::page>
     @php
-        $totalShots = $record->shots()->count();
-        $totalPoints = $record->shots()->sum('score');
+        $decimal = (bool) (auth()->user()?->preference('decimal_notation') ?? true);
+        $scoring = app(\App\Services\Sessions\ShotScoringService::class);
+        $shots = $record->shots()->get();
+        $totalShots = $shots->count();
+        $totalPoints = $decimal
+            ? round($shots->sum(fn ($shot) => $scoring->decimalScore((float) $shot->distance_from_center)), 1)
+            : (int) $shots->sum('score');
         $average = $totalShots > 0 ? round($totalPoints / $totalShots, 1) : 0;
-        
-        // Get turn options for the dropdown
-        $turnOptions = range(0, max(0, $record->shots()->max('turn_index') ?? 0));
-        
-        $sessionLabel = $record->date?->format('d-m-Y') ? 'Sessie: ' . $record->date->format('d-m-Y') : 'Sessie #' . $record->getKey();
+        $fmt = fn ($value): string => number_format((float) $value, $decimal ? 1 : 0, '.', '');
+
+        $turnOptions = range(0, max(0, (int) ($record->shots()->max('turn_index') ?? 0)));
+        $sessionLabel = $record->date ? 'Sessie · ' . $record->date->format('d-m-Y') : 'Sessie #' . $record->getKey();
     @endphp
 
     
 
-    <div class="mb-6">
-        <div class="flex items-center gap-3">
-            <x-filament::badge color="info" size="md">
-                Modus Bewerken
-            </x-filament::badge>
-            <x-filament::badge color="success" size="md">
-                Punten {{ number_format($totalPoints) }}
-            </x-filament::badge>
-            <x-filament::badge color="warning" size="md">
-                Schoten {{ number_format($totalShots) }}
-            </x-filament::badge>
-            <x-filament::badge color="danger" size="md">
-                Gemiddelde {{ number_format($average, 1, ',', '.') }}
-            </x-filament::badge>
+    <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px; margin-bottom: 16px;">
+        <div>
+            <div class="at-label">Schoten registreren</div>
+            <div style="font-size: 18px; font-weight: 600; color: var(--at-text); margin-top: 4px;">{{ $sessionLabel }}</div>
         </div>
+        <span style="display: inline-flex; align-items: center; gap: 6px; padding: 5px 12px; border-radius: var(--at-r-pill); background: var(--at-accent-12); border: 1px solid var(--at-accent-25); font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.14em; color: var(--at-accent);">
+            <span style="width: 6px; height: 6px; border-radius: 50%; background: var(--at-accent);"></span>
+            MODUS BEWERKEN
+        </span>
     </div>
 
-    <div class="mb-4">
-        <x-filament::section icon="heroicon-o-calendar-days" icon-size="sm" class="bg-white/85 dark:bg-gray-900/60 rounded-2xl p-4 shadow-sm">
-            <x-slot name="heading">
-                {{ $sessionLabel }}
-            </x-slot>
-        </x-filament::section>
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-bottom: 20px;">
+        <x-aimtrack.stat-card label="Punten" :value="$fmt($totalPoints)" valueTone="accent" />
+        <x-aimtrack.stat-card label="Schoten" :value="(string) $totalShots" />
+        <x-aimtrack.stat-card label="Gemiddelde / schot" :value="$totalShots > 0 ? $fmt($average) : '—'" />
     </div>
 
-    <!-- Beurt Selectie -->
-    <div class="mb-6 rounded-3xl border border-gray-200/70 bg-white/80 px-5 py-4 shadow-sm dark:border-gray-800/60 dark:bg-gray-900/60">
-        <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        
+    <!-- Info / beurt-legenda -->
+    <div x-data="{ expanded: false }" style="margin-bottom: 20px; padding: 14px 16px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-2xl);">
+        <button type="button" x-on:click="expanded = ! expanded"
+            style="display: flex; align-items: center; justify-content: space-between; width: 100%; background: none; border: none; color: var(--at-text); cursor: pointer; padding: 0;">
+            <span style="display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600;">
+                <x-filament::icon icon="heroicon-o-information-circle" class="h-4 w-4" style="color: var(--at-muted);" />
+                Hoe werkt de interactieve roos?
+            </span>
+            <x-filament::icon icon="heroicon-m-chevron-down" x-bind:class="expanded ? 'rotate-180' : ''" class="h-4 w-4 transition-transform duration-200" style="color: var(--at-muted);" />
+        </button>
 
-            <div x-data="{ expanded: false }" class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                <x-filament::section icon="heroicon-o-information-circle" icon-size="sm" class="flex-1 bg-white/85 dark:bg-gray-900/60">
-                    <x-slot name="heading">
-                        <div class="flex items-center gap-2 cursor-pointer" x-on:click="expanded = ! expanded">
-                            <span>Interactieve roos</span>
-                        </div>
-                    </x-slot>
-                    
-                    <x-slot name="description">
-                        Open dit panel voor extra informatie over de interactieve roos
-                    </x-slot>
-                    
-                    <x-slot name="afterHeader">
-                        <div class="cursor-pointer" x-on:click="expanded = ! expanded">
-                            <x-filament::icon 
-                                icon="heroicon-m-chevron-down" 
-                                x-bind:class="expanded ? 'rotate-180' : ''"
-                                class="transition-transform duration-200 text-gray-500 dark:text-gray-400"
-                            />
-                        </div>
-                    </x-slot>
+        <div x-show="expanded" x-collapse.duration.300ms style="margin-top: 12px; font-size: 13px; color: var(--at-muted); line-height: 1.6;">
+            Klik op de roos om een schot te plaatsen, wissel tussen beurten met de selector, en verwijder een marker met een long-press (2s) of rechtermuisklik. Score en ring worden automatisch berekend.
 
-                    <div x-show="expanded" x-collapse.duration.300ms>
-                        Klik om schoten te plaatsen, wissel tussen beurten en verwijder markers met een long-press (of rechtermuisklik).
-                        
-                        <div class="mt-4">
-                            <div class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Beurt legenda:</div>
-                            <div class="flex flex-wrap gap-2">
-                                @foreach ($turnOptions as $turn)
-                                    <div class="flex items-center gap-1">
-                                        <span class="inline-flex h-4 w-4 rounded-full border border-gray-300 dark:border-gray-600" style="background-color: {{ $this->getTurnColor($turn) }}">&nbsp;</span>
-                                        <span class="text-xs text-gray-700 dark:text-gray-300">Beurt {{ $turn + 1 }}</span>
-                                    </div>
-                                @endforeach
-                            </div>
-                        </div>
-                        
-                        <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-300">
-                            <x-filament::badge color="gray">Lang indrukken = verwijderen</x-filament::badge>
-                            <x-filament::badge color="gray">Klik om nieuwe schoten te registreren</x-filament::badge>
-                        </div>
-                    </div>
-                </x-filament::section>
+            <div style="margin-top: 14px;">
+                <div class="at-label" style="margin-bottom: 8px;">Beurt-legenda</div>
+                <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+                    @foreach ($turnOptions as $turn)
+                        <span style="display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--at-text);">
+                            <span style="display: inline-block; width: 14px; height: 14px; border-radius: 50%; border: 1px solid var(--at-line); background: {{ $this->getTurnColor($turn) }};"></span>
+                            Beurt {{ $turn + 1 }}
+                        </span>
+                    @endforeach
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -101,17 +101,34 @@
 
         <div>
             <div class="at-label">OPTIES</div>
+            @php
+                // Echte, persisterende user-voorkeuren (CreateSession::$boardPreferences).
+                // Label-volgorde conform new-session-wizard.jsx.
+                $optionRows = [
+                    ['key' => 'auto_ai_reflection', 'label' => 'AI-reflectie'],
+                    ['key' => 'decimal_notation', 'label' => 'Decimaal-notatie'],
+                    ['key' => 'board_show_rings', 'label' => 'Toon ringen-view'],
+                ];
+            @endphp
             <div style="margin-top: 10px; display: flex; flex-direction: column; gap: 8px;">
-                @foreach ([['AI-reflectie', true], ['Decimaal-notatie', true], ['Toon ringen-view', false]] as [$label, $on])
-                    <div style="display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--at-text);">
-                        <div style="width: 30px; height: 18px; border-radius: 999px; background: {{ $on ? 'var(--at-accent)' : 'var(--at-line)' }}; position: relative; flex-shrink: 0;">
-                            <div style="position: absolute; top: 2px; left: {{ $on ? '14px' : '2px' }}; width: 14px; height: 14px; border-radius: 50%; background: var(--at-cta-text);"></div>
-                        </div>
-                        <span>{{ $label }}</span>
-                    </div>
+                @foreach ($optionRows as $option)
+                    @php $on = (bool) ($this->boardPreferences[$option['key']] ?? false); @endphp
+                    <button
+                        type="button"
+                        wire:click="togglePreference('{{ $option['key'] }}')"
+                        role="switch"
+                        aria-checked="{{ $on ? 'true' : 'false' }}"
+                        aria-label="{{ $option['label'] }}"
+                        style="display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--at-text); background: none; border: none; padding: 2px 0; cursor: pointer; text-align: left; width: 100%;"
+                    >
+                        <span style="width: 30px; height: 18px; border-radius: 999px; background: {{ $on ? 'var(--at-accent)' : 'var(--at-line)' }}; position: relative; flex-shrink: 0; transition: background 0.15s ease;">
+                            <span style="position: absolute; top: 2px; left: {{ $on ? '14px' : '2px' }}; width: 14px; height: 14px; border-radius: 50%; background: var(--at-cta-text); transition: left 0.15s ease;"></span>
+                        </span>
+                        <span>{{ $option['label'] }}</span>
+                    </button>
                 @endforeach
             </div>
-            <div style="margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">VOORKEUREN · BINNENKORT INSTELBAAR</div>
+            <div style="margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">VOORKEUREN · GELDEN VOOR AL JE SESSIES</div>
         </div>
 
         <x-aimtrack.bracket-frame :rounded="8" :padding="14" style="background: var(--at-accent-12); display: flex; flex-direction: column; gap: 6px;">

--- a/resources/views/livewire/session-shot-board.blade.php
+++ b/resources/views/livewire/session-shot-board.blade.php
@@ -8,6 +8,7 @@
             turns: @entangle('turnOptions').live,
             currentTurn: @entangle('currentTurnIndex').live,
             turnLegend: @entangle('turnLegend').live,
+            showRings: @entangle('showRings').live,
             allTurnsValue: @js(\App\Livewire\SessionShotBoard::ALL_TURNS_VALUE),
         })
     }">
@@ -48,60 +49,56 @@
         </x-slot>
     </x-filament::modal>
 
-    <!-- Beurt Selectie -->
-    <div class="mb-6">
-        <x-filament::section>
-            <x-slot name="heading">
-                <div class="flex items-center justify-between">
-                    <span class="text-sm font-semibold text-gray-700 dark:text-gray-100">Beurt selectie</span>
-                    @if ($canEdit)
+    <!-- Controlebalk: beurt-selectie · nieuwe beurt · ringnummers-toggle -->
+    <div class="mb-5" style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 16px; padding: 16px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-2xl);">
+        <div style="display: flex; flex-direction: column; gap: 6px;">
+            <span class="at-label">Beurt</span>
+            <select wire:model.live="currentTurnIndex"
+                style="background: var(--at-bg); border: 1px solid var(--at-line); color: var(--at-text); border-radius: var(--at-r-lg); padding: 8px 14px; font-size: 13px; font-family: var(--at-font-mono);">
+                <option value="{{ \App\Livewire\SessionShotBoard::ALL_TURNS_VALUE }}">Alle beurten</option>
+                @foreach ($turnOptions as $turn)
+                    <option value="{{ $turn }}">Beurt {{ $turn + 1 }}</option>
+                @endforeach
+            </select>
+        </div>
 
+        @if ($canEdit)
+            <button type="button" wire:click="addTurn"
+                style="display: inline-flex; align-items: center; gap: 6px; padding: 9px 14px; border-radius: var(--at-r-lg); background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; border: none; cursor: pointer;">
+                <x-filament::icon icon="heroicon-m-plus" class="h-4 w-4" />
+                Nieuwe beurt
+            </button>
+        @endif
 
-                     <x-slot name="afterHeader">
-                         <x-filament::button
-                            type="button"
-                            size="sm"
-                            color="primary"
-                            icon="heroicon-m-plus"
-                            wire:click="addTurn"
-                        >
-                            Nieuwe beurt
-                        </x-filament::button>
-                    </x-slot>
-                       
-                    @endif
-                </div>
-            </x-slot>
-            
-            <div class="space-y-2">
-                <select wire:model.live="currentTurnIndex" class="rounded-lg border-gray-300 bg-white px-4 py-2 text-sm focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white">
-                    <option value="{{ \App\Livewire\SessionShotBoard::ALL_TURNS_VALUE }}">Alle beurten</option>
-                    @foreach ($turnOptions as $turn)
-                        <option value="{{ $turn }}">Beurt {{ $turn + 1 }}</option>
-                    @endforeach
-                </select>
-            </div>
-        </x-filament::section>
+        <button type="button" wire:click="toggleRings" role="switch" aria-checked="{{ $showRings ? 'true' : 'false' }}" aria-label="Toon ringnummers op de roos"
+            style="display: inline-flex; align-items: center; gap: 10px; margin-left: auto; padding: 8px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); color: var(--at-text); font-size: 13px; cursor: pointer;">
+            <span style="width: 30px; height: 18px; border-radius: 999px; background: {{ $showRings ? 'var(--at-accent)' : 'var(--at-line)' }}; position: relative; flex-shrink: 0; transition: background .15s ease;">
+                <span style="position: absolute; top: 2px; left: {{ $showRings ? '14px' : '2px' }}; width: 14px; height: 14px; border-radius: 50%; background: var(--at-cta-text); transition: left .15s ease;"></span>
+            </span>
+            Ringnummers
+        </button>
     </div>
 
-    <div class="mx-10 rounded-3xl border border-gray-200/70 bg-white/80 px-5 py-5 shadow-sm dark:border-gray-800/60 dark:bg-gray-900/60">
-        <div class="mt-6"
+    <div style="display: flex; flex-direction: column; gap: 20px; padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-2xl);">
+        <div
             x-data="targetBoard({
-            recordShot: (x, y) => $wire.recordShot(x, y),
-            canEdit: @js($canEdit),
-            rawMarkers: @entangle('markers').live,
-            turns: @entangle('turnOptions').live,
-            currentTurn: @entangle('currentTurnIndex').live,
-            turnLegend: @entangle('turnLegend').live,
-            allTurnsValue: @js(\App\Livewire\SessionShotBoard::ALL_TURNS_VALUE),
-        })"
+                recordShot: (x, y) => $wire.recordShot(x, y),
+                canEdit: @js($canEdit),
+                rawMarkers: @entangle('markers').live,
+                turns: @entangle('turnOptions').live,
+                currentTurn: @entangle('currentTurnIndex').live,
+                turnLegend: @entangle('turnLegend').live,
+                showRings: @entangle('showRings').live,
+                allTurnsValue: @js(\App\Livewire\SessionShotBoard::ALL_TURNS_VALUE),
+            })"
             class="w-full flex flex-col lg:flex-row gap-6"
             x-on:keydown.escape.window="closeContextMenu()"
         >
-            <!-- Interactieve Roos -->
-            <div class="w-full max-w-xl space-y-4">
+            <!-- Interactieve Roos — canvas-techniek ongewijzigd (klik=schot, long-press/rechtsklik=verwijderen) -->
+            <div class="w-full max-w-xl space-y-3">
                 <div
-                    class="relative w-full aspect-square bg-gradient-to-br from-gray-900 to-gray-800 rounded-3xl shadow-2xl overflow-hidden border border-gray-800/60"
+                    class="relative w-full aspect-square overflow-hidden"
+                    style="border-radius: var(--at-r-2xl); border: 1px solid var(--at-line); box-shadow: 0 18px 44px -26px rgba(0,0,0,0.85);"
                     x-ref="board"
                     wire:ignore
                 >
@@ -110,30 +107,24 @@
                     @contextmenu.prevent="handleCanvasRightClick($event)"
                 ></canvas>
                 </div>
+                <p style="font-size: 11px; color: var(--at-muted); font-family: var(--at-font-mono); letter-spacing: 0.04em;">
+                    @if ($canEdit)
+                        KLIK = SCHOT · LANG INDRUKKEN OF RECHTSKLIK OP EEN MARKER = VERWIJDEREN
+                    @else
+                        ALLEEN-LEZEN WEERGAVE
+                    @endif
+                </p>
             </div>
 
             <!-- Doelgebied & Schoten -->
-            <div class="flex-1 space-y-4">
-                <x-filament::section>
-                    <x-slot name="heading">
-                        <div class="flex items-center gap-2">
-                            <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-100">Doelgebied & schoten</h3>
-                        </div>
-                    </x-slot>
-
-                     <x-slot name="description">
-                        Beheer beurten en bekijk gedetailleerde schotinformatie. Gebruik de filters om specifieke beurten te tonen.
-                    </x-slot>
-                    
-                    <div class="space-y-2">
-                        <p class="text-xs text-gray-500 mb-0"></p>
-                        <div class="p-2">
-                            {{ $this->table }}
-                        </div>
-                    </div>
-                </x-filament::section>
-
-                
+            <div class="flex-1 space-y-3" style="min-width: 0;">
+                <div class="at-label">Doelgebied &amp; schoten</div>
+                <p style="font-size: 12px; color: var(--at-muted); margin: 0;">
+                    Beheer beurten en bekijk schotinformatie. Gebruik de filters om specifieke beurten te tonen.
+                </p>
+                <div>
+                    {{ $this->table }}
+                </div>
             </div>
         </div>
     </div>
@@ -170,7 +161,7 @@
         const registerTargetBoard = () => {
             console.log('[SessionShotBoard] registerTargetBoard executed');
 
-            window.targetBoard = ({ recordShot, canEdit, rawMarkers, turns, currentTurn, turnLegend, allTurnsValue }) => ({
+            window.targetBoard = ({ recordShot, canEdit, rawMarkers, turns, currentTurn, turnLegend, showRings, allTurnsValue }) => ({
                 rawMarkers,
                 renderMarkers: [],
                 currentMarkers: [],
@@ -178,6 +169,7 @@
                 currentTurn: Number(currentTurn ?? 0),
                 turnLegend: Array.isArray(turnLegend) ? [...turnLegend] : [],
                 allTurnsValue: allTurnsValue ?? -1,
+                showRings: showRings ?? false,
                 canEdit,
                 longPressTimeout: null,
                 longPressTarget: null,
@@ -207,6 +199,10 @@
                     this.$watch('turnLegend', (value) => {
                         console.log('[SessionShotBoard] turnLegend updated', value);
                         this.turnLegend = Array.isArray(value) ? [...value] : [];
+                    });
+                    this.$watch('showRings', (value) => {
+                        this.showRings = Boolean(value);
+                        this.scheduleDraw();
                     });
                     this.$watch('currentTurn', (value) => {
                         const normalizedValue = this.normalizeTurnValue(value);
@@ -317,20 +313,22 @@
                         ctx.stroke();
                     });
 
-                    ctx.fillStyle = '#f8fafc';
-                    ctx.font = `${Math.floor(size * 0.034)}px 'Space Grotesk', sans-serif`;
-                    ctx.textAlign = 'center';
-                    ctx.textBaseline = 'middle';
+                    if (this.showRings) {
+                        ctx.fillStyle = '#f8fafc';
+                        ctx.font = `${Math.floor(size * 0.034)}px 'Space Grotesk', sans-serif`;
+                        ctx.textAlign = 'center';
+                        ctx.textBaseline = 'middle';
 
-                    rings.forEach((ring, index) => {
-                        const radius = outerRadius - (index + 0.5) * ringThickness;
-                        const angles = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2];
-                        angles.forEach((angle) => {
-                            const x = center + Math.cos(angle) * radius;
-                            const y = center + Math.sin(angle) * radius;
-                            ctx.fillText(ring.label, x, y);
+                        rings.forEach((ring, index) => {
+                            const radius = outerRadius - (index + 0.5) * ringThickness;
+                            const angles = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2];
+                            angles.forEach((angle) => {
+                                const x = center + Math.cos(angle) * radius;
+                                const y = center + Math.sin(angle) * radius;
+                                ctx.fillText(ring.label, x, y);
+                            });
                         });
-                    });
+                    }
 
                     ctx.lineWidth = size * 0.004;
                     ctx.strokeStyle = '#0f172a';

--- a/tests/Feature/RangeConsole/ShotBoardDisplayTest.php
+++ b/tests/Feature/RangeConsole/ShotBoardDisplayTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\SessionShotBoard;
+use App\Models\Session;
+use App\Models\SessionShot;
+use App\Models\User;
+use Livewire\Livewire;
+
+/**
+ * Schot op afstand 0.13 van het midden → decimaalscore 7.4, hele ring 8.
+ * Het verschil maakt zichtbaar of decimaal-notatie aan of uit staat.
+ */
+function offCentreShot(Session $session): SessionShot
+{
+    return SessionShot::factory()->create([
+        'session_id' => $session->id,
+        'turn_index' => 0,
+        'shot_index' => 0,
+        'x_normalized' => 0.5,
+        'y_normalized' => 0.37,
+        'distance_from_center' => 0.13,
+        'ring' => 8,
+        'score' => 8,
+    ]);
+}
+
+it('records a shot on the current turn and scores it', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->assertSet('currentTurnIndex', 0)
+        ->call('recordShot', 0.5, 0.5);
+
+    $shot = $session->shots()->first();
+
+    expect($shot)->not->toBeNull()
+        ->and($shot->turn_index)->toBe(0)
+        ->and($shot->ring)->toBe(10)
+        ->and($shot->score)->toBe(10);
+});
+
+it('summarises the score column as a decimal total/average when decimal notation is on', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('decimal_notation', true);
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    $board = Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->instance();
+
+    // distance 0.13 -> 7.4 ; distance 0.0 -> 10.0
+    $shots = collect([
+        (object) ['distance_from_center' => 0.13, 'score' => 8],
+        (object) ['distance_from_center' => 0.0, 'score' => 10],
+    ]);
+
+    expect($board->summarizeScores($shots, false))->toBe('17.4')
+        ->and($board->summarizeScores($shots, true))->toBe('8.7');
+});
+
+it('summarises the score column as whole rings when decimal notation is off', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('decimal_notation', false);
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    $board = Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->instance();
+
+    $shots = collect([
+        (object) ['distance_from_center' => 0.13, 'score' => 8],
+        (object) ['distance_from_center' => 0.0, 'score' => 10],
+    ]);
+
+    expect($board->summarizeScores($shots, false))->toBe('18')
+        ->and($board->summarizeScores($shots, true))->toBe('9.0');
+});
+
+it('initialises display flags from the user preferences', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('board_show_rings', true);
+    $user->setPreference('decimal_notation', false);
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->assertSet('showRings', true)
+        ->assertSet('decimalNotation', false);
+});
+
+it('renders a ring-toggle control bound to toggleRings', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->assertSeeHtml('wire:click="toggleRings"');
+});
+
+it('toggles ring display and persists it to the user', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->assertSet('showRings', false)
+        ->call('toggleRings')
+        ->assertSet('showRings', true);
+
+    expect($user->fresh()->preference('board_show_rings'))->toBeTrue();
+});
+
+it('formats a score with one decimal when decimal notation is on', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('decimal_notation', true);
+    $session = Session::factory()->create(['user_id' => $user->id]);
+    $shot = offCentreShot($session);
+
+    $board = Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->instance();
+
+    expect($board->formatScore($shot->score, $shot))->toBe('+7.4');
+});
+
+it('formats a score as a whole ring when decimal notation is off', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('decimal_notation', false);
+    $session = Session::factory()->create(['user_id' => $user->id]);
+    $shot = offCentreShot($session);
+
+    $board = Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->instance();
+
+    expect($board->formatScore($shot->score, $shot))->toBe('+8');
+});
+
+it('formats a zero-ring shot as +0 when decimal notation is off', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('decimal_notation', false);
+    $session = Session::factory()->create(['user_id' => $user->id]);
+    $shot = SessionShot::factory()->create([
+        'session_id' => $session->id,
+        'turn_index' => 0,
+        'shot_index' => 0,
+        'x_normalized' => 0.0,
+        'y_normalized' => 0.0,
+        'distance_from_center' => 0.6,
+        'ring' => 0,
+        'score' => 0,
+    ]);
+
+    $board = Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->instance();
+
+    expect($board->formatScore($shot->score, $shot))->toBe('+0');
+});
+
+it('does not record a shot when the board is not editable', function (): void {
+    $owner = User::factory()->create();
+    $viewer = User::factory()->create();
+    $session = Session::factory()->create(['user_id' => $owner->id]);
+
+    Livewire::actingAs($viewer)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->assertSet('canEdit', false)
+        ->call('recordShot', 0.5, 0.5);
+
+    expect($session->shots()->count())->toBe(0);
+});
+
+it('initialises display flags from the viewer preferences on a read-only board', function (): void {
+    $owner = User::factory()->create();
+    $viewer = User::factory()->create();
+    $viewer->setPreference('board_show_rings', true);
+    $session = Session::factory()->create(['user_id' => $owner->id]);
+
+    Livewire::actingAs($viewer)
+        ->test(SessionShotBoard::class, ['session' => $session, 'readOnly' => true])
+        ->assertSet('canEdit', false)
+        ->assertSet('showRings', true);
+});
+
+it('reflects an enabled ring preference in the toggle aria-checked state', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('board_show_rings', true);
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->assertSeeHtml('aria-checked="true"');
+});
+
+it('shows the ring toggle off by default', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(SessionShotBoard::class, ['session' => $session])
+        ->assertSeeHtml('aria-checked="false"');
+});

--- a/tests/Feature/RangeConsole/ShotBoardFinishTest.php
+++ b/tests/Feature/RangeConsole/ShotBoardFinishTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\SessionResource;
+use App\Filament\Resources\SessionResource\Pages\ManageSessionShots;
+use App\Jobs\GenerateSessionReflectionJob;
+use App\Models\Session;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Laravel\Pennant\Feature;
+use Livewire\Livewire;
+
+it('queues an AI reflection when finishing with the preference on and AI enabled', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withAnthropicKey()->create();
+    $user->setPreference('auto_ai_reflection', true);
+    Feature::for($user)->activate('aimtrack-ai');
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(ManageSessionShots::class, ['record' => $session->id])
+        ->call('finishSession')
+        ->assertRedirect(SessionResource::getUrl('view', ['record' => $session->id]));
+
+    Bus::assertDispatched(GenerateSessionReflectionJob::class);
+});
+
+it('does not queue a reflection when the auto preference is off', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withAnthropicKey()->create();
+    Feature::for($user)->activate('aimtrack-ai');
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(ManageSessionShots::class, ['record' => $session->id])
+        ->call('finishSession')
+        ->assertRedirect(SessionResource::getUrl('view', ['record' => $session->id]));
+
+    Bus::assertNotDispatched(GenerateSessionReflectionJob::class);
+});
+
+it('does not queue a reflection when AI is disabled even if the preference is on', function (): void {
+    Bus::fake();
+
+    $user = User::factory()->withAnthropicKey()->create();
+    $user->setPreference('auto_ai_reflection', true);
+    Feature::for($user)->deactivate('aimtrack-ai');
+    $session = Session::factory()->create(['user_id' => $user->id]);
+
+    Livewire::actingAs($user)
+        ->test(ManageSessionShots::class, ['record' => $session->id])
+        ->call('finishSession');
+
+    Bus::assertNotDispatched(GenerateSessionReflectionJob::class);
+});

--- a/tests/Feature/RangeConsole/WizardShotOptionsTest.php
+++ b/tests/Feature/RangeConsole/WizardShotOptionsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\SessionResource\Pages\CreateSession;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('initialises the Schoten-step options from the user preferences', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('board_show_rings', true);
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->assertSet('boardPreferences.board_show_rings', true)
+        ->assertSet('boardPreferences.decimal_notation', true)   // default
+        ->assertSet('boardPreferences.auto_ai_reflection', false); // default
+});
+
+it('persists a toggled option to the user', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->call('togglePreference', 'board_show_rings')
+        ->assertSet('boardPreferences.board_show_rings', true);
+
+    expect($user->fresh()->preference('board_show_rings'))->toBeTrue();
+});
+
+it('toggles a preference back off', function (): void {
+    $user = User::factory()->create();
+    $user->setPreference('decimal_notation', true);
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->call('togglePreference', 'decimal_notation')
+        ->assertSet('boardPreferences.decimal_notation', false);
+
+    expect($user->fresh()->preference('decimal_notation'))->toBeFalse();
+});
+
+it('ignores unknown preference keys when toggling', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->call('togglePreference', 'totally_unknown');
+
+    expect($user->fresh()->preference('totally_unknown'))->toBeNull();
+});
+
+it('renders the Schoten-step options as interactive toggles', function (): void {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(CreateSession::class)
+        ->assertSee('AI-reflectie')
+        ->assertSee('Decimaal-notatie')
+        ->assertSee('Toon ringen-view')
+        ->assertSeeHtml("togglePreference('board_show_rings')")
+        ->assertSeeHtml("togglePreference('decimal_notation')")
+        ->assertSeeHtml("togglePreference('auto_ai_reflection')");
+});

--- a/tests/Unit/Models/UserPreferencesTest.php
+++ b/tests/Unit/Models/UserPreferencesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+it('returns sensible defaults when no preferences are stored', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->preference('board_show_rings'))->toBeFalse()
+        ->and($user->preference('decimal_notation'))->toBeTrue()
+        ->and($user->preference('auto_ai_reflection'))->toBeFalse();
+});
+
+it('persists a known preference and reads it back', function (): void {
+    $user = User::factory()->create();
+
+    $user->setPreference('board_show_rings', true);
+
+    expect($user->fresh()->preference('board_show_rings'))->toBeTrue();
+});
+
+it('ignores unknown preference keys', function (): void {
+    $user = User::factory()->create();
+
+    $user->setPreference('totally_unknown', true);
+
+    expect($user->fresh()->preference('totally_unknown'))->toBeNull()
+        ->and($user->fresh()->preferences ?? [])->not->toHaveKey('totally_unknown');
+});
+
+it('casts the preferences column to an array', function (): void {
+    $user = User::factory()->create();
+
+    $user->setPreference('decimal_notation', false);
+
+    expect($user->fresh()->preferences)->toBeArray()
+        ->and($user->fresh()->preference('decimal_notation'))->toBeFalse();
+});

--- a/tests/Unit/Services/ShotScoringServiceTest.php
+++ b/tests/Unit/Services/ShotScoringServiceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Sessions\ShotScoringService;
+
+it('derives a one-decimal score from the distance to the centre', function (float $distance, float $expected): void {
+    expect((new ShotScoringService)->decimalScore($distance))->toBe($expected);
+})->with([
+    'bullseye' => [0.0, 10.0],
+    'quarter' => [0.25, 5.0],
+    'rim' => [0.5, 0.0],
+    'near centre' => [0.1, 8.0],
+]);
+
+it('never returns a negative decimal score beyond the rim', function (): void {
+    expect((new ShotScoringService)->decimalScore(0.9))->toBe(0.0);
+});


### PR DESCRIPTION
**Wat**

Vervolg/fix op #82 fase 1 (Range Console) — het schotenbord en de nieuwe-sessie wizard.

- Wizard "Schoten"-stap: de OPTIES (AI-reflectie, Decimaal-notatie, Toon ringen) zijn nu **echte, persisterende toggles** i.p.v. dode HTML — per gebruiker opgeslagen via een nieuwe `users.preferences` JSON-kolom (`User::preference()/setPreference()`).
- Schotenbord: **werkende ringnummers-toggle** (toont/verbergt de ringlabels op de roos) + **decimaal-notatie** (scores met 1 decimaal, afgeleid uit `distance_from_center` — puur weergave, scoring ongewijzigd).
- Tabelvoet `Totaal`/`Gem.` is nu **decimaal-bewust**, zodat rijen, voet én KPI-strook niet meer uiteenlopen.
- Nieuwe **"Sessie afronden"**-actie plant automatisch een AI-reflectie in wanneer de voorkeur aanstaat én de `aimtrack-ai` feature-flag actief is (bestaande `GenerateSessionReflectionJob`).
- **Design-token restyle** (`--at-*`) van de bordpagina, de wizard-stap en de read-only roos in sessie-detail.

> **Techniek bewust 100% behouden:** canvas-klik = schot, long-press (2s) / rechtermuisklik op een marker = verwijderen, beurten, `wire:ignore`. Geen dubbelklik. Alleen de omhulling + de dode toggles zijn aangepakt.

**Waarom**

Gemeld door de schutter: wizard-opties niet aanpasbaar, "toon ringen" deed niets, en onduidelijkheid over waar schoten ingevoerd worden (het echte loggen zit op de bordpagina ná opslaan; de wizard-stap is bewust een preview). Zie #100 (onder umbrella #82).

**Hoe getest**

- `php artisan test`: **373 tests groen** (1083 assertions) — unit (User-voorkeuren, decimal-scoring), feature (wizard-toggles, bord-weergave + ring-toggle + decimaal, `recordShot`/`deleteShot`, `finishSession` AI-dispatch met `Bus::fake`), incl. read-only- en canEdit-guards.
- `vendor/bin/pint --dirty`: clean.
- Adversariële multi-agent review over de diff (techniek-behoud, correctheid, architectuur, test-gaps): 8 bevestigde findings verwerkt (o.a. de decimaal-bewuste tabelvoet) — alle technique-preservation checks groen.
- ⚠️ Live-browser test niet uitgevoerd (geen Playwright/gebouwde assets in deze omgeving + globale `withoutVite()`). Canvas-JS is structureel ongewijzigd; aanbevolen handmatige check: klik→marker, long-press/rechtsklik→verwijderen, ring-toggle, decimaal aan/uit.