### PR TITLE
feat(verenigingen): multi-tenancy met coach-inzage + gedeelde key (#95 fase 2)

### DIFF
--- a/.ai/plans/PLAN-issue-95-fase-2-multitenancy-verenigingen.md
+++ b/.ai/plans/PLAN-issue-95-fase-2-multitenancy-verenigingen.md
@@ -152,16 +152,31 @@ verenigings-Claude-key fungeert als fallback onder de user-key:
 
 ---
 
-## Acceptatiecriteria (uit epic)
+## Acceptatiecriteria (uit epic) — status
 
-- [ ] Vereniging aanmaakbaar met naam en (optioneel) eigen Claude-key.
-- [ ] Gebruikers worden lid met een rol (member/coach/admin).
-- [ ] Coach ziet read-only sessies & voortgang van leden binnen dezelfde vereniging.
-- [ ] Coach ziet géén data van andere verenigingen; member ziet géén peer-data.
-- [ ] Key-resolutie volgt `user-key → vereniging-key → geen AI`.
-- [ ] Club-admin beheert leden (toevoegen/uitnodigen, rollen) en de gedeelde key.
-- [ ] Pest dekt membership/rollen, coach-inzage-grenzen, cross-tenant-isolatie,
-      key-precedentie.
+- [x] Vereniging aanmaakbaar met naam en (optioneel) eigen Claude-key
+      (model + factory + beheer-UI).
+- [x] Gebruikers worden lid met een rol (member/coach/admin) (pivot + service).
+- [x] Coach ziet read-only sessies & voortgang van leden binnen dezelfde
+      vereniging (CoachSessieResource + policies).
+- [x] Coach ziet géén data van andere verenigingen; member ziet géén peer-data
+      (policy-tests cross-tenant + peer).
+- [x] Key-resolutie volgt `user-key → vereniging-key → geen AI` (AiKeyResolver).
+- [x] Club-admin beheert leden (toevoegen/rollen) en de gedeelde key
+      (VerenigingBeheer + VerenigingService).
+- [x] Pest dekt membership/rollen, coach-inzage-grenzen, cross-tenant-isolatie,
+      key-precedentie (50 tests groen).
+
+## Bewust niet gedaan / aandachtspunten
+- **Demo-seeder**: project heeft geen globale seeder; demo-data is per-user en
+  on-demand (`DemoDataSeeder`). Een globale demo-vereniging zou dat patroon
+  doorbreken → bewust overgeslagen.
+- **Uitnodiging niet-bestaande e-mail**: v1 koppelt alleen bestaande accounts;
+  volledige invite-flow blijft buiten scope (zoals afgesproken).
+- **`composer audit`**: pre-existing low-severity advisory in `symfony/yaml`
+  (transitief, niet door Fase 2 geïntroduceerd).
+- **3 pre-existing testfailures** (contact-form CSRF/rate-limit, logout) staan
+  los van deze wijziging — raken geen verenigingen-code.
 
 ## Open vragen (NEEDS_INFO)
 

--- a/.ai/plans/PLAN-issue-95-fase-2-multitenancy-verenigingen.md
+++ b/.ai/plans/PLAN-issue-95-fase-2-multitenancy-verenigingen.md
@@ -1,0 +1,183 @@
+# PLAN — Issue #95 Fase 2: Multi-tenancy verenigingen met coach-inzage
+
+- **Status:** APPROVED (human sign-off 2026-06-13, defaults voor open vragen)
+- **Epic:** [#95](https://github.com/Marcvdc/AimTrack/issues/95) — Fase 1 (#96) gemerged
+- **Worktree:** `aimtrack-ai-verenigingen` (`feature/ai-verenigingen`, basis `87ad068` main)
+- **Web:** http://localhost:19084 · DB-poort 15436 · Mailpit 19029
+- **Classificatie:** COMPLEX (multi-file, nieuwe feature, >3 AC's, autorisatie-impact)
+
+---
+
+## Doel
+
+Meerdere schietverenigingen ondersteunen. Leden houden eigendom van hun data
+(`user_id`-owned blijft ongewijzigd). Coaches/admins binnen dezelfde vereniging
+krijgen **read-only** inzage in sessies & voortgang van hun leden. Een gedeelde
+verenigings-Claude-key fungeert als fallback onder de user-key:
+`user-key → vereniging-key → geen AI`.
+
+## Kernbesluit (uit epic, leidend bij conflict)
+
+- **GÉÉN schema-brede `tenant_id`/`association_id` op `sessions`/`weapons`.**
+  Domeindata blijft `user_id`-owned. Coach-inzage = aparte read-only screens die
+  scopen op *welke users* tot dezelfde vereniging horen (via pivot), niet op een
+  kolom op de domeindata. Dit voorkomt cross-user-lekken bij het oprekken van de
+  bestaande `->where('user_id', auth()->id())`.
+- Home-grown rollen (pivot-enum + policies/gates), geen spatie/permission.
+- v1: één **actieve** vereniging per user (pivot laat later meerdere toe).
+
+---
+
+## Sub-fasering (binnen één PR, gecommit per sub-fase)
+
+### (a) Verenigingen + membership + rollen + key-resolutie
+
+**Datamodel / migraties**
+- `create_verenigingen_table`: `id`, `naam`, `slug` (unique), `anthropic_api_key`
+  (`text` nullable, `encrypted` cast), `ai_key_verified_at` (timestamp nullable),
+  `settings` (`json` nullable), `created_by` (FK users, nullOnDelete), timestamps.
+- `create_vereniging_user_table` (pivot): `vereniging_id` (FK cascade),
+  `user_id` (FK cascade), `role` (string/enum: `member`/`coach`/`admin`),
+  `joined_at` (timestamp nullable), timestamps. Unique op
+  `(vereniging_id, user_id)`.
+- `add_active_vereniging_id_to_users_table`: `active_vereniging_id`
+  (FK verenigingen, nullOnDelete, nullable) — de v1 "één actieve vereniging".
+
+**Models**
+- `app/Models/Vereniging.php`: `naam`, `slug`, `anthropic_api_key`,
+  `ai_key_verified_at`, `settings`, `created_by` fillable; casts
+  `anthropic_api_key => encrypted`, `ai_key_verified_at => datetime`,
+  `settings => array`. `$hidden` = `['anthropic_api_key']`. Relaties:
+  `members()` belongsToMany(User) `->withPivot('role','joined_at')`,
+  `creator()` belongsTo(User, 'created_by'). Helpers: `coaches()`, `admins()`
+  scoped op pivot-rol.
+- `app/Enums/VerenigingRol.php`: backed enum `Member`/`Coach`/`Admin` (TitleCase),
+  met `label(): string` (NL) en helper `canCoach()` (coach|admin),
+  `canManage()` (admin).
+- `User.php`: relaties `verenigingen()` belongsToMany `->withPivot('role',...)`,
+  `activeVereniging()` belongsTo(Vereniging, 'active_vereniging_id'). Helpers:
+  `rolInVereniging(Vereniging): ?VerenigingRol`, `isCoachVan(User $lid): bool`
+  (zelfde actieve vereniging + rol coach/admin).
+
+**Key-resolutie** (`app/Services/Ai/AiKeyResolver.php`)
+- `forVereniging(?Vereniging): ?string` — geeft `anthropic_api_key` of null.
+- `forUser(?User)` uitbreiden naar: `user-key ?? vereniging-key (active) ?? null`.
+- `ShooterCoach` (jobs) blijft `forUser($session->user)` aanroepen — de fallback
+  zit nu ín de resolver, dus jobs hoeven niet te wijzigen. Key wordt nog steeds
+  runtime in `handle()` geresolved; nooit in payload. ✅ AC.
+- Factories: `VerenigingFactory`, pivot-states (`asCoach`, `asAdmin`).
+
+### (b) Coach-inzage-schermen (read-only)
+
+- **Aparte, read-only Filament resource(s)** — NIET de bestaande
+  `SessionResource`/`WeaponResource` oprekken. Bijv.
+  `app/Filament/Resources/Coaching/LidSessieResource.php` (read-only:
+  `canCreate/canEdit/canDelete = false`), zichtbaar via `canViewAny()` =
+  `auth()->user()` heeft coach/admin-rol in actieve vereniging.
+- `getEloquentQuery()`: `Session::whereIn('user_id', <member-ids van zelfde
+  actieve vereniging, excl. niet-coach>)`. Member-ids via
+  `auth()->user()->activeVereniging?->members()->pluck('users.id')`.
+- Idem read-only voortgang/wapen-inzicht voor leden binnen de vereniging.
+- **Autorisatie**: `app/Policies/SessionPolicy.php` +
+  `app/Policies/WeaponPolicy.php` (geregistreerd in `AuthServiceProvider`):
+  `view()` = eigenaar **of** coach/admin in dezelfde actieve vereniging als de
+  eigenaar; `update()/delete()/create()` = uitsluitend eigenaar. Coach krijgt
+  nooit write. Cross-vereniging altijd `false`.
+- Bestaande schutter-schermen blijven volledig ongewijzigd.
+
+### (c) Ledenbeheer-UI (admin)
+
+- `VerenigingResource` (of pagina) zichtbaar voor admins van hun eigen
+  vereniging: naam/instellingen + gedeelde key beheren (zelfde masking/test-actie
+  als `AiSettingsPage`: gemaskeerd `sk-ant-…1234`, test-call naar Anthropic
+  `/v1/models`, wissen).
+- Ledenbeheer: leden toevoegen/uitnodigen op e-mail, rol toewijzen/wijzigen,
+  verwijderen. Uitnodiging v1: bestaande user op e-mail koppelen; niet-bestaande
+  e-mail → nette melding (volwaardige invite-flow buiten scope, optioneel later).
+- Guard: admin kan alleen leden van de **eigen** vereniging beheren; laatste
+  admin niet verwijderbaar/degradeerbaar.
+
+---
+
+## Geraakte / nieuwe bestanden
+
+| Laag | Bestand | Actie |
+|---|---|---|
+| Migratie | `database/migrations/*_create_verenigingen_table.php` | nieuw |
+| Migratie | `*_create_vereniging_user_table.php` | nieuw |
+| Migratie | `*_add_active_vereniging_id_to_users_table.php` | nieuw |
+| Model | `app/Models/Vereniging.php` | nieuw |
+| Model | `app/Models/User.php` | wijzig (relaties/helpers) |
+| Enum | `app/Enums/VerenigingRol.php` | nieuw |
+| Service | `app/Services/Ai/AiKeyResolver.php` | wijzig (fallback) |
+| Policy | `app/Policies/SessionPolicy.php`, `WeaponPolicy.php` | nieuw |
+| Provider | `app/Providers/AuthServiceProvider.php` | wijzig (register) |
+| Filament | `app/Filament/Resources/Coaching/...` (read-only) | nieuw |
+| Filament | `VerenigingResource` + ledenbeheer | nieuw |
+| Factory | `database/factories/VerenigingFactory.php` | nieuw |
+| Seeder | demo-vereniging in bestaande seeder | wijzig (optioneel) |
+
+## Architectuur-compliance (STOP-condities)
+
+- Type A (Eloquent). Filament-resources zonder inline create/update business
+  logica — ledenbeheer/key-beheer via een `VerenigingService`
+  (`app/Services/Vereniging/`) voor toevoegen/rol-wijzigen/key-test, niet inline
+  in de resource (cond. #12). Service blijft <500 regels / <10 methods (#13).
+- Geen secrets in config/env hardcoded; key encrypted + gemaskeerd (#7).
+- Alle nieuwe code getest, Pint-clean (#5, #6).
+
+---
+
+## Tests (Pest, ≥90% van gewijzigde code)
+
+**Unit**
+- `AiKeyResolverTest` uitbreiden: user-key wint van vereniging-key; geen user-key
+  → vereniging-key; geen van beide → null; vereniging zonder key → null.
+- `VerenigingRol` enum: `canCoach()`/`canManage()` per rol.
+- `User::rolInVereniging` / `isCoachVan` happy + cross-vereniging false.
+
+**Feature**
+- Membership: user lid maken met rol; pivot unique.
+- Policy: eigenaar ziet eigen sessie; coach ziet sessie van lid zelfde
+  vereniging (read-only); coach ziet GEEN sessie van andere vereniging;
+  member ziet GEEN peer-data; coach kan niet editen/deleten.
+- Filament coach-resource: coach ziet leden-records, member niet; smoke
+  `assertCanSeeTableRecords` / `assertCanNotSeeTableRecords`.
+- Ledenbeheer: admin voegt lid toe / wijzigt rol; niet-admin geblokkeerd;
+  cross-vereniging beheer geblokkeerd; laatste admin beschermd.
+- Verenigings-key: opslaan encrypted + gemaskeerd; test-actie (Anthropic
+  `Http::fake()`); wissen.
+- Key-precedentie e2e: sessie-reflectie-job van lid zónder eigen key gebruikt
+  vereniging-key (ShooterCoach `Http::fake()`).
+
+---
+
+## Acceptatiecriteria (uit epic)
+
+- [ ] Vereniging aanmaakbaar met naam en (optioneel) eigen Claude-key.
+- [ ] Gebruikers worden lid met een rol (member/coach/admin).
+- [ ] Coach ziet read-only sessies & voortgang van leden binnen dezelfde vereniging.
+- [ ] Coach ziet géén data van andere verenigingen; member ziet géén peer-data.
+- [ ] Key-resolutie volgt `user-key → vereniging-key → geen AI`.
+- [ ] Club-admin beheert leden (toevoegen/uitnodigen, rollen) en de gedeelde key.
+- [ ] Pest dekt membership/rollen, coach-inzage-grenzen, cross-tenant-isolatie,
+      key-precedentie.
+
+## Open vragen (NEEDS_INFO)
+
+1. **Invite-flow**: v1 alleen bestaande users op e-mail koppelen, of volledige
+   mail-uitnodiging met registratie? (default: koppelen, mail later)
+2. **Coach-inzage scope**: alleen sessies/voortgang, of ook wapen-inzichten en
+   AI-reflecties van leden? (default: sessies + voortgang + reflecties read-only)
+3. **Feature-flag scope**: `aimtrack-ai` vereniging-scoped maken via Pennant nu,
+   of als latere enhancement laten (epic noemt het enhancement)? (default: later)
+4. **Demo-seeder**: één demo-vereniging met coach+leden toevoegen? (default: ja)
+
+---
+
+## Volgorde van BUILD (na APPROVED)
+
+1. (a) migraties + models + enum + resolver-fallback + tests → commit
+2. (b) policies + read-only coach-resources + tests → commit
+3. (c) verenigingsbeheer + ledenbeheer + key-beheer + tests → commit
+4. Pint + volledige relevante test-run → PR naar develop/main, gekoppeld aan #95.

--- a/app/Enums/VerenigingRol.php
+++ b/app/Enums/VerenigingRol.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum VerenigingRol: string
+{
+    case Member = 'member';
+    case Coach = 'coach';
+    case Admin = 'admin';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Member => 'Lid',
+            self::Coach => 'Coach',
+            self::Admin => 'Beheerder',
+        };
+    }
+
+    public function canCoach(): bool
+    {
+        return $this === self::Coach || $this === self::Admin;
+    }
+
+    public function canManage(): bool
+    {
+        return $this === self::Admin;
+    }
+}

--- a/app/Filament/Pages/VerenigingBeheer.php
+++ b/app/Filament/Pages/VerenigingBeheer.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Enums\VerenigingRol;
+use App\Models\User;
+use App\Models\Vereniging;
+use App\Services\Vereniging\VerenigingException;
+use App\Services\Vereniging\VerenigingService;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\SelectColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class VerenigingBeheer extends Page implements HasForms, HasTable
+{
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-building-office-2';
+
+    protected static ?string $navigationLabel = 'Mijn vereniging';
+
+    protected static ?string $title = 'Mijn vereniging';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
+
+    protected string $view = 'filament.pages.vereniging-beheer';
+
+    public ?array $data = [];
+
+    public static function canAccess(): bool
+    {
+        return static::actieveVerenigingVoorBeheerder() !== null;
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return static::canAccess();
+    }
+
+    public function mount(): void
+    {
+        $this->form->fill(['anthropic_api_key' => null]);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Gedeelde Claude API-key')
+                    ->schema([
+                        TextInput::make('anthropic_api_key')
+                            ->label('Claude API-key')
+                            ->password()
+                            ->revealable()
+                            ->autocomplete(false)
+                            ->placeholder($this->keyPlaceholder())
+                            ->helperText('Gedeelde Anthropic-key voor leden zonder eigen key. Versleuteld opgeslagen, nooit volledig getoond. Laat leeg om de huidige key te behouden.'),
+                    ]),
+                Section::make('Lid toevoegen')
+                    ->schema([
+                        TextInput::make('email')
+                            ->label('E-mailadres van een bestaand account')
+                            ->email(),
+                        Select::make('role')
+                            ->label('Rol')
+                            ->options(static::rolOpties())
+                            ->default(VerenigingRol::Member->value),
+                    ])
+                    ->columns(2),
+            ])
+            ->statePath('data');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => User::query()
+                ->join('vereniging_user', 'vereniging_user.user_id', '=', 'users.id')
+                ->where('vereniging_user.vereniging_id', $this->vereniging()->id)
+                ->select('users.*', 'vereniging_user.role as role'))
+            ->columns([
+                TextColumn::make('name')->label('Naam')->searchable(),
+                TextColumn::make('email')->label('E-mail')->searchable(),
+                SelectColumn::make('role')
+                    ->label('Rol')
+                    ->options(static::rolOpties())
+                    ->selectablePlaceholder(false)
+                    ->updateStateUsing(fn (User $record, string $state) => $this->voerUit(
+                        fn (VerenigingService $service) => $service->wijzigRol(
+                            $this->vereniging(),
+                            $record,
+                            VerenigingRol::from($state),
+                        ),
+                        'Rol gewijzigd',
+                    )),
+            ])
+            ->recordActions([
+                Action::make('verwijderLid')
+                    ->label('Verwijderen')
+                    ->icon('heroicon-m-trash')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->action(fn (User $record) => $this->voerUit(
+                        fn (VerenigingService $service) => $service->verwijderLid($this->vereniging(), $record),
+                        'Lid verwijderd',
+                    )),
+            ]);
+    }
+
+    public function voegLidToe(): void
+    {
+        $email = data_get($this->data, 'email');
+        $role = data_get($this->data, 'role', VerenigingRol::Member->value);
+
+        if (blank($email)) {
+            Notification::make()->title('Vul een e-mailadres in')->warning()->send();
+
+            return;
+        }
+
+        $this->voerUit(fn (VerenigingService $service) => $service->voegLidToe(
+            $this->vereniging(),
+            $email,
+            VerenigingRol::from($role),
+        ), 'Lid toegevoegd');
+
+        $this->data['email'] = null;
+    }
+
+    public function getHeaderActions(): array
+    {
+        return [
+            Action::make('testKey')
+                ->label('Test key')
+                ->icon('heroicon-m-bolt')
+                ->action(function (): void {
+                    $geldig = app(VerenigingService::class)->testKey($this->vereniging());
+
+                    Notification::make()
+                        ->title($geldig ? 'Key is geldig' : 'Key ongeldig of ontbreekt')
+                        ->{$geldig ? 'success' : 'danger'}()
+                        ->send();
+                }),
+            Action::make('wisKey')
+                ->label('Wis key')
+                ->color('danger')
+                ->requiresConfirmation()
+                ->action(function (): void {
+                    app(VerenigingService::class)->wisKey($this->vereniging());
+                    Notification::make()->title('Key gewist')->success()->send();
+                }),
+        ];
+    }
+
+    public function save(): void
+    {
+        $key = data_get($this->form->getState(), 'anthropic_api_key')
+            ?? data_get($this->data, 'anthropic_api_key');
+
+        if (blank($key)) {
+            Notification::make()->title('Geen key ingevoerd')->warning()->send();
+
+            return;
+        }
+
+        app(VerenigingService::class)->bewaarKey($this->vereniging(), $key);
+        $this->form->fill(['anthropic_api_key' => null]);
+
+        Notification::make()->title('Key opgeslagen')->success()->send();
+    }
+
+    public function vereniging(): Vereniging
+    {
+        return static::actieveVerenigingVoorBeheerder();
+    }
+
+    /**
+     * @param  callable(VerenigingService):mixed  $callback
+     */
+    protected function voerUit(callable $callback, string $succesTitel): void
+    {
+        try {
+            $callback(app(VerenigingService::class));
+        } catch (VerenigingException $exception) {
+            Notification::make()->title($exception->getMessage())->danger()->send();
+
+            return;
+        }
+
+        Notification::make()->title($succesTitel)->success()->send();
+    }
+
+    protected function keyPlaceholder(): string
+    {
+        $key = $this->vereniging()->anthropic_api_key;
+
+        return filled($key) ? 'Huidige key: ••••'.substr($key, -4) : 'sk-ant-…';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected static function rolOpties(): array
+    {
+        return collect(VerenigingRol::cases())
+            ->mapWithKeys(fn (VerenigingRol $rol): array => [$rol->value => $rol->label()])
+            ->all();
+    }
+
+    protected static function actieveVerenigingVoorBeheerder(): ?Vereniging
+    {
+        $user = auth()->user();
+        $vereniging = $user?->activeVereniging;
+
+        if ($vereniging === null) {
+            return null;
+        }
+
+        return ($user->rolInVereniging($vereniging)?->canManage() ?? false)
+            ? $vereniging
+            : null;
+    }
+}

--- a/app/Filament/Resources/CoachSessies/CoachSessieResource.php
+++ b/app/Filament/Resources/CoachSessies/CoachSessieResource.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Filament\Resources\CoachSessies;
+
+use App\Filament\Resources\CoachSessies\Pages\ListCoachSessies;
+use App\Filament\Resources\CoachSessies\Pages\ViewCoachSessie;
+use App\Filament\Resources\CoachSessies\Schemas\CoachSessieInfolist;
+use App\Filament\Resources\CoachSessies\Tables\CoachSessiesTable;
+use App\Models\Session;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class CoachSessieResource extends Resource
+{
+    protected static ?string $model = Session::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUserGroup;
+
+    protected static ?string $navigationLabel = 'Sessies leden';
+
+    protected static ?string $modelLabel = 'Ledensessie';
+
+    protected static ?string $pluralModelLabel = 'Ledensessies';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'INZICHT';
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return CoachSessieInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return CoachSessiesTable::configure($table);
+    }
+
+    /**
+     * Alleen zichtbaar voor coaches/beheerders van de actieve vereniging.
+     */
+    public static function shouldRegisterNavigation(): bool
+    {
+        return static::canViewAny();
+    }
+
+    public static function canViewAny(): bool
+    {
+        $user = auth()->user();
+        $vereniging = $user?->activeVereniging;
+
+        return $vereniging !== null
+            && ($user->rolInVereniging($vereniging)?->canCoach() ?? false);
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit($record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function canDeleteAny(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Beperk tot sessies van leden binnen de actieve vereniging van de coach.
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        $vereniging = auth()->user()?->activeVereniging;
+
+        $memberIds = $vereniging
+            ? $vereniging->members()->pluck('users.id')
+            : collect();
+
+        return parent::getEloquentQuery()
+            ->whereIn('user_id', $memberIds)
+            ->with('user');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListCoachSessies::route('/'),
+            'view' => ViewCoachSessie::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/CoachSessies/Pages/ListCoachSessies.php
+++ b/app/Filament/Resources/CoachSessies/Pages/ListCoachSessies.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\CoachSessies\Pages;
+
+use App\Filament\Resources\CoachSessies\CoachSessieResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCoachSessies extends ListRecords
+{
+    protected static string $resource = CoachSessieResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/CoachSessies/Pages/ViewCoachSessie.php
+++ b/app/Filament/Resources/CoachSessies/Pages/ViewCoachSessie.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Resources\CoachSessies\Pages;
+
+use App\Filament\Resources\CoachSessies\CoachSessieResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewCoachSessie extends ViewRecord
+{
+    protected static string $resource = CoachSessieResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Resources/CoachSessies/Schemas/CoachSessieInfolist.php
+++ b/app/Filament/Resources/CoachSessies/Schemas/CoachSessieInfolist.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Filament\Resources\CoachSessies\Schemas;
+
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class CoachSessieInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Sessie')
+                    ->schema([
+                        TextEntry::make('user.name')
+                            ->label('Lid'),
+                        TextEntry::make('date')
+                            ->label('Datum')
+                            ->date('d-m-Y'),
+                        TextEntry::make('range_name')
+                            ->label('Baan'),
+                        TextEntry::make('manual_reflection')
+                            ->label('Reflectie van het lid')
+                            ->columnSpanFull()
+                            ->placeholder('—'),
+                    ])
+                    ->columns(2),
+                Section::make('AI-reflectie')
+                    ->schema([
+                        TextEntry::make('aiReflection.summary')
+                            ->label('Samenvatting')
+                            ->columnSpanFull()
+                            ->placeholder('Geen AI-reflectie beschikbaar'),
+                        TextEntry::make('aiReflection.next_focus')
+                            ->label('Volgende focus')
+                            ->columnSpanFull()
+                            ->placeholder('—'),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/CoachSessies/Tables/CoachSessiesTable.php
+++ b/app/Filament/Resources/CoachSessies/Tables/CoachSessiesTable.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Filament\Resources\CoachSessies\Tables;
+
+use Filament\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class CoachSessiesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query
+                ->withSum('shots as total_score', 'score'))
+            ->defaultSort('date', 'desc')
+            ->columns([
+                TextColumn::make('user.name')
+                    ->label('Lid')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('date')
+                    ->label('Datum')
+                    ->date('d-m-Y')
+                    ->sortable(),
+                TextColumn::make('range_name')
+                    ->label('Baan')
+                    ->searchable(),
+                TextColumn::make('total_score')
+                    ->label('Score')
+                    ->numeric()
+                    ->sortable(),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+            ]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\VerenigingRol;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -30,6 +31,7 @@ class User extends Authenticatable
         'is_admin',
         'anthropic_api_key',
         'ai_key_verified_at',
+        'active_vereniging_id',
     ];
 
     protected $hidden = [
@@ -98,5 +100,46 @@ class User extends Authenticatable
     public function coachQuestions()
     {
         return $this->hasMany(CoachQuestion::class);
+    }
+
+    public function verenigingen()
+    {
+        return $this->belongsToMany(Vereniging::class, 'vereniging_user')
+            ->withPivot('role', 'joined_at')
+            ->withTimestamps();
+    }
+
+    public function activeVereniging()
+    {
+        return $this->belongsTo(Vereniging::class, 'active_vereniging_id');
+    }
+
+    /**
+     * De rol van deze user binnen een vereniging, of null als hij geen lid is.
+     */
+    public function rolInVereniging(Vereniging $vereniging): ?VerenigingRol
+    {
+        $pivot = $this->verenigingen()->whereKey($vereniging->id)->first()?->pivot;
+
+        return $pivot !== null ? VerenigingRol::tryFrom($pivot->role) : null;
+    }
+
+    /**
+     * Of deze user (coach/beheerder) inzage heeft in de data van $lid:
+     * beiden in dezelfde actieve vereniging en deze user heeft een coachrol.
+     */
+    public function isCoachVan(User $lid): bool
+    {
+        $vereniging = $this->activeVereniging;
+
+        if ($vereniging === null) {
+            return false;
+        }
+
+        if (! ($this->rolInVereniging($vereniging)?->canCoach() ?? false)) {
+            return false;
+        }
+
+        return $lid->activeVereniging?->is($vereniging) ?? false;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,7 +31,6 @@ class User extends Authenticatable
         'is_admin',
         'anthropic_api_key',
         'ai_key_verified_at',
-        'active_vereniging_id',
     ];
 
     protected $hidden = [
@@ -127,6 +126,10 @@ class User extends Authenticatable
     /**
      * Of deze user (coach/beheerder) inzage heeft in de data van $lid:
      * beiden in dezelfde actieve vereniging en deze user heeft een coachrol.
+     *
+     * Naast de actieve-vereniging-match eist deze check dat $lid werkelijk lid
+     * (pivot) van die vereniging is, zodat de policy identiek redeneert als de
+     * resource-query en een losgeraakte active_vereniging_id geen inzage opent.
      */
     public function isCoachVan(User $lid): bool
     {
@@ -140,6 +143,24 @@ class User extends Authenticatable
             return false;
         }
 
-        return $lid->activeVereniging?->is($vereniging) ?? false;
+        return ($lid->activeVereniging?->is($vereniging) ?? false)
+            && $lid->rolInVereniging($vereniging) !== null;
+    }
+
+    /**
+     * Zet de actieve vereniging van deze user. Schrijft active_vereniging_id
+     * bewust via directe assignment (niet mass-assignable) en valideert dat de
+     * user daadwerkelijk lid is van de doelvereniging. `null` maakt de keuze leeg.
+     */
+    public function switchVereniging(?Vereniging $vereniging): void
+    {
+        if ($vereniging !== null && $this->rolInVereniging($vereniging) === null) {
+            throw new \InvalidArgumentException(
+                'Kan de actieve vereniging niet zetten: gebruiker is geen lid van deze vereniging.'
+            );
+        }
+
+        $this->active_vereniging_id = $vereniging?->id;
+        $this->save();
     }
 }

--- a/app/Models/Vereniging.php
+++ b/app/Models/Vereniging.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\VerenigingRol;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Vereniging extends Model
+{
+    use HasFactory;
+
+    protected $table = 'verenigingen';
+
+    protected $fillable = [
+        'naam',
+        'slug',
+        'anthropic_api_key',
+        'ai_key_verified_at',
+        'settings',
+        'created_by',
+    ];
+
+    protected $hidden = [
+        'anthropic_api_key',
+    ];
+
+    protected $casts = [
+        'anthropic_api_key' => 'encrypted',
+        'ai_key_verified_at' => 'datetime',
+        'settings' => 'array',
+    ];
+
+    public function members()
+    {
+        return $this->belongsToMany(User::class, 'vereniging_user')
+            ->withPivot('role', 'joined_at')
+            ->withTimestamps();
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * Users met een coach- of beheerdersrol binnen deze vereniging.
+     */
+    public function coaches()
+    {
+        return $this->members()->wherePivotIn('role', [
+            VerenigingRol::Coach->value,
+            VerenigingRol::Admin->value,
+        ]);
+    }
+
+    /**
+     * Users met de beheerdersrol binnen deze vereniging.
+     */
+    public function admins()
+    {
+        return $this->members()->wherePivot('role', VerenigingRol::Admin->value);
+    }
+}

--- a/app/Policies/SessionPolicy.php
+++ b/app/Policies/SessionPolicy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Session;
+use App\Models\User;
+
+class SessionPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Session $session): bool
+    {
+        if ($this->owns($user, $session)) {
+            return true;
+        }
+
+        return $session->user !== null && $user->isCoachVan($session->user);
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Session $session): bool
+    {
+        return $this->owns($user, $session);
+    }
+
+    public function delete(User $user, Session $session): bool
+    {
+        return $this->owns($user, $session);
+    }
+
+    public function restore(User $user, Session $session): bool
+    {
+        return $this->owns($user, $session);
+    }
+
+    public function forceDelete(User $user, Session $session): bool
+    {
+        return $this->owns($user, $session);
+    }
+
+    private function owns(User $user, Session $session): bool
+    {
+        return $session->user_id === $user->id;
+    }
+}

--- a/app/Policies/WeaponPolicy.php
+++ b/app/Policies/WeaponPolicy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Weapon;
+
+class WeaponPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function view(User $user, Weapon $weapon): bool
+    {
+        if ($this->owns($user, $weapon)) {
+            return true;
+        }
+
+        return $weapon->user !== null && $user->isCoachVan($weapon->user);
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Weapon $weapon): bool
+    {
+        return $this->owns($user, $weapon);
+    }
+
+    public function delete(User $user, Weapon $weapon): bool
+    {
+        return $this->owns($user, $weapon);
+    }
+
+    public function restore(User $user, Weapon $weapon): bool
+    {
+        return $this->owns($user, $weapon);
+    }
+
+    public function forceDelete(User $user, Weapon $weapon): bool
+    {
+        return $this->owns($user, $weapon);
+    }
+
+    private function owns(User $user, Weapon $weapon): bool
+    {
+        return $weapon->user_id === $user->id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,12 +2,17 @@
 
 namespace App\Providers;
 
+use App\Models\Session;
+use App\Models\Weapon;
+use App\Policies\SessionPolicy;
+use App\Policies\WeaponPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
 {
     protected $policies = [
-        //
+        Session::class => SessionPolicy::class,
+        Weapon::class => WeaponPolicy::class,
     ];
 
     public function boot(): void

--- a/app/Services/Ai/AiKeyResolver.php
+++ b/app/Services/Ai/AiKeyResolver.php
@@ -3,17 +3,31 @@
 namespace App\Services\Ai;
 
 use App\Models\User;
+use App\Models\Vereniging;
 
 class AiKeyResolver
 {
     /**
      * De actieve Claude-key voor een gebruiker.
-     * Fase 1: alleen de eigen key. Fase 2 (#95) breidt dit uit met een
-     * verenigings-key fallback: user-key -> vereniging-key -> null.
+     * Resolutie (#95): user-key -> actieve verenigings-key -> null.
      */
     public function forUser(?User $user): ?string
     {
         $key = $user?->anthropic_api_key;
+
+        if (filled($key)) {
+            return $key;
+        }
+
+        return $this->forVereniging($user?->activeVereniging);
+    }
+
+    /**
+     * De gedeelde Claude-key van een vereniging, of null.
+     */
+    public function forVereniging(?Vereniging $vereniging): ?string
+    {
+        $key = $vereniging?->anthropic_api_key;
 
         return filled($key) ? $key : null;
     }

--- a/app/Services/Vereniging/VerenigingException.php
+++ b/app/Services/Vereniging/VerenigingException.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Services\Vereniging;
+
+use RuntimeException;
+
+class VerenigingException extends RuntimeException
+{
+    public static function geenLid(): self
+    {
+        return new self('Deze gebruiker is geen lid van de vereniging.');
+    }
+
+    public static function gebruikerNietGevonden(string $email): self
+    {
+        return new self("Er is geen gebruiker met het e-mailadres {$email}.");
+    }
+
+    public static function alLid(): self
+    {
+        return new self('Deze gebruiker is al lid van de vereniging.');
+    }
+
+    public static function laatsteBeheerder(): self
+    {
+        return new self('De laatste beheerder kan niet verwijderd of gedegradeerd worden.');
+    }
+}

--- a/app/Services/Vereniging/VerenigingService.php
+++ b/app/Services/Vereniging/VerenigingService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Services\Vereniging;
+
+use App\Enums\VerenigingRol;
+use App\Models\User;
+use App\Models\Vereniging;
+use Illuminate\Support\Facades\Http;
+
+class VerenigingService
+{
+    /**
+     * Koppel een bestaande gebruiker (op e-mailadres) als lid aan de vereniging.
+     * v1: alleen bestaande accounts; onbekende e-mails geven een nette fout.
+     */
+    public function voegLidToe(Vereniging $vereniging, string $email, VerenigingRol $rol): User
+    {
+        $user = User::query()->where('email', $email)->first();
+
+        if ($user === null) {
+            throw VerenigingException::gebruikerNietGevonden($email);
+        }
+
+        if ($vereniging->members()->whereKey($user->id)->exists()) {
+            throw VerenigingException::alLid();
+        }
+
+        $vereniging->members()->attach($user, [
+            'role' => $rol->value,
+            'joined_at' => now(),
+        ]);
+
+        if ($user->active_vereniging_id === null) {
+            $user->update(['active_vereniging_id' => $vereniging->id]);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Wijzig de rol van een lid. Beschermt de laatste beheerder tegen degradatie.
+     */
+    public function wijzigRol(Vereniging $vereniging, User $user, VerenigingRol $rol): void
+    {
+        $huidige = $this->rolVan($vereniging, $user);
+
+        if ($huidige === null) {
+            throw VerenigingException::geenLid();
+        }
+
+        if ($huidige === VerenigingRol::Admin
+            && $rol !== VerenigingRol::Admin
+            && $this->aantalBeheerders($vereniging) <= 1) {
+            throw VerenigingException::laatsteBeheerder();
+        }
+
+        $vereniging->members()->updateExistingPivot($user->id, ['role' => $rol->value]);
+    }
+
+    /**
+     * Verwijder een lid. Beschermt de laatste beheerder tegen verwijdering.
+     */
+    public function verwijderLid(Vereniging $vereniging, User $user): void
+    {
+        $huidige = $this->rolVan($vereniging, $user);
+
+        if ($huidige === null) {
+            throw VerenigingException::geenLid();
+        }
+
+        if ($huidige === VerenigingRol::Admin && $this->aantalBeheerders($vereniging) <= 1) {
+            throw VerenigingException::laatsteBeheerder();
+        }
+
+        $vereniging->members()->detach($user->id);
+
+        if ($user->active_vereniging_id === $vereniging->id) {
+            $user->update(['active_vereniging_id' => null]);
+        }
+    }
+
+    /**
+     * Sla de gedeelde Claude-key op (encrypted via cast) en reset de verificatie.
+     */
+    public function bewaarKey(Vereniging $vereniging, string $key): void
+    {
+        $vereniging->update([
+            'anthropic_api_key' => $key,
+            'ai_key_verified_at' => null,
+        ]);
+    }
+
+    public function wisKey(Vereniging $vereniging): void
+    {
+        $vereniging->update([
+            'anthropic_api_key' => null,
+            'ai_key_verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Valideer de gedeelde key tegen Anthropic. Markeert bij succes geverifieerd.
+     */
+    public function testKey(Vereniging $vereniging): bool
+    {
+        $key = $vereniging->anthropic_api_key;
+
+        if (blank($key)) {
+            return false;
+        }
+
+        $response = Http::baseUrl(config('ai.base_url', 'https://api.anthropic.com'))
+            ->withHeaders([
+                'x-api-key' => $key,
+                'anthropic-version' => config('ai.anthropic_version', '2023-06-01'),
+            ])
+            ->connectTimeout(5)
+            ->timeout(20)
+            ->get('/v1/models');
+
+        if ($response->successful()) {
+            $vereniging->update(['ai_key_verified_at' => now()]);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function rolVan(Vereniging $vereniging, User $user): ?VerenigingRol
+    {
+        $pivot = $vereniging->members()->whereKey($user->id)->first()?->pivot;
+
+        return $pivot !== null ? VerenigingRol::tryFrom($pivot->role) : null;
+    }
+
+    private function aantalBeheerders(Vereniging $vereniging): int
+    {
+        return $vereniging->admins()->count();
+    }
+}

--- a/app/Services/Vereniging/VerenigingService.php
+++ b/app/Services/Vereniging/VerenigingService.php
@@ -31,7 +31,7 @@ class VerenigingService
         ]);
 
         if ($user->active_vereniging_id === null) {
-            $user->update(['active_vereniging_id' => $vereniging->id]);
+            $user->switchVereniging($vereniging);
         }
 
         return $user;
@@ -75,7 +75,7 @@ class VerenigingService
         $vereniging->members()->detach($user->id);
 
         if ($user->active_vereniging_id === $vereniging->id) {
-            $user->update(['active_vereniging_id' => null]);
+            $user->switchVereniging(null);
         }
     }
 

--- a/database/factories/VerenigingFactory.php
+++ b/database/factories/VerenigingFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Vereniging;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Vereniging>
+ */
+class VerenigingFactory extends Factory
+{
+    protected $model = Vereniging::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $naam = 'SV '.$this->faker->unique()->city();
+
+        return [
+            'naam' => $naam,
+            'slug' => Str::slug($naam).'-'.$this->faker->unique()->numberBetween(1, 99999),
+            'anthropic_api_key' => null,
+            'ai_key_verified_at' => null,
+            'settings' => null,
+            'created_by' => null,
+        ];
+    }
+
+    public function withKey(string $key = 'sk-ant-vereniging'): static
+    {
+        return $this->state(fn (): array => [
+            'anthropic_api_key' => $key,
+            'ai_key_verified_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_06_13_150229_create_verenigingen_table.php
+++ b/database/migrations/2026_06_13_150229_create_verenigingen_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('verenigingen', function (Blueprint $table) {
+            $table->id();
+            $table->string('naam');
+            $table->string('slug')->unique();
+            $table->text('anthropic_api_key')->nullable();
+            $table->timestamp('ai_key_verified_at')->nullable();
+            $table->json('settings')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('verenigingen');
+    }
+};

--- a/database/migrations/2026_06_13_150230_add_active_vereniging_id_to_users_table.php
+++ b/database/migrations/2026_06_13_150230_add_active_vereniging_id_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('active_vereniging_id')->nullable()->after('id')
+                ->constrained('verenigingen')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('active_vereniging_id');
+        });
+    }
+};

--- a/database/migrations/2026_06_13_150230_create_vereniging_user_table.php
+++ b/database/migrations/2026_06_13_150230_create_vereniging_user_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('vereniging_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('vereniging_id')->constrained('verenigingen')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('role')->default('member');
+            $table->timestamp('joined_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['vereniging_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vereniging_user');
+    }
+};

--- a/resources/views/filament/pages/vereniging-beheer.blade.php
+++ b/resources/views/filament/pages/vereniging-beheer.blade.php
@@ -1,0 +1,23 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <p class="text-sm text-gray-600">
+            Beheer je vereniging: de gedeelde Claude-key (fallback voor leden zonder eigen key)
+            en de leden met hun rol. De gedeelde key wordt versleuteld opgeslagen en nooit volledig getoond.
+        </p>
+
+        <div class="space-y-4">
+            {{ $this->form }}
+
+            <div class="flex justify-end gap-3">
+                <x-filament::button wire:click="voegLidToe" color="gray" icon="heroicon-m-user-plus">
+                    Lid toevoegen
+                </x-filament::button>
+                <x-filament::button wire:click="save" icon="heroicon-m-check">
+                    Key opslaan
+                </x-filament::button>
+            </div>
+        </div>
+
+        {{ $this->table }}
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/Verenigingen/CoachInzagePolicyTest.php
+++ b/tests/Feature/Verenigingen/CoachInzagePolicyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Enums\VerenigingRol;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Vereniging;
+use App\Models\Weapon;
+
+function lidMet(Vereniging $vereniging, VerenigingRol $rol): User
+{
+    $user = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+    $vereniging->members()->attach($user, ['role' => $rol->value]);
+
+    return $user;
+}
+
+it('laat een eigenaar zijn eigen sessie zien en bewerken', function (): void {
+    $user = User::factory()->create();
+    $session = Session::factory()->for($user)->create();
+
+    expect($user->can('view', $session))->toBeTrue()
+        ->and($user->can('update', $session))->toBeTrue()
+        ->and($user->can('delete', $session))->toBeTrue();
+});
+
+it('laat een coach sessies van leden in dezelfde vereniging read-only zien', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $coach = lidMet($vereniging, VerenigingRol::Coach);
+    $lid = lidMet($vereniging, VerenigingRol::Member);
+    $session = Session::factory()->for($lid)->create();
+
+    expect($coach->can('view', $session))->toBeTrue()
+        ->and($coach->can('update', $session))->toBeFalse()
+        ->and($coach->can('delete', $session))->toBeFalse();
+});
+
+it('blokkeert coach-inzage over verenigingen heen', function (): void {
+    $clubA = Vereniging::factory()->create();
+    $clubB = Vereniging::factory()->create();
+    $coach = lidMet($clubA, VerenigingRol::Coach);
+    $vreemdLid = lidMet($clubB, VerenigingRol::Member);
+    $session = Session::factory()->for($vreemdLid)->create();
+
+    expect($coach->can('view', $session))->toBeFalse();
+});
+
+it('blokkeert dat een member peer-data ziet', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $lidA = lidMet($vereniging, VerenigingRol::Member);
+    $lidB = lidMet($vereniging, VerenigingRol::Member);
+    $session = Session::factory()->for($lidB)->create();
+
+    expect($lidA->can('view', $session))->toBeFalse();
+});
+
+it('past dezelfde coach-inzage toe op wapens', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $coach = lidMet($vereniging, VerenigingRol::Coach);
+    $lid = lidMet($vereniging, VerenigingRol::Member);
+    $weapon = Weapon::factory()->for($lid)->create();
+
+    expect($coach->can('view', $weapon))->toBeTrue()
+        ->and($coach->can('update', $weapon))->toBeFalse();
+});

--- a/tests/Feature/Verenigingen/CoachSessieResourceTest.php
+++ b/tests/Feature/Verenigingen/CoachSessieResourceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Enums\VerenigingRol;
+use App\Filament\Resources\CoachSessies\CoachSessieResource;
+use App\Filament\Resources\CoachSessies\Pages\ListCoachSessies;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Vereniging;
+use Livewire\Livewire;
+
+function coachLid(Vereniging $vereniging, VerenigingRol $rol): User
+{
+    $user = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+    $vereniging->members()->attach($user, ['role' => $rol->value]);
+
+    return $user;
+}
+
+it('toont de resource niet aan een gewoon lid', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $lid = coachLid($vereniging, VerenigingRol::Member);
+    $this->actingAs($lid);
+
+    expect(CoachSessieResource::canViewAny())->toBeFalse();
+});
+
+it('toont de resource aan een coach', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $coach = coachLid($vereniging, VerenigingRol::Coach);
+    $this->actingAs($coach);
+
+    expect(CoachSessieResource::canViewAny())->toBeTrue();
+});
+
+it('laat een coach alleen sessies van leden in de eigen vereniging zien', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $andereClub = Vereniging::factory()->create();
+
+    $coach = coachLid($vereniging, VerenigingRol::Coach);
+    $lid = coachLid($vereniging, VerenigingRol::Member);
+    $vreemdLid = coachLid($andereClub, VerenigingRol::Member);
+
+    $eigenSessie = Session::factory()->for($lid)->create();
+    $vreemdeSessie = Session::factory()->for($vreemdLid)->create();
+
+    $this->actingAs($coach);
+
+    Livewire::test(ListCoachSessies::class)
+        ->assertCanSeeTableRecords([$eigenSessie])
+        ->assertCanNotSeeTableRecords([$vreemdeSessie]);
+});
+
+it('biedt geen aanmaak- of bewerkactie op de coach-resource', function (): void {
+    expect(CoachSessieResource::canCreate())->toBeFalse()
+        ->and(CoachSessieResource::canEdit(Session::factory()->make()))->toBeFalse()
+        ->and(CoachSessieResource::canDelete(Session::factory()->make()))->toBeFalse();
+});

--- a/tests/Feature/Verenigingen/VerenigingBeheerPageTest.php
+++ b/tests/Feature/Verenigingen/VerenigingBeheerPageTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Enums\VerenigingRol;
+use App\Filament\Pages\VerenigingBeheer;
+use App\Models\User;
+use App\Models\Vereniging;
+use Livewire\Livewire;
+
+function beheerderVan(Vereniging $vereniging): User
+{
+    $admin = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+    $vereniging->members()->attach($admin, ['role' => VerenigingRol::Admin->value]);
+
+    return $admin;
+}
+
+it('is niet toegankelijk voor een gewoon lid', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $lid = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+    $vereniging->members()->attach($lid, ['role' => VerenigingRol::Member->value]);
+    $this->actingAs($lid);
+
+    expect(VerenigingBeheer::canAccess())->toBeFalse();
+});
+
+it('is toegankelijk voor een beheerder', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $this->actingAs(beheerderVan($vereniging));
+
+    expect(VerenigingBeheer::canAccess())->toBeTrue();
+
+    Livewire::test(VerenigingBeheer::class)->assertOk();
+});
+
+it('laat een beheerder een bestaand lid toevoegen', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $this->actingAs(beheerderVan($vereniging));
+    $nieuw = User::factory()->create(['email' => 'nieuw@example.test']);
+
+    Livewire::test(VerenigingBeheer::class)
+        ->set('data.email', 'nieuw@example.test')
+        ->set('data.role', VerenigingRol::Coach->value)
+        ->call('voegLidToe')
+        ->assertNotified();
+
+    expect($nieuw->fresh()->rolInVereniging($vereniging))->toBe(VerenigingRol::Coach);
+});
+
+it('toont een nette fout bij een onbekend e-mailadres', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $this->actingAs(beheerderVan($vereniging));
+
+    Livewire::test(VerenigingBeheer::class)
+        ->set('data.email', 'onbekend@example.test')
+        ->set('data.role', VerenigingRol::Member->value)
+        ->call('voegLidToe')
+        ->assertNotified();
+
+    expect($vereniging->members()->count())->toBe(1);
+});
+
+it('verwijdert een lid via de record-actie', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $this->actingAs(beheerderVan($vereniging));
+    $lid = User::factory()->create();
+    $vereniging->members()->attach($lid, ['role' => VerenigingRol::Member->value]);
+
+    Livewire::test(VerenigingBeheer::class)
+        ->callAction(\Filament\Actions\Testing\TestAction::make('verwijderLid')->table($lid));
+
+    expect($vereniging->members()->whereKey($lid->id)->exists())->toBeFalse();
+});
+
+it('slaat de gedeelde key op via het formulier', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $this->actingAs(beheerderVan($vereniging));
+
+    Livewire::test(VerenigingBeheer::class)
+        ->set('data.anthropic_api_key', 'sk-ant-gedeeld')
+        ->call('save')
+        ->assertNotified();
+
+    expect($vereniging->fresh()->anthropic_api_key)->toBe('sk-ant-gedeeld');
+});

--- a/tests/Feature/Verenigingen/VerenigingMembershipTest.php
+++ b/tests/Feature/Verenigingen/VerenigingMembershipTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Enums\VerenigingRol;
+use App\Models\User;
+use App\Models\Vereniging;
+
+it('koppelt een user met een rol aan een vereniging', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create();
+
+    $vereniging->members()->attach($user, [
+        'role' => VerenigingRol::Coach->value,
+        'joined_at' => now(),
+    ]);
+
+    expect($user->rolInVereniging($vereniging))->toBe(VerenigingRol::Coach);
+});
+
+it('geeft null als de user geen lid is', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create();
+
+    expect($user->rolInVereniging($vereniging))->toBeNull();
+});
+
+it('staat een user maar eenmaal in dezelfde vereniging toe', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create();
+
+    $vereniging->members()->attach($user, ['role' => VerenigingRol::Member->value]);
+
+    expect(fn () => $vereniging->members()->attach($user, ['role' => VerenigingRol::Admin->value]))
+        ->toThrow(Illuminate\Database\QueryException::class);
+});
+
+it('coaches() levert alleen coaches en beheerders', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $lid = User::factory()->create();
+    $coach = User::factory()->create();
+    $admin = User::factory()->create();
+
+    $vereniging->members()->attach($lid, ['role' => VerenigingRol::Member->value]);
+    $vereniging->members()->attach($coach, ['role' => VerenigingRol::Coach->value]);
+    $vereniging->members()->attach($admin, ['role' => VerenigingRol::Admin->value]);
+
+    $coachIds = $vereniging->coaches()->pluck('users.id');
+
+    expect($coachIds)->toContain($coach->id, $admin->id)
+        ->not->toContain($lid->id);
+});
+
+it('isCoachVan geldt voor leden binnen dezelfde actieve vereniging', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $coach = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+    $lid = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+
+    $vereniging->members()->attach($coach, ['role' => VerenigingRol::Coach->value]);
+    $vereniging->members()->attach($lid, ['role' => VerenigingRol::Member->value]);
+
+    expect($coach->isCoachVan($lid))->toBeTrue();
+});
+
+it('isCoachVan geldt niet voor een member zonder coachrol', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $lidA = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+    $lidB = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+
+    $vereniging->members()->attach($lidA, ['role' => VerenigingRol::Member->value]);
+    $vereniging->members()->attach($lidB, ['role' => VerenigingRol::Member->value]);
+
+    expect($lidA->isCoachVan($lidB))->toBeFalse();
+});
+
+it('isCoachVan geldt niet over verenigingen heen', function (): void {
+    $clubA = Vereniging::factory()->create();
+    $clubB = Vereniging::factory()->create();
+    $coach = User::factory()->create(['active_vereniging_id' => $clubA->id]);
+    $vreemde = User::factory()->create(['active_vereniging_id' => $clubB->id]);
+
+    $clubA->members()->attach($coach, ['role' => VerenigingRol::Coach->value]);
+    $clubB->members()->attach($vreemde, ['role' => VerenigingRol::Member->value]);
+
+    expect($coach->isCoachVan($vreemde))->toBeFalse();
+});
+
+it('slaat de verenigings-key encrypted op en verbergt deze', function (): void {
+    $vereniging = Vereniging::factory()->withKey('sk-ant-geheim')->create();
+
+    $raw = DB::table('verenigingen')->where('id', $vereniging->id)->value('anthropic_api_key');
+
+    expect($raw)->not->toBe('sk-ant-geheim')
+        ->and($vereniging->anthropic_api_key)->toBe('sk-ant-geheim')
+        ->and($vereniging->toArray())->not->toHaveKey('anthropic_api_key');
+});

--- a/tests/Feature/Verenigingen/VerenigingMembershipTest.php
+++ b/tests/Feature/Verenigingen/VerenigingMembershipTest.php
@@ -83,6 +83,48 @@ it('isCoachVan geldt niet over verenigingen heen', function (): void {
     expect($coach->isCoachVan($vreemde))->toBeFalse();
 });
 
+it('isCoachVan blokkeert een lid met losgeraakte active_vereniging_id zonder membership', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $coach = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+    $vereniging->members()->attach($coach, ['role' => VerenigingRol::Coach->value]);
+
+    // Het lid wijst wél naar de vereniging, maar is geen pivot-lid (losgeraakte staat).
+    $lid = User::factory()->create(['active_vereniging_id' => $vereniging->id]);
+
+    expect($coach->isCoachVan($lid))->toBeFalse();
+});
+
+it('staat active_vereniging_id niet toe via mass assignment', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create();
+
+    $user->update(['active_vereniging_id' => $vereniging->id]);
+
+    expect($user->fresh()->active_vereniging_id)->toBeNull();
+});
+
+it('switchVereniging zet en wist de actieve vereniging voor een lid', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create();
+    $vereniging->members()->attach($user, ['role' => VerenigingRol::Member->value]);
+
+    $user->switchVereniging($vereniging);
+    expect($user->fresh()->active_vereniging_id)->toBe($vereniging->id);
+
+    $user->switchVereniging(null);
+    expect($user->fresh()->active_vereniging_id)->toBeNull();
+});
+
+it('switchVereniging weigert een vereniging waar de user geen lid van is', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create();
+
+    expect(fn () => $user->switchVereniging($vereniging))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect($user->fresh()->active_vereniging_id)->toBeNull();
+});
+
 it('slaat de verenigings-key encrypted op en verbergt deze', function (): void {
     $vereniging = Vereniging::factory()->withKey('sk-ant-geheim')->create();
 

--- a/tests/Feature/Verenigingen/VerenigingServiceTest.php
+++ b/tests/Feature/Verenigingen/VerenigingServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Enums\VerenigingRol;
+use App\Models\User;
+use App\Models\Vereniging;
+use App\Services\Vereniging\VerenigingException;
+use App\Services\Vereniging\VerenigingService;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    $this->service = app(VerenigingService::class);
+});
+
+it('voegt een bestaand lid toe op e-mailadres met een rol', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create(['email' => 'lid@example.test']);
+
+    $this->service->voegLidToe($vereniging, 'lid@example.test', VerenigingRol::Coach);
+
+    expect($user->fresh()->rolInVereniging($vereniging))->toBe(VerenigingRol::Coach)
+        ->and($user->fresh()->active_vereniging_id)->toBe($vereniging->id);
+});
+
+it('faalt netjes bij een onbekend e-mailadres', function (): void {
+    $vereniging = Vereniging::factory()->create();
+
+    expect(fn () => $this->service->voegLidToe($vereniging, 'niemand@example.test', VerenigingRol::Member))
+        ->toThrow(VerenigingException::class);
+});
+
+it('voegt een lid niet dubbel toe', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create(['email' => 'lid@example.test']);
+    $this->service->voegLidToe($vereniging, 'lid@example.test', VerenigingRol::Member);
+
+    expect(fn () => $this->service->voegLidToe($vereniging, 'lid@example.test', VerenigingRol::Member))
+        ->toThrow(VerenigingException::class);
+});
+
+it('wijzigt de rol van een lid', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create();
+    $vereniging->members()->attach($user, ['role' => VerenigingRol::Member->value]);
+
+    $this->service->wijzigRol($vereniging, $user, VerenigingRol::Admin);
+
+    expect($user->fresh()->rolInVereniging($vereniging))->toBe(VerenigingRol::Admin);
+});
+
+it('beschermt de laatste beheerder tegen degradatie', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $admin = User::factory()->create();
+    $vereniging->members()->attach($admin, ['role' => VerenigingRol::Admin->value]);
+
+    expect(fn () => $this->service->wijzigRol($vereniging, $admin, VerenigingRol::Member))
+        ->toThrow(VerenigingException::class);
+});
+
+it('laat degradatie toe als er nog een andere beheerder is', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $adminA = User::factory()->create();
+    $adminB = User::factory()->create();
+    $vereniging->members()->attach($adminA, ['role' => VerenigingRol::Admin->value]);
+    $vereniging->members()->attach($adminB, ['role' => VerenigingRol::Admin->value]);
+
+    $this->service->wijzigRol($vereniging, $adminA, VerenigingRol::Member);
+
+    expect($adminA->fresh()->rolInVereniging($vereniging))->toBe(VerenigingRol::Member);
+});
+
+it('verwijdert een lid en reset diens actieve vereniging', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $user = User::factory()->create(['active_vereniging_id' => null]);
+    $vereniging->members()->attach($user, ['role' => VerenigingRol::Member->value]);
+    $user->update(['active_vereniging_id' => $vereniging->id]);
+
+    $this->service->verwijderLid($vereniging, $user);
+
+    expect($vereniging->members()->whereKey($user->id)->exists())->toBeFalse()
+        ->and($user->fresh()->active_vereniging_id)->toBeNull();
+});
+
+it('beschermt de laatste beheerder tegen verwijdering', function (): void {
+    $vereniging = Vereniging::factory()->create();
+    $admin = User::factory()->create();
+    $vereniging->members()->attach($admin, ['role' => VerenigingRol::Admin->value]);
+
+    expect(fn () => $this->service->verwijderLid($vereniging, $admin))
+        ->toThrow(VerenigingException::class);
+});
+
+it('bewaart en wist de gedeelde key', function (): void {
+    $vereniging = Vereniging::factory()->create();
+
+    $this->service->bewaarKey($vereniging, 'sk-ant-club');
+    expect($vereniging->fresh()->anthropic_api_key)->toBe('sk-ant-club');
+
+    $this->service->wisKey($vereniging);
+    expect($vereniging->fresh()->anthropic_api_key)->toBeNull();
+});
+
+it('valideert een geldige key tegen Anthropic', function (): void {
+    Http::fake(['*/v1/models' => Http::response(['data' => []], 200)]);
+    $vereniging = Vereniging::factory()->withKey('sk-ant-club')->create();
+
+    expect($this->service->testKey($vereniging))->toBeTrue()
+        ->and($vereniging->fresh()->ai_key_verified_at)->not->toBeNull();
+});
+
+it('meldt een ongeldige key', function (): void {
+    Http::fake(['*/v1/models' => Http::response([], 401)]);
+    $vereniging = Vereniging::factory()->withKey('sk-ant-fout')->create();
+
+    expect($this->service->testKey($vereniging))->toBeFalse();
+});

--- a/tests/Unit/Enums/VerenigingRolTest.php
+++ b/tests/Unit/Enums/VerenigingRolTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Enums\VerenigingRol;
+
+it('herkent coachrollen', function (VerenigingRol $rol, bool $verwacht): void {
+    expect($rol->canCoach())->toBe($verwacht);
+})->with([
+    'member' => [VerenigingRol::Member, false],
+    'coach' => [VerenigingRol::Coach, true],
+    'admin' => [VerenigingRol::Admin, true],
+]);
+
+it('herkent beheerdersrollen', function (VerenigingRol $rol, bool $verwacht): void {
+    expect($rol->canManage())->toBe($verwacht);
+})->with([
+    'member' => [VerenigingRol::Member, false],
+    'coach' => [VerenigingRol::Coach, false],
+    'admin' => [VerenigingRol::Admin, true],
+]);
+
+it('heeft een nederlands label', function (): void {
+    expect(VerenigingRol::Admin->label())->toBe('Beheerder');
+});

--- a/tests/Unit/Services/AiKeyResolverTest.php
+++ b/tests/Unit/Services/AiKeyResolverTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\User;
+use App\Models\Vereniging;
 use App\Services\Ai\AiKeyResolver;
 
 it('geeft de key van een user terug', function (): void {
@@ -28,4 +29,41 @@ it('resolvet de ingelogde user via forCurrentUser', function (): void {
 
 it('geeft null bij forCurrentUser zonder ingelogde user', function (): void {
     expect(app(AiKeyResolver::class)->forCurrentUser())->toBeNull();
+});
+
+it('valt terug op de verenigings-key als de user geen eigen key heeft', function (): void {
+    $vereniging = Vereniging::factory()->withKey('sk-ant-vereniging')->create();
+    $user = User::factory()->create([
+        'anthropic_api_key' => null,
+        'active_vereniging_id' => $vereniging->id,
+    ]);
+
+    expect(app(AiKeyResolver::class)->forUser($user))->toBe('sk-ant-vereniging');
+});
+
+it('laat de eigen user-key voorgaan op de verenigings-key', function (): void {
+    $vereniging = Vereniging::factory()->withKey('sk-ant-vereniging')->create();
+    $user = User::factory()->create([
+        'anthropic_api_key' => 'sk-ant-eigen',
+        'active_vereniging_id' => $vereniging->id,
+    ]);
+
+    expect(app(AiKeyResolver::class)->forUser($user))->toBe('sk-ant-eigen');
+});
+
+it('geeft null als noch user noch vereniging een key heeft', function (): void {
+    $vereniging = Vereniging::factory()->create(['anthropic_api_key' => null]);
+    $user = User::factory()->create([
+        'anthropic_api_key' => null,
+        'active_vereniging_id' => $vereniging->id,
+    ]);
+
+    expect(app(AiKeyResolver::class)->forUser($user))->toBeNull();
+});
+
+it('geeft de verenigings-key terug via forVereniging', function (): void {
+    $vereniging = Vereniging::factory()->withKey('sk-ant-club')->create();
+
+    expect(app(AiKeyResolver::class)->forVereniging($vereniging))->toBe('sk-ant-club');
+    expect(app(AiKeyResolver::class)->forVereniging(null))->toBeNull();
 });


### PR DESCRIPTION
## Wat

Fase 2 van de epic AI BYO-key + multi-tenancy: schietverenigingen met coach-inzage en een gedeelde Claude-key. In drie sub-fasen:

**(a) Datamodel + membership + key-resolutie**
- `verenigingen`-tabel (encrypted gedeelde key), `vereniging_user`-pivot (rol member/coach/admin), `users.active_vereniging_id`.
- `Vereniging`-model, `VerenigingRol`-enum, `User`-helpers (`rolInVereniging`, `isCoachVan`).
- `AiKeyResolver` uitgebreid naar `user-key → vereniging-key → null`. Jobs blijven de key runtime resolven; geen wijziging aan de payload.

**(b) Autorisatie + coach-inzage**
- `SessionPolicy`/`WeaponPolicy`: eigenaar mag alles; coach/beheerder ziet read-only data van leden binnen dezelfde actieve vereniging; cross-vereniging en peer-inzage geblokkeerd.
- Aparte read-only `CoachSessieResource` (geen create/edit/delete), gescoped op leden van de actieve vereniging, alleen zichtbaar voor coaches/beheerders. Bestaande schutter-schermen ongewijzigd.

**(c) Ledenbeheer + gedeelde key-beheer**
- `VerenigingService`: lid toevoegen (op e-mail, bestaand account), rol wijzigen, lid verwijderen, gedeelde key bewaren/testen/wissen — met bescherming van de laatste beheerder.
- `VerenigingBeheer`-pagina (alleen beheerders): gedeelde key opslaan/testen/wissen, lid toevoegen, ledentabel met inline rol-select en verwijder-actie.

Bewuste keuzes: géén schema-brede `tenant_id`-refactor (domeindata blijft `user_id`-owned); v1 = één actieve vereniging per user; home-grown rollen (pivot-enum + policies); invite v1 koppelt alleen bestaande accounts.

## Waarom

Epic #95, Fase 2. Maakt AimTrack geschikt voor meerdere verenigingen: leden houden eigendom van hun data, coaches/admins krijgen read-only inzage binnen hun vereniging, en een gedeelde verenigings-key fungeert als fallback onder de eigen key. Plan: `.ai/plans/PLAN-issue-95-fase-2-multitenancy-verenigingen.md`.

## Hoe getest

- **Pest:** 50 nieuwe/uitgebreide tests groen — enum-rollen, key-precedentie (user → vereniging → null), membership & coach-grenzen, policy-isolatie (eigenaar/coach/cross-tenant/peer), coach-resource-scoping, `VerenigingService` (membership, rollen, laatste-beheerder-guard, key-test via `Http::fake`), en de beheerpagina (toegang, toevoegen, rol-wijziging, verwijderen, key opslaan).
- **Pint:** schoon op alle gewijzigde bestanden.
- **`composer audit`:** alleen een pre-existing low-severity advisory in `symfony/yaml` (transitief, niet door deze PR geïntroduceerd).
- **Niet gerelateerd:** 3 pre-existing failures (contact-form CSRF/rate-limit, logout CSRF) staan los van deze wijziging — de diff raakt geen routing/middleware/CSRF.