### PR TITLE
feat(responsive): custom onderdelen mobile-fluid maken (#104 · #82 fase 4)

### DIFF
--- a/resources/css/aimtrack-tokens.css
+++ b/resources/css/aimtrack-tokens.css
@@ -39,8 +39,8 @@
 
     /* Display sizes (uit design-tokens.jsx TYPE rules) */
     --at-display-xl: 64px;
-    --at-display-lg: 44px;
-    --at-display-md: 28px;
+    --at-display-lg: clamp(28px, 8vw, 44px);
+    --at-display-md: clamp(20px, 5vw, 28px);
 
     --at-text-heading:    22px;
     --at-text-subheading: 17px;
@@ -48,9 +48,9 @@
     --at-text-small:      12px;
     --at-text-micro:      11px;
 
-    --at-data-xl: 44px;
-    --at-data-lg: 26px;
-    --at-data-md: 18px;
+    --at-data-xl: clamp(30px, 8vw, 44px);
+    --at-data-lg: clamp(18px, 5vw, 26px);
+    --at-data-md: clamp(14px, 3.5vw, 18px);
     --at-label:   10px;
 
     /* ── Spacing (4-punts basis, 7 stappen) ──────────────────────── */
@@ -93,4 +93,113 @@
 
 .at-accent {
     color: var(--at-accent);
+}
+
+/*
+ * ── Fluid SVG-primitieven (#104 · Fase 4 mobile) ─────────────────
+ * De SVG-componenten zetten harde pixel width/height met een correcte
+ * viewBox. Deze centrale regel zorgt dat ze nooit breder worden dan hun
+ * container; height:auto bewaart de aspect-ratio via de viewBox. Eén
+ * knop die alle gebruikers (panel + landing) tegelijk raakt.
+ */
+.aimtrack-sparkline,
+.aimtrack-target-rings,
+.aimtrack-reticle,
+.aimtrack-at-mark,
+.aimtrack-icon {
+    max-width: 100%;
+    height: auto;
+}
+
+/*
+ * ── Responsive layout-utilities (#104 · Fase 4 mobile) ───────────
+ * De custom panel-/landingschermen zetten grid-template-columns inline.
+ * Deze classes vangen de stack-breakpoints centraal op volgens de
+ * projectconventie (max-width 1024 / 768 / 520). De media-overrides
+ * gebruiken !important omdat ze de inline grid-template-columns van het
+ * style-attribuut moeten verslaan. Eén centrale plek — geladen in zowel
+ * het Filament-panel als de standalone landing via <x-aimtrack.head-assets>.
+ */
+
+/* AI-coach: 3-koloms chat-layout → 1 kolom op de stack-grens */
+@media (max-width: 768px) {
+    .at-coach-grid { grid-template-columns: 1fr !important; min-height: 0 !important; }
+}
+
+/* KPI-/stat-rijen (4-up) → 2 op de stack-grens, 1 op telefoon */
+@media (max-width: 768px) {
+    .at-kpi-grid { grid-template-columns: repeat(2, 1fr) !important; }
+}
+@media (max-width: 520px) {
+    .at-kpi-grid { grid-template-columns: 1fr !important; }
+}
+
+/* Hoofd-body met vaste px-aside (320/340px) → 1 kolom op de stack-grens */
+@media (max-width: 768px) {
+    .at-body-2col,
+    .at-session-2col,
+    .at-weapon-2col { grid-template-columns: 1fr !important; }
+}
+
+/* Sessie-detail: 5-up stat-grid → 3 / 2 / 1 */
+@media (max-width: 1024px) {
+    .at-session-stat-grid { grid-template-columns: repeat(3, 1fr) !important; }
+}
+@media (max-width: 768px) {
+    .at-session-stat-grid { grid-template-columns: repeat(2, 1fr) !important; }
+}
+@media (max-width: 520px) {
+    .at-session-stat-grid { grid-template-columns: 1fr !important; }
+}
+
+/* Smalle sub-grids → telefoon-stack */
+@media (max-width: 520px) {
+    .at-weapon-usage-grid,
+    .at-last-session-stats,
+    .at-kalibratie-grid,
+    .at-insight-kv { grid-template-columns: 1fr !important; }
+    .at-weapon-usage-grid > div { border-right: none !important; }
+    .at-session-xysd { flex-direction: column; align-items: flex-start; gap: 2px; }
+}
+
+/* Wapen-detail: vaste 5-koloms tabel → horizontaal scrollbaar op de stack-grens */
+.at-weapon-table-scroll { overflow-x: auto; }
+@media (max-width: 768px) {
+    .at-weapon-table { min-width: 520px; }
+}
+
+/* Series-card: rigide N-koloms → fluïde auto-fit op telefoon */
+@media (max-width: 520px) {
+    .aimtrack-series-grid { grid-template-columns: repeat(auto-fit, minmax(72px, 1fr)) !important; }
+}
+
+/* AI-reflectie-kaart: 90px label-kolom → label boven waarde op de stack-grens */
+@media (max-width: 768px) {
+    .aimtrack-ai-reflect-grid { grid-template-columns: 1fr !important; gap: 2px 6px; }
+}
+
+/* Page-header: titel + acties naast elkaar → gestapeld op de stack-grens */
+@media (max-width: 768px) {
+    .aimtrack-page-header-row { flex-direction: column; align-items: stretch; gap: 8px; }
+}
+
+/* Wizard "Schoten"-preview: aside stackt, numpad 6→3, touch-vriendelijke cellen */
+@media (max-width: 768px) {
+    .aimtrack-wizard-shots { grid-template-columns: 1fr !important; }
+}
+@media (max-width: 520px) {
+    .aimtrack-wizard-numpad { grid-template-columns: repeat(3, 1fr) !important; }
+    .aimtrack-wizard-numpad > div { min-height: 44px; display: flex; align-items: center; justify-content: center; }
+    .aimtrack-wizard-stat-row { gap: 12px !important; }
+}
+
+/* Decoratieve T3 bracket-frame: kleinere hoeken op mobiel */
+@media (max-width: 768px) {
+    .aimtrack-bracket-frame > span[aria-hidden="true"] { width: 10px !important; height: 10px !important; }
+}
+
+/* Decoratieve T4 monogram-stempel: niet meer absoluut over de kaart op telefoon */
+@media (max-width: 520px) {
+    .aimtrack-monogram-stamp[data-corner="top-right"],
+    .aimtrack-monogram-stamp[data-corner="top-left"] { position: static !important; margin-top: -16px; }
 }

--- a/resources/views/components/aimtrack/ai-reflection-card.blade.php
+++ b/resources/views/components/aimtrack/ai-reflection-card.blade.php
@@ -46,7 +46,7 @@
     @unless ($compact)
         <div style="height: 1px; background: var(--at-line);"></div>
 
-        <div style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
+        <div class="aimtrack-ai-reflect-grid" style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
             <div class="at-label" style="color: var(--at-accent);">STERK</div>
             <div style="color: var(--at-text);">{{ $listOrDash($positives) }}</div>
             <div class="at-label">VERBETER</div>

--- a/resources/views/components/aimtrack/at-mark.blade.php
+++ b/resources/views/components/aimtrack/at-mark.blade.php
@@ -9,7 +9,7 @@
 @endphp
 
 <svg
-    {{ $attributes->merge(['style' => 'display: block;']) }}
+    {{ $attributes->merge(['class' => 'aimtrack-at-mark', 'style' => 'display: block;']) }}
     width="{{ $fmt($size) }}"
     height="{{ $fmt($size) }}"
     viewBox="0 0 100 100"

--- a/resources/views/components/aimtrack/empty-state.blade.php
+++ b/resources/views/components/aimtrack/empty-state.blade.php
@@ -1,7 +1,7 @@
 @props([
     'reticleOpacity' => 0.05,
     'reticleSize' => 460,
-    'maxWidth' => '420px',
+    'maxWidth' => 'clamp(280px, 90vw, 420px)',
     'iconAccent' => false,
 ])
 
@@ -14,7 +14,7 @@
 <div
     {{ $attributes->merge([
         'class' => 'at-empty-state',
-        'style' => 'position: relative; display: flex; align-items: center; justify-content: center; padding: 32px 24px; min-height: 480px; width: 100%;',
+        'style' => 'position: relative; display: flex; align-items: center; justify-content: center; padding: 32px 24px; min-height: clamp(240px, 60vh, 480px); width: 100%;',
     ]) }}
 >
     {{-- T1 watermark — ambient reticle achter de content --}}
@@ -38,7 +38,7 @@
 
         @isset($title)
             <h2
-                style="font-family: var(--at-font-display); font-size: 22px; font-weight: 600; letter-spacing: -0.015em; color: var(--at-text); margin: 16px 0 0; line-height: 1.2;"
+                style="font-family: var(--at-font-display); font-size: clamp(18px, 5.5vw, 22px); font-weight: 600; letter-spacing: -0.015em; color: var(--at-text); margin: 16px 0 0; line-height: 1.2;"
             >
                 {{ $title }}
             </h2>
@@ -46,7 +46,7 @@
 
         @isset($description)
             <p
-                style="font-family: var(--at-font-body); font-size: 14px; line-height: 1.5; color: var(--at-muted); margin: 10px auto 0; max-width: 360px;"
+                style="font-family: var(--at-font-body); font-size: 14px; line-height: 1.5; color: var(--at-muted); margin: 10px auto 0;"
             >
                 {{ $description }}
             </p>

--- a/resources/views/components/aimtrack/icon.blade.php
+++ b/resources/views/components/aimtrack/icon.blade.php
@@ -40,6 +40,7 @@
 
 <svg
     {{ $attributes->merge([
+        'class' => 'aimtrack-icon',
         'aria-hidden' => 'true',
         'style' => "display: inline-block; vertical-align: middle; color: {$color};",
     ]) }}

--- a/resources/views/components/aimtrack/monogram-stamp.blade.php
+++ b/resources/views/components/aimtrack/monogram-stamp.blade.php
@@ -28,6 +28,7 @@
 <span
     {{ $attributes->merge([
         'class' => 'aimtrack-monogram-stamp',
+        'data-corner' => $corner ?? '',
         'style' => "display: inline-flex; align-items: center; gap: 6px; padding: {$padding}; background: {$background}; border: {$border}; border-radius: 4px;".(($cornerStyles !== '') ? ' '.$cornerStyles : ''),
     ]) }}
 >

--- a/resources/views/components/aimtrack/page-header.blade.php
+++ b/resources/views/components/aimtrack/page-header.blade.php
@@ -30,7 +30,7 @@
         />
     @endif
 
-    <div style="position: relative; z-index: 1; display: flex; align-items: flex-start; gap: 16px;">
+    <div class="aimtrack-page-header-row" style="position: relative; z-index: 1; display: flex; align-items: flex-start; gap: 16px;">
         <div style="flex: 1; min-width: 0;">
             <h1 style="font-family: var(--at-font-display); font-size: var(--at-text-heading); font-weight: 600; letter-spacing: -0.01em; margin: 0; color: var(--at-text);">{{ $title }}</h1>
             @if ($subtitle)

--- a/resources/views/components/aimtrack/reticle.blade.php
+++ b/resources/views/components/aimtrack/reticle.blade.php
@@ -26,7 +26,7 @@
 @endphp
 
 <svg
-    {{ $attributes->merge(['style' => 'display: block; opacity: '.$fmt($opacity).';']) }}
+    {{ $attributes->merge(['class' => 'aimtrack-reticle', 'style' => 'display: block; opacity: '.$fmt($opacity).';']) }}
     width="{{ $fmt($size) }}"
     height="{{ $fmt($size) }}"
     viewBox="0 0 {{ $fmt($size) }} {{ $fmt($size) }}"

--- a/resources/views/components/aimtrack/ring-medaillon.blade.php
+++ b/resources/views/components/aimtrack/ring-medaillon.blade.php
@@ -23,7 +23,7 @@
 <div
     {{ $attributes->merge([
         'class' => 'aimtrack-ring-medaillon',
-        'style' => "position: relative; width: {$size}px; height: {$size}px;",
+        'style' => "position: relative; width: 100%; max-width: {$size}px; aspect-ratio: 1; margin-inline: auto;",
     ]) }}
 >
     <x-aimtrack.reticle :size="$size" :stroke="$stroke" :color="$color" :dot="false" opacity="0.85" />

--- a/resources/views/components/aimtrack/series-card.blade.php
+++ b/resources/views/components/aimtrack/series-card.blade.php
@@ -34,7 +34,7 @@
     </div>
 
     @if (count($series) > 0)
-        <div style="display: grid; grid-template-columns: repeat({{ count($series) }}, 1fr);">
+        <div class="aimtrack-series-grid" style="display: grid; grid-template-columns: repeat({{ count($series) }}, 1fr);">
             @foreach ($series as $i => $v)
                 @php
                     $good = $v >= $goodThreshold;
@@ -44,7 +44,7 @@
                 @endphp
                 <div style="padding: 14px; border-right: {{ $rightBorder }}; display: flex; flex-direction: column; gap: 4px;">
                     <div class="at-label" style="letter-spacing: 0.12em;">SERIE {{ $i + 1 }}</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 22px; font-weight: 600; color: {{ $valueColor }}; letter-spacing: -0.02em;">{{ $fmt($v) }}</div>
+                    <div style="font-family: var(--at-font-mono); font-size: clamp(16px, 5vw, 22px); font-weight: 600; color: {{ $valueColor }}; letter-spacing: -0.02em;">{{ $fmt($v) }}</div>
                     <div style="height: 4px; background: var(--at-line); border-radius: 2px; position: relative; overflow: hidden;">
                         <div style="position: absolute; inset: 0; width: {{ $fmt($pct($v), 2) }}%; background: {{ $barColor }};"></div>
                     </div>

--- a/resources/views/components/aimtrack/sparkline.blade.php
+++ b/resources/views/components/aimtrack/sparkline.blade.php
@@ -5,6 +5,7 @@
     'color' => null,
     'strokeWidth' => 1.8,
     'fill' => false,
+    'fluid' => false,
 ])
 
 @php
@@ -41,9 +42,13 @@
 @endphp
 
 <svg
-    {{ $attributes->merge(['class' => 'aimtrack-sparkline', 'style' => 'display: block;']) }}
-    width="{{ $fmt($width) }}"
-    height="{{ $fmt($height) }}"
+    {{ $attributes->merge([
+        'class' => 'aimtrack-sparkline',
+        'style' => $fluid
+            ? 'display: block; width: 100%; max-width: '.$fmt($width).'px; height: auto;'
+            : 'display: block;',
+    ]) }}
+    @unless ($fluid) width="{{ $fmt($width) }}" height="{{ $fmt($height) }}" @endunless
     viewBox="0 0 {{ $fmt($width) }} {{ $fmt($height) }}"
     role="img"
     aria-label="Trend"

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -130,6 +130,7 @@
             font-family: var(--at-font-display);
             font-weight: 600;
             font-size: 15px;
+            min-height: 44px;
             padding: var(--at-space-3) var(--at-space-5);
             cursor: pointer;
         }
@@ -142,6 +143,7 @@
             color: var(--at-accent);
             border: 1px solid var(--at-line);
             border-radius: var(--at-r-pill);
+            min-height: 44px;
             padding: var(--at-space-2) var(--at-space-4);
             cursor: pointer;
             font-family: var(--at-font-display);
@@ -157,13 +159,19 @@
 
         .mkc-success p { color: var(--at-muted); margin: 0; }
 
-        /* Honeypot — visueel verborgen, maar niet display:none zodat bots 'm vinden. */
+        /* Honeypot — visueel verborgen, maar niet display:none zodat bots 'm vinden.
+           Robuuste sr-only/clip-techniek: reserveert geen layout-ruimte en kan geen
+           horizontale page-scroll veroorzaken (i.t.t. de left:-9999px-truc). */
         .mkc-hp {
             position: absolute;
-            left: -9999px;
             width: 1px;
             height: 1px;
+            padding: 0;
+            margin: -1px;
             overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
         }
 
         .mkc-footer {

--- a/resources/views/filament/pages/coach-page.blade.php
+++ b/resources/views/filament/pages/coach-page.blade.php
@@ -59,7 +59,7 @@
                     <a
                         href="{{ $page->getCreateSessionUrl() }}"
                         data-testid="ai-coach-log-session"
-                        style="display: inline-flex; align-items: center; gap: 6px; padding: 10px 18px; border-radius: 8px; background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; text-decoration: none;"
+                        style="display: inline-flex; align-items: center; gap: 6px; padding: 10px 18px; min-height: 44px; border-radius: 8px; background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; text-decoration: none;"
                     >
                         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
                             <line x1="12" y1="5" x2="12" y2="19"></line>
@@ -71,7 +71,7 @@
                         type="button"
                         wire:click="explainAiCoach"
                         data-testid="ai-coach-explain"
-                        style="padding: 10px 18px; border-radius: 8px; border: 1px solid var(--at-line); background: transparent; color: var(--at-text); font-size: 13px; cursor: pointer;"
+                        style="padding: 10px 18px; min-height: 44px; border-radius: 8px; border: 1px solid var(--at-line); background: transparent; color: var(--at-text); font-size: 13px; cursor: pointer;"
                     >
                         Hoe werkt de AI?
                     </button>
@@ -98,7 +98,7 @@
             ]));
         @endphp
 
-        <div data-testid="ai-coach-chat-ready" style="display: grid; grid-template-columns: 260px minmax(0, 1fr) 280px; gap: 16px; align-items: stretch; min-height: 540px;">
+        <div data-testid="ai-coach-chat-ready" class="at-coach-grid" style="display: grid; grid-template-columns: 260px minmax(0, 1fr) 280px; gap: 16px; align-items: stretch; min-height: 540px;">
             <aside style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); padding: 16px 12px; display: flex; flex-direction: column; gap: 4px; overflow: auto;">
                 <div class="at-label" style="padding: 4px 8px 10px;">RECENTE GESPREKKEN</div>
                 @forelse ($conversations as $conv)
@@ -164,7 +164,7 @@
                     @if (count($scoreDrift) >= 2)
                         <x-aimtrack.bracket-frame :rounded="8" :padding="16" style="display: flex; flex-direction: column; gap: 10px;">
                             <div class="at-label" style="color: var(--at-accent);">SCORE-DRIFT · GEM. PER SCHOT · LAATSTE SESSIES</div>
-                            <x-aimtrack.sparkline :data="array_values($scoreDrift)" :width="520" :height="70" :stroke-width="2" :fill="true" color="var(--at-warn)" />
+                            <x-aimtrack.sparkline :data="array_values($scoreDrift)" :width="520" :height="70" :stroke-width="2" :fill="true" color="var(--at-warn)" :fluid="true" />
                             <div style="display: flex; justify-content: space-between; font-family: var(--at-font-mono); font-size: 9px; color: var(--at-muted); letter-spacing: 0.14em;">
                                 <span>SCHOT {{ array_key_first($scoreDrift) }}</span>
                                 <span>SCHOT {{ array_key_last($scoreDrift) }}</span>

--- a/resources/views/filament/pages/dashboard-overview.blade.php
+++ b/resources/views/filament/pages/dashboard-overview.blade.php
@@ -21,7 +21,7 @@
         :reticle-size="200"
     />
 
-    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+    <div class="at-kpi-grid" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
         <x-aimtrack.stat-card
             label="Sessies / mnd"
             :value="(string) $summary->sessionsThisMonth()"
@@ -46,7 +46,7 @@
         />
     </div>
 
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
+    <div class="at-body-2col" style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
             {{-- Leergebieden · voortgang per discipline --}}
             <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
@@ -72,6 +72,7 @@
                                 :data="$discipline['series']"
                                 :width="96"
                                 :height="36"
+                                :fluid="true"
                                 :color="$discipline['trend'] >= 0 ? 'var(--at-accent)' : 'var(--at-warn)'"
                             />
                         @endif

--- a/resources/views/filament/pages/partials/first-run-welcome.blade.php
+++ b/resources/views/filament/pages/partials/first-run-welcome.blade.php
@@ -45,7 +45,7 @@
     {{-- Big ambient reticle watermark behind everything --}}
     <x-aimtrack.watermark-bg center :size="680" :opacity="0.06" :stroke="1" :dot="true" color="var(--at-accent)" />
 
-    <div style="position: relative; z-index: 1; max-width: 520px; width: 100%; text-align: center; padding: 32px 16px;">
+    <div style="position: relative; z-index: 1; max-width: clamp(280px, 90vw, 520px); width: 100%; text-align: center; padding: 32px 16px;">
         {{-- Logo in rounded panel --}}
         <div
             style="display: inline-flex; align-items: center; justify-content: center; width: 90px; height: 90px; border-radius: 22px; background: var(--at-panel); border: 1px solid var(--at-line);"
@@ -60,19 +60,19 @@
         </div>
 
         <h1
-            style="font-family: var(--at-font-display); font-size: 44px; font-weight: 600; letter-spacing: -0.025em; margin: 12px 0 14px; color: var(--at-text); line-height: 1.1;"
+            style="font-family: var(--at-font-display); font-size: var(--at-display-lg); font-weight: 600; letter-spacing: -0.025em; margin: 12px 0 14px; color: var(--at-text); line-height: 1.1;"
         >
             Klaar voor je <span style="color: var(--at-accent);">eerste sessie?</span>
         </h1>
 
         <p
-            style="font-size: 15px; color: var(--at-muted); line-height: 1.6; max-width: 420px; margin: 0 auto;"
+            style="font-size: 15px; color: var(--at-muted); line-height: 1.6; max-width: clamp(280px, 90vw, 420px); margin: 0 auto;"
         >
             Drie korte stappen — wapen toevoegen, profiel afmaken, je eerste sessie loggen. Daarna kijkt AimTrack mee.
         </p>
 
         {{-- Step checklist --}}
-        <div style="margin: 32px auto 0; display: flex; flex-direction: column; gap: 10px; max-width: 380px;">
+        <div style="margin: 32px auto 0; display: flex; flex-direction: column; gap: 10px; max-width: clamp(280px, 90vw, 380px);">
             @foreach ($steps as $i => $step)
                 @php
                     $isCurrent = $i === $currentIndex;

--- a/resources/views/filament/resources/sessions/list-sessions.blade.php
+++ b/resources/views/filament/resources/sessions/list-sessions.blade.php
@@ -23,7 +23,7 @@
         :reticle-size="200"
     />
 
-    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+    <div class="at-kpi-grid" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
         <x-aimtrack.stat-card
             label="Sessies / mnd"
             :value="(string) $summary->sessionsThisMonth()"
@@ -48,7 +48,7 @@
         />
     </div>
 
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
+    <div class="at-body-2col" style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
         <div style="min-width: 0; display: flex; flex-direction: column; gap: 16px;">
             {{ $this->table }}
 
@@ -62,7 +62,7 @@
                         <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Wapens · gebruik</div>
                         <div class="at-label" style="margin-left: auto;">{{ $weaponUsage->count() }} actief</div>
                     </div>
-                    <div style="display: grid; grid-template-columns: repeat({{ min(3, max(1, $weaponUsage->count())) }}, 1fr);">
+                    <div class="at-weapon-usage-grid" style="display: grid; grid-template-columns: repeat({{ min(3, max(1, $weaponUsage->count())) }}, 1fr);">
                         @foreach ($weaponUsage as $weapon)
                             <div style="padding: 16px; display: flex; flex-direction: column; gap: 8px; @if (! $loop->last) border-right: 1px solid var(--at-line); @endif">
                                 <div class="at-label">{{ $weapon['type'] }}@if ($weapon['caliber'] !== '') · {{ $weapon['caliber'] }}@endif</div>
@@ -77,6 +77,7 @@
                                             :data="$weapon['series']"
                                             :width="80"
                                             :height="32"
+                                            :fluid="true"
                                             :color="$weapon['trend'] >= 0 ? 'var(--at-accent)' : 'var(--at-warn)'"
                                         />
                                     @endif
@@ -104,7 +105,7 @@
                             ])->all();
                         @endphp
                         <x-aimtrack.target-rings :size="200" :hits="$hits" />
-                        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; width: 100%;">
+                        <div class="at-last-session-stats" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; width: 100%;">
                             <div>
                                 <div class="at-label" style="letter-spacing: 0.14em;">Score</div>
                                 <div style="font-family: var(--at-font-mono); font-size: 18px; font-weight: 600; color: var(--at-accent);">{{ $lastStats->totalScore() }}</div>
@@ -136,7 +137,7 @@
                     <div class="at-label" style="margin-left: auto;">30d</div>
                 </div>
                 <div style="padding: 14px;">
-                    <x-aimtrack.sparkline :data="array_values($trend)" :width="280" :height="70" :fill="true" />
+                    <x-aimtrack.sparkline :data="array_values($trend)" :width="280" :height="70" :fill="true" :fluid="true" />
                     @if (count($trend) >= 2)
                         <div style="display: flex; justify-content: space-between; margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">
                             <span>{{ \Illuminate\Support\Carbon::parse(array_key_first($trend))->format('d M') }}</span>

--- a/resources/views/filament/resources/sessions/view-session.blade.php
+++ b/resources/views/filament/resources/sessions/view-session.blade.php
@@ -54,7 +54,7 @@
 @endphp
 
 <x-filament-panels::page>
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 16px; align-items: start;">
+    <div class="at-session-2col" style="display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 16px; align-items: start;">
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
             <div style="position: relative; padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
                 <x-aimtrack.watermark-bg :size="220" :opacity="0.07" :top="-60" :right="-40" />
@@ -89,7 +89,7 @@
                 </div>
             </div>
 
-            <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;">
+            <div class="at-session-stat-grid" style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;">
                 <x-aimtrack.stat-card label="Beste schot" :value="$bestShot !== null ? (string) $bestShot : '—'" />
                 <x-aimtrack.stat-card label="Tienen" :value="$tienen.'/'.max(1, $totalShots)" :value-tone="$tienen > 0 ? 'accent' : 'text'" />
                 <x-aimtrack.stat-card label="Negens" :value="$negens.'/'.max(1, $totalShots)" />
@@ -133,7 +133,7 @@
                     @if ($totalShots > 0)
                         <x-aimtrack.target-rings :size="240" :hits="$hits" :score-labels="true" />
                         @if ($meanXmm !== null && $meanYmm !== null && $sdMm !== null)
-                            <div style="display: flex; justify-content: space-between; width: 100%; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">
+                            <div class="at-session-xysd" style="display: flex; justify-content: space-between; width: 100%; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">
                                 <span>X: {{ $meanXmm >= 0 ? '+'.$meanXmm : $meanXmm }} mm</span>
                                 <span>Y: {{ $meanYmm >= 0 ? '+'.$meanYmm : $meanYmm }} mm</span>
                                 <span>SD: {{ $sdMm }} mm</span>

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -23,7 +23,7 @@
 
 <div class="aimtrack-wizard-shots" style="display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 16px; align-items: start;">
     <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
-        <div style="display: flex; align-items: flex-end; gap: 24px; flex-wrap: wrap;">
+        <div class="aimtrack-wizard-stat-row" style="display: flex; align-items: flex-end; gap: 24px; flex-wrap: wrap;">
             <div>
                 <div class="at-label">VOORTGANG</div>
                 <div style="display: flex; align-items: baseline; gap: 6px; margin-top: 6px;">
@@ -49,7 +49,7 @@
 
         <div>
             <div class="at-label">VOLGEND SCHOT · PREVIEW</div>
-            <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 6px; margin-top: 10px; opacity: 0.55; pointer-events: none;" aria-hidden="true">
+            <div class="aimtrack-wizard-numpad" style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 6px; margin-top: 10px; opacity: 0.55; pointer-events: none;" aria-hidden="true">
                 @foreach ($numpad as $value)
                     @php
                         $isTen = str_starts_with($value, '10');

--- a/resources/views/filament/resources/weapons/view-weapon.blade.php
+++ b/resources/views/filament/resources/weapons/view-weapon.blade.php
@@ -36,7 +36,7 @@
 @endphp
 
 <x-filament-panels::page>
-    <div style="display: grid; grid-template-columns: 340px minmax(0, 1fr); gap: 16px; align-items: start;">
+    <div class="at-weapon-2col" style="display: grid; grid-template-columns: 340px minmax(0, 1fr); gap: 16px; align-items: start;">
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
             <div style="padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg);">
                 <div style="aspect-ratio: 16/10; background: linear-gradient(135deg, var(--at-panel-2), var(--at-panel)); border: 1px solid var(--at-line); border-radius: var(--at-r-md); display: flex; align-items: center; justify-content: center; position: relative;">
@@ -71,7 +71,7 @@
 
             <div style="padding: 16px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg);">
                 <div class="at-label" style="margin-bottom: 10px;">KALIBRATIE</div>
-                <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;">
+                <div class="at-kalibratie-grid" style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;">
                     @foreach ($kalibratieRows as [$key, $value])
                         <div>
                             <div style="font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">{{ strtoupper($key) }}</div>
@@ -83,7 +83,7 @@
         </div>
 
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
-            <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+            <div class="at-kpi-grid" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
                 <x-aimtrack.stat-card label="Sessies" :value="(string) $sessionCount" :sub="$sessionCount > 0 ? 'totaal' : 'nog geen'" />
                 <x-aimtrack.stat-card label="Schoten totaal" :value="number_format($totalShots, 0, ',', '.')" />
                 <x-aimtrack.stat-card
@@ -104,7 +104,7 @@
                     <div class="at-label" style="margin-left: auto;">{{ count($trendData) }} sessies</div>
                 </div>
                 <div style="padding: 18px;">
-                    <x-aimtrack.sparkline :data="array_values($trendData)" :width="760" :height="140" :stroke-width="2" :fill="true" />
+                    <x-aimtrack.sparkline :data="array_values($trendData)" :width="760" :height="140" :stroke-width="2" :fill="true" :fluid="true" />
                     @if (count($trendData) >= 2)
                         <div style="display: flex; justify-content: space-between; margin-top: 10px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">
                             <span>{{ Carbon::parse(array_key_first($trendData))->translatedFormat('M Y') }}</span>
@@ -134,7 +134,7 @@
                     @endif
                     @if ($insightPatterns->isNotEmpty() || $insightSuggestions->isNotEmpty())
                         <div style="height: 1px; background: var(--at-line);"></div>
-                        <div style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
+                        <div class="at-insight-kv" style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
                             @if ($insightPatterns->isNotEmpty())
                                 <div class="at-label" style="color: var(--at-accent);">PATRONEN</div>
                                 <div style="color: var(--at-text);">{{ $insightPatterns->implode(' · ') }}</div>
@@ -156,7 +156,8 @@
                 @if ($recentSessions->isEmpty())
                     <div style="padding: 32px 16px; color: var(--at-muted); font-size: 12px; text-align: center;">Nog geen sessies met dit wapen.</div>
                 @else
-                    <div style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 8px 16px; font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-muted); border-bottom: 1px solid var(--at-line);">
+                    <div class="at-weapon-table-scroll">
+                    <div class="at-weapon-table" style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 8px 16px; font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-muted); border-bottom: 1px solid var(--at-line);">
                         <div>Datum</div><div>Locatie</div><div>Schoten</div><div>Score</div><div>Status</div>
                     </div>
                     @foreach ($recentSessions as $session)
@@ -165,7 +166,7 @@
                             $sessionScore = (int) ($session->score_total ?? 0);
                             $sessionShots = (int) ($session->rounds_total ?? 0);
                         @endphp
-                        <div style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 12px 16px; border-bottom: 1px solid var(--at-line); align-items: center; font-size: 12px;">
+                        <div class="at-weapon-table" style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 12px 16px; border-bottom: 1px solid var(--at-line); align-items: center; font-size: 12px;">
                             <div style="font-family: var(--at-font-mono); color: var(--at-muted); font-size: 11px;">
                                 {{ $session->date?->translatedFormat('d M') ?? '—' }}
                                 <div style="font-size: 9px; opacity: 0.7;">{{ $sessionLabel }}</div>
@@ -182,6 +183,7 @@
                             </div>
                         </div>
                     @endforeach
+                    </div>
                 @endif
             </div>
         </div>

--- a/resources/views/livewire/session-shot-board.blade.php
+++ b/resources/views/livewire/session-shot-board.blade.php
@@ -54,7 +54,7 @@
         <div style="display: flex; flex-direction: column; gap: 6px;">
             <span class="at-label">Beurt</span>
             <select wire:model.live="currentTurnIndex"
-                style="background: var(--at-bg); border: 1px solid var(--at-line); color: var(--at-text); border-radius: var(--at-r-lg); padding: 8px 14px; font-size: 13px; font-family: var(--at-font-mono);">
+                style="background: var(--at-bg); border: 1px solid var(--at-line); color: var(--at-text); border-radius: var(--at-r-lg); padding: 8px 14px; min-height: 44px; font-size: 13px; font-family: var(--at-font-mono);">
                 <option value="{{ \App\Livewire\SessionShotBoard::ALL_TURNS_VALUE }}">Alle beurten</option>
                 @foreach ($turnOptions as $turn)
                     <option value="{{ $turn }}">Beurt {{ $turn + 1 }}</option>
@@ -64,14 +64,14 @@
 
         @if ($canEdit)
             <button type="button" wire:click="addTurn"
-                style="display: inline-flex; align-items: center; gap: 6px; padding: 9px 14px; border-radius: var(--at-r-lg); background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; border: none; cursor: pointer;">
+                style="display: inline-flex; align-items: center; gap: 6px; padding: 9px 14px; min-height: 44px; border-radius: var(--at-r-lg); background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; border: none; cursor: pointer;">
                 <x-filament::icon icon="heroicon-m-plus" class="h-4 w-4" />
                 Nieuwe beurt
             </button>
         @endif
 
         <button type="button" wire:click="toggleRings" role="switch" aria-checked="{{ $showRings ? 'true' : 'false' }}" aria-label="Toon ringnummers op de roos"
-            style="display: inline-flex; align-items: center; gap: 10px; margin-left: auto; padding: 8px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); color: var(--at-text); font-size: 13px; cursor: pointer;">
+            style="display: inline-flex; align-items: center; gap: 10px; margin-left: auto; padding: 8px 12px; min-height: 44px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); color: var(--at-text); font-size: 13px; cursor: pointer;">
             <span style="width: 30px; height: 18px; border-radius: 999px; background: {{ $showRings ? 'var(--at-accent)' : 'var(--at-line)' }}; position: relative; flex-shrink: 0; transition: background .15s ease;">
                 <span style="position: absolute; top: 2px; left: {{ $showRings ? '14px' : '2px' }}; width: 14px; height: 14px; border-radius: 50%; background: var(--at-cta-text); transition: left .15s ease;"></span>
             </span>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
 
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        html { scroll-behavior: smooth; }
+        html { scroll-behavior: smooth; overflow-x: hidden; }
 
         .mk-body {
             margin: 0;
@@ -449,12 +449,16 @@
             .mk-reticle-deco { right: -40px; opacity: .6; }
             .mk-features, .mk-ai { padding-top: 56px; padding-bottom: 56px; }
             .mk-feature-grid { grid-template-columns: 1fr; }
+            .mk-hero-stage { width: 100%; max-width: 280px; height: auto; aspect-ratio: 1; transform: none; margin: auto; }
         }
         @media (max-width: 520px) {
             .mk-nav { padding: 14px 18px; gap: 12px; }
             .mk-hero { padding: 44px 18px 36px; }
-            .mk-hero-stage { transform: scale(.74); margin: -55px 0; }
             .mk-cta-row .mk-btn { flex: 1 1 auto; }
+            .mk-reticle-deco { top: 8px; right: -120px; opacity: .35; }
+            .mk-callout-score { left: 0; }
+            .mk-callout-group { right: 0; }
+            .mk-callout-ai { right: 0; }
         }
 
         @media (prefers-reduced-motion: reduce) {
@@ -635,7 +639,7 @@
                 <div class="mk-feature-demo">
                     <div class="mk-demo-trend">
                         <div class="mk-demo-trend-label">SCHOTEN · PER SESSIE</div>
-                        <x-aimtrack.sparkline :data="$trendSeries ?? []" :width="250" :height="50" color="var(--at-accent)" :stroke-width="1.8" :fill="true" />
+                        <x-aimtrack.sparkline :data="$trendSeries ?? []" :width="250" :height="50" color="var(--at-accent)" :stroke-width="1.8" :fill="true" :fluid="true" />
                     </div>
                 </div>
             </article>
@@ -750,7 +754,7 @@
                 </div>
                 <div class="mk-drift">
                     <div class="mk-drift-label">SCORE-DRIFT · SCHOT 30–40</div>
-                    <x-aimtrack.sparkline :data="[9.6, 9.5, 9.4, 9.2, 9.0, 8.9, 9.0, 9.1, 9.3, 9.4, 9.4]" :width="380" :height="50" color="var(--at-warn)" :stroke-width="1.8" />
+                    <x-aimtrack.sparkline :data="[9.6, 9.5, 9.4, 9.2, 9.0, 8.9, 9.0, 9.1, 9.3, 9.4, 9.4]" :width="380" :height="50" color="var(--at-warn)" :stroke-width="1.8" :fluid="true" />
                 </div>
                 <div class="mk-bubble mk-bubble-user">Wat raad je aan?</div>
                 <div class="mk-bubble mk-bubble-ai">

--- a/tests/Feature/DesignComponentsTest.php
+++ b/tests/Feature/DesignComponentsTest.php
@@ -137,8 +137,8 @@ test('ring-medaillon renders reticle, label, value and sub readout', function ()
         ->toContain('SCORE')
         ->toContain('>547<')
         ->toContain('>/600<')
-        ->toContain('width: 200px')
-        ->toContain('height: 200px')
+        ->toContain('max-width: 200px')
+        ->toContain('aspect-ratio: 1')
         ->toContain('<svg');
 });
 
@@ -149,7 +149,13 @@ test('ring-medaillon honours custom size, label, value and sub', function (): vo
         ->toContain('GROEP')
         ->toContain('>22<')
         ->toContain('>mm<')
-        ->toContain('width: 130px');
+        ->toContain('max-width: 130px');
+});
+
+test('fluid svg primitives carry their shared class hooks (#104)', function (): void {
+    expect(Blade::render('<x-aimtrack.reticle :size="100" />'))->toContain('aimtrack-reticle');
+    expect(Blade::render('<x-aimtrack.at-mark :size="20" />'))->toContain('aimtrack-at-mark');
+    expect(Blade::render('<x-aimtrack.icon name="target" :size="16" />'))->toContain('aimtrack-icon');
 });
 
 test('monogram-stamp renders solid stamp by default with at-mark and label', function (): void {

--- a/tests/Feature/DesignTokensTest.php
+++ b/tests/Feature/DesignTokensTest.php
@@ -62,3 +62,24 @@ test('aimtrack tokens stylesheet defines spacing and radius scales', function ()
         expect($css)->toContain($token);
     }
 });
+
+test('aimtrack tokens stylesheet defines the fluid SVG rule and responsive layout utilities (#104)', function (): void {
+    $css = file_get_contents(resource_path('css/aimtrack-tokens.css'));
+
+    expect($css)
+        ->toContain('.aimtrack-sparkline')
+        ->toContain('max-width: 100%')
+        ->toContain('.at-kpi-grid')
+        ->toContain('.at-coach-grid')
+        ->toContain('.at-session-stat-grid')
+        ->toContain('@media (max-width: 768px)')
+        ->toContain('@media (max-width: 520px)');
+});
+
+test('aimtrack data and display type tokens are fluid clamps (#104)', function (): void {
+    $css = file_get_contents(resource_path('css/aimtrack-tokens.css'));
+
+    expect($css)
+        ->toContain('--at-data-lg: clamp(')
+        ->toContain('--at-display-lg: clamp(');
+});

--- a/tests/Unit/Aimtrack/SparklineComponentTest.php
+++ b/tests/Unit/Aimtrack/SparklineComponentTest.php
@@ -53,3 +53,24 @@ test('sparkline marks the latest point with a terminal dot', function (): void {
 
     expect($html)->toContain('<circle');
 });
+
+test('sparkline fluid prop emits a responsive width and drops the fixed pixel attributes (#104)', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" width="380" height="50" :fluid="true" />');
+
+    expect($html)
+        ->toContain('width: 100%')
+        ->toContain('max-width: 380px')
+        ->toContain('height: auto')
+        ->toContain('viewBox="0 0 380 50"')
+        ->not->toContain('width="380"')
+        ->not->toContain('height="50"');
+});
+
+test('sparkline keeps fixed pixel dimensions when not fluid (#104)', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" width="380" height="50" />');
+
+    expect($html)
+        ->toContain('width="380"')
+        ->toContain('height="50"')
+        ->not->toContain('width: 100%');
+});


### PR DESCRIPTION
Closes #104 · onderdeel van #82 (Fase 4 · mobile companion).

Maakt **alle custom onderdelen** (marketing-landing + gedeelde `x-aimtrack.*` SVG-componenten + het Filament-paneel) mobile-responsive. Gekozen aanpak conform de issue: **custom CSS behouden en fluid maken — géén Tailwind-refactor, geen dedicated mobile-schermen** (die blijven een Fase-4b follow-up).

## Aanpak

**Gedeeld fluid-recept (`resources/css/aimtrack-tokens.css`, geladen in panel én landing):**
- Centrale rule `max-width:100%; height:auto` voor `.aimtrack-sparkline/.target-rings/.reticle/.at-mark/.icon` (viewBox bewaart de aspect-ratio).
- Nieuwe optionele `fluid`-prop op `<x-aimtrack.sparkline>` → `width:100%; max-width:{w}px; height:auto`.
- Fluid `clamp()` type-tokens (`--at-data-*`, `--at-display-*`) — desktop ongewijzigd, krimpt op mobiel.
- `ring-medaillon` max-width-cap; class-hooks toegevoegd aan `reticle`/`at-mark`/`icon`.
- Centrale responsive layout-utilities (`.at-kpi-grid`, `.at-coach-grid`, `.at-session-stat-grid`, `.at-body-2col`, …) volgens de **breakpoint-conventie 1024 / 768 / 520 max-width**.

**Per scherm:**
- **Landing**: `html { overflow-x: hidden }`-guard + fluïde hero-stage (de `scale(.74)`-hack verwijderd) + fluid chat-/trend-sparklines + callouts/reticle ingetogen op telefoon.
- **Coach-page**: 3-koloms chat-grid → 1 kolom op 768px.
- **Dashboard / sessie-detail / wapen-detail**: KPI- en 5-up stat-grids stacken; vaste px-asides (320/340px) → 1 kolom; wapen-detail score-trend (760px) fluid + de 5-koloms sessietabel horizontaal scrollbaar.
- **Wizard "Schoten"-preview**: aside stackt, numpad 6→3 kolommen + 44px touch-targets.
- **Contact**: honeypot robuust verborgen (clip-techniek) + 44px knoppen.
- **Decoratief** (sectie 7): bracket-frame-hoeken kleiner op mobiel, monogram-stempel niet meer absoluut over de kaart op telefoon.

## Acceptatiecriteria

- [x] `docW − vw == 0px` op **360 / 390 / 768** (+1280) voor **alle** publieke en admin-pagina's — geverifieerd met headless Chromium, publiek én ingelogd. Landing was 78/48/40 → **0/0/0**.
- [x] Coach-page, dashboard, sessie-detail en wapen-detail stacken correct; geen kolom/kaart valt buiten beeld op ≤520px.
- [x] Alle SVG-primitieven schalen mee (shared rule + `fluid`-prop).
- [x] Interactieve primaire controls ≥ 44×44px touch-target.
- [x] Custom CSS fluid, geen Tailwind-refactor; breakpoint-conventie consistent.
- [x] `npm run build` groen; Pint schoon.

## Verificatie

- **Headless Chromium overflow-meting** (360/390/768/1280, ingelogd) — page-overflow 0 op alle pagina's; resterende "offenders" zijn óf decoratieve reticles (geclipt door de guard) óf Filament-eigen scrollbare tabellen (buiten scope) óf de bewuste horizontaal-scrollbare wapentabel.
- **Pest**: pristine = 6 failed / 367 passed → met deze PR = **6 failed / 372 passed**. De 6 failures zijn **identiek op de ongewijzigde branch** (ContactForm rate-limiter, ContactPage `assertSeeLivewire` [Livewire v4], Logout CSRF [bekend sinds #81], NewSessionWizard ×3) → **0 regressies**, **+5 nieuwe slagende tests** (sparkline `fluid`, class-hooks, fluid-tokens).

## Bewust niet in deze PR

- Dedicated mobile-schermen (Vandaag / Live-loggen / AI-coach mobile) → **Fase 4b** follow-up.
- Touch-op-canvas verwijderflow (long-press/rechtsklik) op het schotenbord is op touch onbetrouwbaar (geen `touchstart/end`-wiring) — JS-gedrag, buiten de fluid-CSS-scope; aanrader als aparte follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
