### PR TITLE
feat(copilot): introduce as AimTrack AI-Coach via system prompt

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,13 +2,6 @@
 
 namespace App\Providers\Filament;
 
-use Illuminate\Cookie\Middleware\EncryptCookies;
-use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
-use Illuminate\Session\Middleware\StartSession;
-use Illuminate\View\Middleware\ShareErrorsFromSession;
-use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
-use Illuminate\Routing\Middleware\SubstituteBindings;
-use Illuminate\Auth\Middleware\Authenticate;
 use App\Filament\Widgets\FailedJobsWidget;
 use App\Support\Features\AimtrackFeatureToggle;
 use EslamRedaDiv\FilamentCopilot\FilamentCopilotPlugin;
@@ -17,7 +10,14 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use Filament\View\PanelsRenderHook;
+use Illuminate\Auth\Middleware\Authenticate;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\HtmlString;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 
 class AdminPanelProvider extends PanelProvider
 {
@@ -80,6 +80,10 @@ class AdminPanelProvider extends PanelProvider
                 FilamentCopilotPlugin::make()
                     ->provider('anthropic')
                     ->model('claude-haiku-4-5-20251001')
+                    // De system prompt staat in config/filament-copilot.php. Met een lege
+                    // "extra" prompt voorkomen we dat het package diezelfde config-prompt
+                    // nog een tweede keer als "## Additional Instructions" toevoegt.
+                    ->systemPrompt('')
                     ->rateLimitEnabled()
                     ->memoryEnabled()
                     ->authorizeUsing(fn (): bool => app(AimtrackFeatureToggle::class)->aiEnabled()),

--- a/config/filament-copilot.php
+++ b/config/filament-copilot.php
@@ -121,9 +121,42 @@ return [
     |--------------------------------------------------------------------------
     | System Prompt
     |--------------------------------------------------------------------------
+    | Basis-identiteit van de copilot. Vervangt de generieke "Filament admin
+    | panel assistant"-prompt van het package, zodat de assistent zich als de
+    | AimTrack AI-Coach voorstelt. De operationele richtlijnen (tools,
+    | bevestiging, geheugen) zijn behouden zodat de copilot blijft werken.
     */
 
-    'system_prompt' => null,
+    'system_prompt' => <<<'PROMPT'
+        Je bent de AimTrack AI-Coach: een behulpzame coach-assistent voor schutters en coaches binnen AimTrack. Je helpt gebruikers hun trainingsdata begrijpen, doelen stellen en gerichte feedback krijgen over hun sessies, wapens en techniek.
+
+        Stel jezelf altijd voor als "AimTrack AI-Coach" — nooit als een admin panel-assistent. Antwoord standaard in het Nederlands.
+
+        ## Richtlijnen
+        - Respecteer altijd de rechten van de gebruiker. Voer nooit acties uit waarvoor de gebruiker geen autorisatie heeft.
+        - Bevestig wijzigingen voordat je opslaat, tenzij de gebruiker expliciet vraagt om direct op te slaan.
+        - Geef duidelijke, beknopte en coachende antwoorden.
+        - Als een actie mislukt, leg uit waarom en stel alternatieven voor.
+
+        ## Werken met resources, pagina's en widgets
+        Je hebt globale tools voor ontdekking en uitvoering:
+        - **list_resources** / **list_pages** / **list_widgets** — bekijk wat beschikbaar is
+        - **get_tools** — ontdek de copilot-tools voor een specifieke resource, pagina of widget
+        - **run_tool** — voer een ontdekte tool uit met de vereiste argumenten
+
+        ### Werkwijze
+        1. De context hieronder somt de beschikbare resources, pagina's en widgets met hun beschrijving op.
+        2. Wil je een actie op een resource uitvoeren, gebruik dan **get_tools** met de resource-class om beschikbare tools te ontdekken.
+        3. Gebruik **run_tool** om de specifieke tool met de vereiste argumenten uit te voeren.
+        4. Vereist een tool bevestiging (needToAsk), vraag dit dan altijd eerst aan de gebruiker.
+
+        ## Bevestigingsregels
+        - Tools die "CONFIRMATION REQUIRED" teruggeven, vereisen expliciete bevestiging van de gebruiker voordat je ze opnieuw uitvoert.
+        - Vraag de gebruiker altijd om bevestiging vóór destructieve acties (verwijderen, definitief verwijderen).
+
+        ## Geheugen
+        - Gebruik **remember** / **recall** om voorkeuren van de gebruiker op te slaan en op te halen tussen gesprekken.
+        PROMPT,
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/Filament/Copilot/CopilotSystemPromptTest.php
+++ b/tests/Feature/Filament/Copilot/CopilotSystemPromptTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use EslamRedaDiv\FilamentCopilot\Agent\ContextBuilder;
+use Filament\Facades\Filament;
+
+it('configures the copilot to introduce itself as the AimTrack AI-Coach', function () {
+    $prompt = config('filament-copilot.system_prompt');
+
+    expect($prompt)->toBeString()
+        ->toContain('AimTrack AI-Coach')
+        ->not->toContain('admin panel assistent')
+        ->not->toContain('Filament admin panel assistant');
+});
+
+it('uses the configured coach prompt as the copilot base prompt', function () {
+    $builder = app(ContextBuilder::class);
+
+    $buildBasePrompt = (new ReflectionMethod($builder, 'buildBasePrompt'));
+    $buildBasePrompt->setAccessible(true);
+
+    expect($buildBasePrompt->invoke($builder))
+        ->toBe(config('filament-copilot.system_prompt'));
+});
+
+it('does not append the config prompt a second time as additional instructions', function () {
+    $plugin = Filament::getPanel('admin')->getPlugin('filament-copilot');
+
+    expect($plugin->getSystemPrompt())->toBe('');
+});


### PR DESCRIPTION
**Wat**
De copilot stelt zich nu voor als de **AimTrack AI-Coach** in plaats van de generieke *"Filament admin panel assistent"*.

- `config/filament-copilot.php`: `system_prompt` ingevuld met een Nederlandse coach-prompt (identiteit: coach voor schutters/coaches, gericht op training/sessies/wapens/techniek). De operationele richtlijnen — tool-workflow (`list_*`/`get_tools`/`run_tool`), bevestiging en geheugen — zijn behouden zodat de copilot blijft werken.
- `AdminPanelProvider`: `->systemPrompt('')` op de plugin. Het package leest `config.system_prompt` op twee plekken (base prompt én "Additional Instructions"); de lege extra-prompt voorkomt dat dezelfde prompt dubbel wordt geïnjecteerd.

**Waarom**
De begroeting werd door de AI gegenereerd op basis van de package-default system prompt, waardoor de assistent zich voorstelde als *"Ik ben je Filament admin panel assistent"*. Dat moet de AimTrack AI-Coach zijn. (Geen gekoppeld issue — voortzetting van de copilot-feature.)

**Hoe getest**
- `vendor/bin/pint` — schoon.
- `php artisan test tests/Feature/Filament/Copilot tests/Feature/Filament/Pages/CoachPageTest.php` — **17 tests groen** (43 assertions), inclusief 3 nieuwe tests: coach-identiteit aanwezig, oude admin-assistent-identiteit afwezig, en geen dubbele prompt-injectie.