### PR TITLE
feat(ui): custom onderdelen mobile-responsive maken (#104)

### DIFF
--- a/resources/css/aimtrack-tokens.css
+++ b/resources/css/aimtrack-tokens.css
@@ -48,10 +48,21 @@
     --at-text-small:      12px;
     --at-text-micro:      11px;
 
-    --at-data-xl: 44px;
-    --at-data-lg: 26px;
-    --at-data-md: 18px;
+    /*
+     * Numerieke data-sizes zijn fluid (clamp): op smalle viewports krimpen de
+     * KPI-/stat-waarden mee zodat ze niet uit hun kaart breken (#104). De
+     * bovengrens is de oorspronkelijke vaste maat, zodat desktop ongewijzigd
+     * blijft.
+     */
+    --at-data-xl: clamp(30px, 8vw, 44px);
+    --at-data-lg: clamp(18px, 5vw, 26px);
+    --at-data-md: clamp(14px, 3.5vw, 18px);
     --at-label:   10px;
+
+    /* Display-sizes als fluid varianten (#104) — voor koppen die op mobiel
+       anders te groot worden (first-run-welcome, empty-states). */
+    --at-display-lg-fluid: clamp(28px, 8vw, 44px);
+    --at-display-md-fluid: clamp(20px, 5vw, 28px);
 
     /* ── Spacing (4-punts basis, 7 stappen) ──────────────────────── */
     --at-space-1: 4px;
@@ -93,4 +104,160 @@
 
 .at-accent {
     color: var(--at-accent);
+}
+
+/*
+ * ── Responsive · mobile-fluid recept (#104) ─────────────────────────────
+ *
+ * Dit bestand is de single source of truth voor zowel de publieke landing
+ * (via <x-aimtrack.head-assets>) als het Filament-panel (via
+ * AdminPanelProvider::aimTrackDesignAssets()). De regels hieronder grijpen dus
+ * in beide contexten tegelijk — één centrale fix raakt alle gebruikers.
+ *
+ * Breakpoint-conventie (aansluitend op welcome.blade.php): max-width queries op
+ * 1024 / 768 / 520px. Geen mobile-first/min-width mengen.
+ */
+
+/* Globale guard: voorkom zijwaartse page-scroll als een decoratief element
+   buiten de viewport uitsteekt. body heeft dit al op de landing; html niet. */
+html {
+    overflow-x: hidden;
+}
+
+/*
+ * SVG-primitieven schalen nooit groter dan hun container. De viewBox bewaart de
+ * aspect-ratio, dus height:auto houdt ze proportioneel. Iconen (inline, vaste
+ * kleine maat) krijgen alleen max-width zodat hun inline-grootte intact blijft.
+ */
+.aimtrack-sparkline,
+.aimtrack-target-rings,
+.aimtrack-reticle,
+.aimtrack-at-mark {
+    max-width: 100%;
+    height: auto;
+}
+
+.aimtrack-icon {
+    max-width: 100%;
+}
+
+/*
+ * Fluid grid-utilities — vervangen ad-hoc inline grid-template-columns die op
+ * mobiel niet terugvallen. Toepassen via class op de bestaande grid-div.
+ */
+
+/* Hoofd-detail layout: content + aside. Stackt op de primaire stack-grens. */
+.at-grid-main-aside {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) var(--at-aside-w, 320px);
+    gap: 16px;
+    align-items: start;
+}
+
+/* Aside-links variant (sidebar vóór content). */
+.at-grid-aside-main {
+    display: grid;
+    grid-template-columns: var(--at-aside-w, 340px) minmax(0, 1fr);
+    gap: 16px;
+    align-items: start;
+}
+
+/* KPI-/stat-rij: 4 kolommen op desktop, halveert en stackt op mobiel. */
+.at-grid-stats {
+    display: grid;
+    grid-template-columns: repeat(var(--at-stats-cols, 4), minmax(0, 1fr));
+    gap: 12px;
+}
+
+/* Drie-koloms werkblad (coach): sidebar · canvas · context-aside. */
+.at-grid-triptych {
+    display: grid;
+    grid-template-columns: 260px minmax(0, 1fr) 280px;
+    gap: 16px;
+    align-items: stretch;
+}
+
+/* Label · waarde tweekoloms-lijst (smalle label-kolom + tekst). Op mobiel
+   stackt het label boven de waarde. */
+.at-grid-label-value {
+    display: grid;
+    grid-template-columns: 90px 1fr;
+    gap: 6px;
+}
+
+/* Touch-targets: interactieve elementen minstens 44×44px op coarse pointers. */
+.at-touch {
+    min-height: 44px;
+    min-width: 44px;
+}
+
+/* Wizard score-numpad: cellen zijn volwaardige touch-targets. */
+.at-wizard-numpad > * {
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/*
+ * Tablet landscape: stat-rijen met >3 kolommen vallen terug naar 3 zodat de
+ * kaarten leesbaar blijven. (CSS repeat() accepteert geen min()/var() als
+ * teller, dus de stap is hier bewust met expliciete waarden uitgeschreven.)
+ */
+@media (max-width: 1024px) {
+    .at-grid-stats {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    /* Asides stacken altijd onder de content op de primaire stack-grens. */
+    .at-grid-main-aside,
+    .at-grid-aside-main {
+        grid-template-columns: 1fr;
+    }
+
+    .at-grid-stats {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .at-grid-triptych {
+        grid-template-columns: 1fr;
+    }
+
+    /* Label boven waarde i.p.v. naast elkaar zodra het krap wordt. */
+    .at-grid-label-value {
+        grid-template-columns: 1fr;
+        gap: 2px;
+    }
+
+    /* Page-header: titel en acties onder elkaar op smalle schermen. */
+    .aimtrack-page-header-row {
+        flex-direction: column;
+        gap: 8px;
+    }
+}
+
+@media (max-width: 520px) {
+    .at-grid-stats {
+        grid-template-columns: 1fr;
+    }
+
+    /* Wizard-numpad: 6 → 3 kolommen op telefoon. */
+    .at-wizard-numpad {
+        grid-template-columns: repeat(3, 1fr) !important;
+    }
+
+    /* Wapen-gebruik kolommen stacken; verticale scheiding wordt een hairline. */
+    .at-weapon-usage {
+        grid-template-columns: 1fr !important;
+    }
+
+    .at-weapon-usage > * {
+        border-right: none !important;
+    }
+
+    .at-weapon-usage > * + * {
+        border-top: 1px solid var(--at-line);
+    }
 }

--- a/resources/css/aimtrack-tokens.css
+++ b/resources/css/aimtrack-tokens.css
@@ -119,8 +119,12 @@
  */
 
 /* Globale guard: voorkom zijwaartse page-scroll als een decoratief element
-   buiten de viewport uitsteekt. body heeft dit al op de landing; html niet. */
-html {
+   buiten de viewport uitsteekt. body heeft dit al op de landing; html niet.
+   Bewust NIET op het Filament-panel (body.fi-body): daar mag het clippen van
+   de html-scrollroot de sticky topbar/sidebar en horizontaal scrollende
+   tabellen niet raken. Matcht .fi-body niet, dan geldt de guard overal
+   (= identiek aan het vorige gedrag). */
+html:not(:has(.fi-body)) {
     overflow-x: hidden;
 }
 

--- a/resources/views/components/aimtrack/ai-reflection-card.blade.php
+++ b/resources/views/components/aimtrack/ai-reflection-card.blade.php
@@ -46,7 +46,7 @@
     @unless ($compact)
         <div style="height: 1px; background: var(--at-line);"></div>
 
-        <div style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
+        <div class="at-grid-label-value" style="font-size: 12px;">
             <div class="at-label" style="color: var(--at-accent);">STERK</div>
             <div style="color: var(--at-text);">{{ $listOrDash($positives) }}</div>
             <div class="at-label">VERBETER</div>

--- a/resources/views/components/aimtrack/at-mark.blade.php
+++ b/resources/views/components/aimtrack/at-mark.blade.php
@@ -9,7 +9,7 @@
 @endphp
 
 <svg
-    {{ $attributes->merge(['style' => 'display: block;']) }}
+    {{ $attributes->merge(['class' => 'aimtrack-at-mark', 'style' => 'display: block;']) }}
     width="{{ $fmt($size) }}"
     height="{{ $fmt($size) }}"
     viewBox="0 0 100 100"

--- a/resources/views/components/aimtrack/empty-state.blade.php
+++ b/resources/views/components/aimtrack/empty-state.blade.php
@@ -9,12 +9,16 @@
     $reticleOpacity = (float) $reticleOpacity;
     $reticleSize = (int) $reticleSize;
     $iconBorderColor = $iconAccent ? 'var(--at-accent-25, rgba(100, 244, 179, 0.25))' : 'var(--at-line)';
+
+    // Fluid max-width: krimp mee op smalle viewports, gecapt op de meegegeven
+    // breedte zodat desktop ongewijzigd blijft (#104).
+    $fluidMaxWidth = 'clamp(280px, 90vw, '.$maxWidth.')';
 @endphp
 
 <div
     {{ $attributes->merge([
         'class' => 'at-empty-state',
-        'style' => 'position: relative; display: flex; align-items: center; justify-content: center; padding: 32px 24px; min-height: 480px; width: 100%;',
+        'style' => 'position: relative; display: flex; align-items: center; justify-content: center; padding: 32px 24px; min-height: clamp(240px, 60vh, 480px); width: 100%;',
     ]) }}
 >
     {{-- T1 watermark — ambient reticle achter de content --}}
@@ -27,7 +31,7 @@
         color="var(--at-accent)"
     />
 
-    <div style="position: relative; z-index: 1; text-align: center; max-width: {{ $maxWidth }}; width: 100%;">
+    <div style="position: relative; z-index: 1; text-align: center; max-width: {{ $fluidMaxWidth }}; width: 100%;">
         @isset($icon)
             <div
                 style="display: inline-flex; width: 64px; height: 64px; border-radius: 18px; background: var(--at-panel); border: 1px solid {{ $iconBorderColor }}; align-items: center; justify-content: center; color: var(--at-accent);"
@@ -38,7 +42,7 @@
 
         @isset($title)
             <h2
-                style="font-family: var(--at-font-display); font-size: 22px; font-weight: 600; letter-spacing: -0.015em; color: var(--at-text); margin: 16px 0 0; line-height: 1.2;"
+                style="font-family: var(--at-font-display); font-size: clamp(18px, 5.5vw, 22px); font-weight: 600; letter-spacing: -0.015em; color: var(--at-text); margin: 16px 0 0; line-height: 1.2;"
             >
                 {{ $title }}
             </h2>
@@ -46,7 +50,7 @@
 
         @isset($description)
             <p
-                style="font-family: var(--at-font-body); font-size: 14px; line-height: 1.5; color: var(--at-muted); margin: 10px auto 0; max-width: 360px;"
+                style="font-family: var(--at-font-body); font-size: 14px; line-height: 1.5; color: var(--at-muted); margin: 10px auto 0; max-width: min(100%, 360px);"
             >
                 {{ $description }}
             </p>

--- a/resources/views/components/aimtrack/icon.blade.php
+++ b/resources/views/components/aimtrack/icon.blade.php
@@ -40,6 +40,7 @@
 
 <svg
     {{ $attributes->merge([
+        'class' => 'aimtrack-icon',
         'aria-hidden' => 'true',
         'style' => "display: inline-block; vertical-align: middle; color: {$color};",
     ]) }}

--- a/resources/views/components/aimtrack/page-header.blade.php
+++ b/resources/views/components/aimtrack/page-header.blade.php
@@ -30,7 +30,7 @@
         />
     @endif
 
-    <div style="position: relative; z-index: 1; display: flex; align-items: flex-start; gap: 16px;">
+    <div class="aimtrack-page-header-row" style="position: relative; z-index: 1; display: flex; align-items: flex-start; gap: 16px;">
         <div style="flex: 1; min-width: 0;">
             <h1 style="font-family: var(--at-font-display); font-size: var(--at-text-heading); font-weight: 600; letter-spacing: -0.01em; margin: 0; color: var(--at-text);">{{ $title }}</h1>
             @if ($subtitle)

--- a/resources/views/components/aimtrack/reticle.blade.php
+++ b/resources/views/components/aimtrack/reticle.blade.php
@@ -26,7 +26,7 @@
 @endphp
 
 <svg
-    {{ $attributes->merge(['style' => 'display: block; opacity: '.$fmt($opacity).';']) }}
+    {{ $attributes->merge(['class' => 'aimtrack-reticle', 'style' => 'display: block; opacity: '.$fmt($opacity).';']) }}
     width="{{ $fmt($size) }}"
     height="{{ $fmt($size) }}"
     viewBox="0 0 {{ $fmt($size) }} {{ $fmt($size) }}"

--- a/resources/views/components/aimtrack/ring-medaillon.blade.php
+++ b/resources/views/components/aimtrack/ring-medaillon.blade.php
@@ -23,7 +23,7 @@
 <div
     {{ $attributes->merge([
         'class' => 'aimtrack-ring-medaillon',
-        'style' => "position: relative; width: {$size}px; height: {$size}px;",
+        'style' => "position: relative; width: 100%; max-width: {$size}px; aspect-ratio: 1; margin-inline: auto;",
     ]) }}
 >
     <x-aimtrack.reticle :size="$size" :stroke="$stroke" :color="$color" :dot="false" opacity="0.85" />

--- a/resources/views/components/aimtrack/series-card.blade.php
+++ b/resources/views/components/aimtrack/series-card.blade.php
@@ -34,7 +34,7 @@
     </div>
 
     @if (count($series) > 0)
-        <div style="display: grid; grid-template-columns: repeat({{ count($series) }}, 1fr);">
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));">
             @foreach ($series as $i => $v)
                 @php
                     $good = $v >= $goodThreshold;
@@ -44,7 +44,7 @@
                 @endphp
                 <div style="padding: 14px; border-right: {{ $rightBorder }}; display: flex; flex-direction: column; gap: 4px;">
                     <div class="at-label" style="letter-spacing: 0.12em;">SERIE {{ $i + 1 }}</div>
-                    <div style="font-family: var(--at-font-mono); font-size: 22px; font-weight: 600; color: {{ $valueColor }}; letter-spacing: -0.02em;">{{ $fmt($v) }}</div>
+                    <div style="font-family: var(--at-font-mono); font-size: clamp(16px, 4.5vw, 22px); font-weight: 600; color: {{ $valueColor }}; letter-spacing: -0.02em;">{{ $fmt($v) }}</div>
                     <div style="height: 4px; background: var(--at-line); border-radius: 2px; position: relative; overflow: hidden;">
                         <div style="position: absolute; inset: 0; width: {{ $fmt($pct($v), 2) }}%; background: {{ $barColor }};"></div>
                     </div>

--- a/resources/views/components/aimtrack/sparkline.blade.php
+++ b/resources/views/components/aimtrack/sparkline.blade.php
@@ -5,6 +5,7 @@
     'color' => null,
     'strokeWidth' => 1.8,
     'fill' => false,
+    'fluid' => false,
 ])
 
 @php
@@ -13,6 +14,7 @@
     $height = (float) $height;
     $color = $color ?? 'var(--at-accent)';
     $strokeWidth = (float) $strokeWidth;
+    $fluid = (bool) $fluid;
 
     $fmt = static fn (float $value): string => rtrim(rtrim(number_format($value, 3, '.', ''), '0'), '.') ?: '0';
 
@@ -41,9 +43,16 @@
 @endphp
 
 <svg
-    {{ $attributes->merge(['class' => 'aimtrack-sparkline', 'style' => 'display: block;']) }}
-    width="{{ $fmt($width) }}"
-    height="{{ $fmt($height) }}"
+    {{ $attributes->merge([
+        'class' => 'aimtrack-sparkline',
+        'style' => $fluid
+            ? 'display: block; width: 100%; max-width: '.$fmt($width).'px; height: auto;'
+            : 'display: block;',
+    ]) }}
+    @unless ($fluid)
+        width="{{ $fmt($width) }}"
+        height="{{ $fmt($height) }}"
+    @endunless
     viewBox="0 0 {{ $fmt($width) }} {{ $fmt($height) }}"
     role="img"
     aria-label="Trend"

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -131,6 +131,7 @@
             font-weight: 600;
             font-size: 15px;
             padding: var(--at-space-3) var(--at-space-5);
+            min-height: 44px;
             cursor: pointer;
         }
 

--- a/resources/views/filament/pages/coach-page.blade.php
+++ b/resources/views/filament/pages/coach-page.blade.php
@@ -98,7 +98,7 @@
             ]));
         @endphp
 
-        <div data-testid="ai-coach-chat-ready" style="display: grid; grid-template-columns: 260px minmax(0, 1fr) 280px; gap: 16px; align-items: stretch; min-height: 540px;">
+        <div data-testid="ai-coach-chat-ready" class="at-grid-triptych" style="min-height: 540px;">
             <aside style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); padding: 16px 12px; display: flex; flex-direction: column; gap: 4px; overflow: auto;">
                 <div class="at-label" style="padding: 4px 8px 10px;">RECENTE GESPREKKEN</div>
                 @forelse ($conversations as $conv)
@@ -164,7 +164,7 @@
                     @if (count($scoreDrift) >= 2)
                         <x-aimtrack.bracket-frame :rounded="8" :padding="16" style="display: flex; flex-direction: column; gap: 10px;">
                             <div class="at-label" style="color: var(--at-accent);">SCORE-DRIFT · GEM. PER SCHOT · LAATSTE SESSIES</div>
-                            <x-aimtrack.sparkline :data="array_values($scoreDrift)" :width="520" :height="70" :stroke-width="2" :fill="true" color="var(--at-warn)" />
+                            <x-aimtrack.sparkline :data="array_values($scoreDrift)" :width="520" :height="70" :stroke-width="2" :fill="true" color="var(--at-warn)" fluid />
                             <div style="display: flex; justify-content: space-between; font-family: var(--at-font-mono); font-size: 9px; color: var(--at-muted); letter-spacing: 0.14em;">
                                 <span>SCHOT {{ array_key_first($scoreDrift) }}</span>
                                 <span>SCHOT {{ array_key_last($scoreDrift) }}</span>

--- a/resources/views/filament/pages/dashboard-overview.blade.php
+++ b/resources/views/filament/pages/dashboard-overview.blade.php
@@ -21,7 +21,7 @@
         :reticle-size="200"
     />
 
-    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+    <div class="at-grid-stats">
         <x-aimtrack.stat-card
             label="Sessies / mnd"
             :value="(string) $summary->sessionsThisMonth()"
@@ -46,7 +46,7 @@
         />
     </div>
 
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
+    <div class="at-grid-main-aside">
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
             {{-- Leergebieden · voortgang per discipline --}}
             <div style="background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
@@ -73,6 +73,7 @@
                                 :width="96"
                                 :height="36"
                                 :color="$discipline['trend'] >= 0 ? 'var(--at-accent)' : 'var(--at-warn)'"
+                                fluid
                             />
                         @endif
                     </div>

--- a/resources/views/filament/pages/partials/first-run-welcome.blade.php
+++ b/resources/views/filament/pages/partials/first-run-welcome.blade.php
@@ -60,19 +60,19 @@
         </div>
 
         <h1
-            style="font-family: var(--at-font-display); font-size: 44px; font-weight: 600; letter-spacing: -0.025em; margin: 12px 0 14px; color: var(--at-text); line-height: 1.1;"
+            style="font-family: var(--at-font-display); font-size: var(--at-display-lg-fluid); font-weight: 600; letter-spacing: -0.025em; margin: 12px 0 14px; color: var(--at-text); line-height: 1.1;"
         >
             Klaar voor je <span style="color: var(--at-accent);">eerste sessie?</span>
         </h1>
 
         <p
-            style="font-size: 15px; color: var(--at-muted); line-height: 1.6; max-width: 420px; margin: 0 auto;"
+            style="font-size: 15px; color: var(--at-muted); line-height: 1.6; max-width: min(100%, 420px); margin: 0 auto;"
         >
             Drie korte stappen — wapen toevoegen, profiel afmaken, je eerste sessie loggen. Daarna kijkt AimTrack mee.
         </p>
 
         {{-- Step checklist --}}
-        <div style="margin: 32px auto 0; display: flex; flex-direction: column; gap: 10px; max-width: 380px;">
+        <div style="margin: 32px auto 0; display: flex; flex-direction: column; gap: 10px; max-width: min(100%, 380px);">
             @foreach ($steps as $i => $step)
                 @php
                     $isCurrent = $i === $currentIndex;

--- a/resources/views/filament/resources/sessions/list-sessions.blade.php
+++ b/resources/views/filament/resources/sessions/list-sessions.blade.php
@@ -23,7 +23,7 @@
         :reticle-size="200"
     />
 
-    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+    <div class="at-grid-stats">
         <x-aimtrack.stat-card
             label="Sessies / mnd"
             :value="(string) $summary->sessionsThisMonth()"
@@ -48,7 +48,7 @@
         />
     </div>
 
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 16px; align-items: start;">
+    <div class="at-grid-main-aside">
         <div style="min-width: 0; display: flex; flex-direction: column; gap: 16px;">
             {{ $this->table }}
 
@@ -62,7 +62,7 @@
                         <div style="font-size: 13px; font-weight: 600; color: var(--at-text);">Wapens · gebruik</div>
                         <div class="at-label" style="margin-left: auto;">{{ $weaponUsage->count() }} actief</div>
                     </div>
-                    <div style="display: grid; grid-template-columns: repeat({{ min(3, max(1, $weaponUsage->count())) }}, 1fr);">
+                    <div class="at-weapon-usage" style="display: grid; grid-template-columns: repeat({{ min(3, max(1, $weaponUsage->count())) }}, 1fr);">
                         @foreach ($weaponUsage as $weapon)
                             <div style="padding: 16px; display: flex; flex-direction: column; gap: 8px; @if (! $loop->last) border-right: 1px solid var(--at-line); @endif">
                                 <div class="at-label">{{ $weapon['type'] }}@if ($weapon['caliber'] !== '') · {{ $weapon['caliber'] }}@endif</div>
@@ -78,6 +78,7 @@
                                             :width="80"
                                             :height="32"
                                             :color="$weapon['trend'] >= 0 ? 'var(--at-accent)' : 'var(--at-warn)'"
+                                            fluid
                                         />
                                     @endif
                                 </div>
@@ -136,7 +137,7 @@
                     <div class="at-label" style="margin-left: auto;">30d</div>
                 </div>
                 <div style="padding: 14px;">
-                    <x-aimtrack.sparkline :data="array_values($trend)" :width="280" :height="70" :fill="true" />
+                    <x-aimtrack.sparkline :data="array_values($trend)" :width="280" :height="70" :fill="true" fluid />
                     @if (count($trend) >= 2)
                         <div style="display: flex; justify-content: space-between; margin-top: 8px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.08em;">
                             <span>{{ \Illuminate\Support\Carbon::parse(array_key_first($trend))->format('d M') }}</span>

--- a/resources/views/filament/resources/sessions/view-session.blade.php
+++ b/resources/views/filament/resources/sessions/view-session.blade.php
@@ -54,7 +54,7 @@
 @endphp
 
 <x-filament-panels::page>
-    <div style="display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 16px; align-items: start;">
+    <div class="at-grid-main-aside" style="--at-aside-w: 340px;">
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
             <div style="position: relative; padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg); overflow: hidden;">
                 <x-aimtrack.watermark-bg :size="220" :opacity="0.07" :top="-60" :right="-40" />
@@ -89,7 +89,7 @@
                 </div>
             </div>
 
-            <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px;">
+            <div class="at-grid-stats" style="--at-stats-cols: 5;">
                 <x-aimtrack.stat-card label="Beste schot" :value="$bestShot !== null ? (string) $bestShot : '—'" />
                 <x-aimtrack.stat-card label="Tienen" :value="$tienen.'/'.max(1, $totalShots)" :value-tone="$tienen > 0 ? 'accent' : 'text'" />
                 <x-aimtrack.stat-card label="Negens" :value="$negens.'/'.max(1, $totalShots)" />

--- a/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
+++ b/resources/views/filament/resources/sessions/wizard-shots-step.blade.php
@@ -21,7 +21,7 @@
     $sessionRange = $wizardData['range_name'] ?? ($wizardData['location'] ?? null);
 @endphp
 
-<div class="aimtrack-wizard-shots" style="display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 16px; align-items: start;">
+<div class="aimtrack-wizard-shots at-grid-main-aside" style="--at-aside-w: 280px;">
     <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
         <div style="display: flex; align-items: flex-end; gap: 24px; flex-wrap: wrap;">
             <div>
@@ -49,7 +49,7 @@
 
         <div>
             <div class="at-label">VOLGEND SCHOT · PREVIEW</div>
-            <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 6px; margin-top: 10px; opacity: 0.55; pointer-events: none;" aria-hidden="true">
+            <div class="at-wizard-numpad" style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 6px; margin-top: 10px; opacity: 0.55; pointer-events: none;" aria-hidden="true">
                 @foreach ($numpad as $value)
                     @php
                         $isTen = str_starts_with($value, '10');

--- a/resources/views/filament/resources/weapons/view-weapon.blade.php
+++ b/resources/views/filament/resources/weapons/view-weapon.blade.php
@@ -36,7 +36,7 @@
 @endphp
 
 <x-filament-panels::page>
-    <div style="display: grid; grid-template-columns: 340px minmax(0, 1fr); gap: 16px; align-items: start;">
+    <div class="at-grid-aside-main" style="--at-aside-w: 340px;">
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
             <div style="padding: 20px; background: var(--at-panel); border: 1px solid var(--at-line); border-radius: var(--at-r-lg);">
                 <div style="aspect-ratio: 16/10; background: linear-gradient(135deg, var(--at-panel-2), var(--at-panel)); border: 1px solid var(--at-line); border-radius: var(--at-r-md); display: flex; align-items: center; justify-content: center; position: relative;">
@@ -83,7 +83,7 @@
         </div>
 
         <div style="display: flex; flex-direction: column; gap: 16px; min-width: 0;">
-            <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
+            <div class="at-grid-stats">
                 <x-aimtrack.stat-card label="Sessies" :value="(string) $sessionCount" :sub="$sessionCount > 0 ? 'totaal' : 'nog geen'" />
                 <x-aimtrack.stat-card label="Schoten totaal" :value="number_format($totalShots, 0, ',', '.')" />
                 <x-aimtrack.stat-card
@@ -104,7 +104,7 @@
                     <div class="at-label" style="margin-left: auto;">{{ count($trendData) }} sessies</div>
                 </div>
                 <div style="padding: 18px;">
-                    <x-aimtrack.sparkline :data="array_values($trendData)" :width="760" :height="140" :stroke-width="2" :fill="true" />
+                    <x-aimtrack.sparkline :data="array_values($trendData)" :width="760" :height="140" :stroke-width="2" :fill="true" fluid />
                     @if (count($trendData) >= 2)
                         <div style="display: flex; justify-content: space-between; margin-top: 10px; font-family: var(--at-font-mono); font-size: 10px; color: var(--at-muted); letter-spacing: 0.12em;">
                             <span>{{ Carbon::parse(array_key_first($trendData))->translatedFormat('M Y') }}</span>
@@ -134,7 +134,7 @@
                     @endif
                     @if ($insightPatterns->isNotEmpty() || $insightSuggestions->isNotEmpty())
                         <div style="height: 1px; background: var(--at-line);"></div>
-                        <div style="display: grid; grid-template-columns: 90px 1fr; gap: 6px; font-size: 12px;">
+                        <div class="at-grid-label-value" style="font-size: 12px;">
                             @if ($insightPatterns->isNotEmpty())
                                 <div class="at-label" style="color: var(--at-accent);">PATRONEN</div>
                                 <div style="color: var(--at-text);">{{ $insightPatterns->implode(' · ') }}</div>
@@ -156,7 +156,8 @@
                 @if ($recentSessions->isEmpty())
                     <div style="padding: 32px 16px; color: var(--at-muted); font-size: 12px; text-align: center;">Nog geen sessies met dit wapen.</div>
                 @else
-                    <div style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 8px 16px; font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-muted); border-bottom: 1px solid var(--at-line);">
+                    <div style="overflow-x: auto;">
+                    <div style="display: grid; grid-template-columns: 100px minmax(160px, 1fr) 90px 80px 80px; min-width: 510px; padding: 8px 16px; font-family: var(--at-font-mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--at-muted); border-bottom: 1px solid var(--at-line);">
                         <div>Datum</div><div>Locatie</div><div>Schoten</div><div>Score</div><div>Status</div>
                     </div>
                     @foreach ($recentSessions as $session)
@@ -165,7 +166,7 @@
                             $sessionScore = (int) ($session->score_total ?? 0);
                             $sessionShots = (int) ($session->rounds_total ?? 0);
                         @endphp
-                        <div style="display: grid; grid-template-columns: 100px minmax(0, 1fr) 90px 80px 80px; padding: 12px 16px; border-bottom: 1px solid var(--at-line); align-items: center; font-size: 12px;">
+                        <div style="display: grid; grid-template-columns: 100px minmax(160px, 1fr) 90px 80px 80px; min-width: 510px; padding: 12px 16px; border-bottom: 1px solid var(--at-line); align-items: center; font-size: 12px;">
                             <div style="font-family: var(--at-font-mono); color: var(--at-muted); font-size: 11px;">
                                 {{ $session->date?->translatedFormat('d M') ?? '—' }}
                                 <div style="font-size: 9px; opacity: 0.7;">{{ $sessionLabel }}</div>
@@ -182,6 +183,7 @@
                             </div>
                         </div>
                     @endforeach
+                    </div>
                 @endif
             </div>
         </div>

--- a/resources/views/livewire/session-shot-board.blade.php
+++ b/resources/views/livewire/session-shot-board.blade.php
@@ -64,14 +64,14 @@
 
         @if ($canEdit)
             <button type="button" wire:click="addTurn"
-                style="display: inline-flex; align-items: center; gap: 6px; padding: 9px 14px; border-radius: var(--at-r-lg); background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; border: none; cursor: pointer;">
+                style="display: inline-flex; align-items: center; justify-content: center; gap: 6px; min-height: 44px; padding: 9px 14px; border-radius: var(--at-r-lg); background: var(--at-accent); color: var(--at-cta-text); font-weight: 600; font-size: 13px; border: none; cursor: pointer;">
                 <x-filament::icon icon="heroicon-m-plus" class="h-4 w-4" />
                 Nieuwe beurt
             </button>
         @endif
 
         <button type="button" wire:click="toggleRings" role="switch" aria-checked="{{ $showRings ? 'true' : 'false' }}" aria-label="Toon ringnummers op de roos"
-            style="display: inline-flex; align-items: center; gap: 10px; margin-left: auto; padding: 8px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); color: var(--at-text); font-size: 13px; cursor: pointer;">
+            style="display: inline-flex; align-items: center; gap: 10px; margin-left: auto; min-height: 44px; padding: 8px 12px; border-radius: var(--at-r-lg); background: var(--at-panel-2); border: 1px solid var(--at-line); color: var(--at-text); font-size: 13px; cursor: pointer;">
             <span style="width: 30px; height: 18px; border-radius: 999px; background: {{ $showRings ? 'var(--at-accent)' : 'var(--at-line)' }}; position: relative; flex-shrink: 0; transition: background .15s ease;">
                 <span style="position: absolute; top: 2px; left: {{ $showRings ? '14px' : '2px' }}; width: 14px; height: 14px; border-radius: 50%; background: var(--at-cta-text); transition: left .15s ease;"></span>
             </span>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
 
     <style>
         *, *::before, *::after { box-sizing: border-box; }
-        html { scroll-behavior: smooth; }
+        html { scroll-behavior: smooth; overflow-x: hidden; }
 
         .mk-body {
             margin: 0;
@@ -449,12 +449,16 @@
             .mk-reticle-deco { right: -40px; opacity: .6; }
             .mk-features, .mk-ai { padding-top: 56px; padding-bottom: 56px; }
             .mk-feature-grid { grid-template-columns: 1fr; }
+            /* Hero-vizier fluid i.p.v. vaste 420px — schaalt mee, behoudt vierkant. */
+            .mk-hero-stage { width: 100%; max-width: 280px; height: auto; aspect-ratio: 1; margin: 0 auto; }
         }
         @media (max-width: 520px) {
             .mk-nav { padding: 14px 18px; gap: 12px; }
             .mk-hero { padding: 44px 18px 36px; }
-            .mk-hero-stage { transform: scale(.74); margin: -55px 0; }
             .mk-cta-row .mk-btn { flex: 1 1 auto; }
+            /* Decoratief vizier ver genoeg buiten beeld duwen zodat het de smalle
+               viewport niet verbreedt (overflow-x:hidden clipt de rest). */
+            .mk-reticle-deco { right: -260px; top: -260px; opacity: .4; }
         }
 
         @media (prefers-reduced-motion: reduce) {
@@ -750,7 +754,7 @@
                 </div>
                 <div class="mk-drift">
                     <div class="mk-drift-label">SCORE-DRIFT · SCHOT 30–40</div>
-                    <x-aimtrack.sparkline :data="[9.6, 9.5, 9.4, 9.2, 9.0, 8.9, 9.0, 9.1, 9.3, 9.4, 9.4]" :width="380" :height="50" color="var(--at-warn)" :stroke-width="1.8" />
+                    <x-aimtrack.sparkline :data="[9.6, 9.5, 9.4, 9.2, 9.0, 8.9, 9.0, 9.1, 9.3, 9.4, 9.4]" :width="380" :height="50" color="var(--at-warn)" :stroke-width="1.8" fluid />
                 </div>
                 <div class="mk-bubble mk-bubble-user">Wat raad je aan?</div>
                 <div class="mk-bubble mk-bubble-ai">

--- a/tests/Feature/DesignComponentsTest.php
+++ b/tests/Feature/DesignComponentsTest.php
@@ -137,8 +137,9 @@ test('ring-medaillon renders reticle, label, value and sub readout', function ()
         ->toContain('SCORE')
         ->toContain('>547<')
         ->toContain('>/600<')
-        ->toContain('width: 200px')
-        ->toContain('height: 200px')
+        ->toContain('width: 100%')
+        ->toContain('max-width: 200px')
+        ->toContain('aspect-ratio: 1')
         ->toContain('<svg');
 });
 
@@ -149,7 +150,7 @@ test('ring-medaillon honours custom size, label, value and sub', function (): vo
         ->toContain('GROEP')
         ->toContain('>22<')
         ->toContain('>mm<')
-        ->toContain('width: 130px');
+        ->toContain('max-width: 130px');
 });
 
 test('monogram-stamp renders solid stamp by default with at-mark and label', function (): void {

--- a/tests/Feature/EmptyStateComponentTest.php
+++ b/tests/Feature/EmptyStateComponentTest.php
@@ -29,7 +29,7 @@ test('empty-state honours custom reticle size, opacity and max width', function 
     expect($html)
         ->toContain('width="320"')
         ->toContain('opacity: 0.08')
-        ->toContain('max-width: 520px');
+        ->toContain('max-width: clamp(280px, 90vw, 520px)');
 });
 
 test('empty-state renders title slot inside h2 with display font', function (): void {

--- a/tests/Feature/MobileResponsiveTest.php
+++ b/tests/Feature/MobileResponsiveTest.php
@@ -65,7 +65,7 @@ test('design tokens stylesheet defines the shared fluid svg rule and overflow gu
         ->toContain('.aimtrack-at-mark')
         ->toContain('max-width: 100%')
         ->toContain('height: auto')
-        ->toContain('html {')
+        ->toContain('html:not(:has(.fi-body)) {')
         ->toContain('overflow-x: hidden');
 });
 

--- a/tests/Feature/MobileResponsiveTest.php
+++ b/tests/Feature/MobileResponsiveTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use App\Models\Weapon;
+use Illuminate\Support\Facades\Blade;
+
+/*
+ * Issue #104 — Custom onderdelen mobile-responsive maken.
+ *
+ * Deze tests borgen het fluid-recept (#104): de gedeelde CSS-rule, de fluid
+ * type-tokens, de `fluid`-prop op sparkline, en de responsive grid-utilities.
+ * De bron-van-waarheid is resources/css/aimtrack-tokens.css, die zowel de
+ * publieke landing als het Filament-panel voedt.
+ */
+
+test('sparkline emits fixed width/height attributes by default', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" :width="280" :height="70" />');
+
+    expect($html)
+        ->toContain('aimtrack-sparkline')
+        ->toContain('width="280"')
+        ->toContain('height="70"')
+        ->toContain('viewBox="0 0 280 70"')
+        ->not->toContain('width: 100%');
+});
+
+test('sparkline fluid prop swaps fixed dimensions for a capped percentage width', function (): void {
+    $html = Blade::render('<x-aimtrack.sparkline :data="[1, 2, 3]" :width="380" :height="50" fluid />');
+
+    expect($html)
+        ->toContain('width: 100%')
+        ->toContain('max-width: 380px')
+        ->toContain('height: auto')
+        ->toContain('viewBox="0 0 380 50"')
+        ->not->toContain('width="380"')
+        ->not->toContain('height="50"');
+});
+
+test('svg primitives carry the shared fluid hook class', function (): void {
+    expect(Blade::render('<x-aimtrack.reticle />'))->toContain('aimtrack-reticle');
+    expect(Blade::render('<x-aimtrack.at-mark />'))->toContain('aimtrack-at-mark');
+    expect(Blade::render('<x-aimtrack.icon name="target" />'))->toContain('aimtrack-icon');
+    expect(Blade::render('<x-aimtrack.sparkline :data="[1, 2]" />'))->toContain('aimtrack-sparkline');
+    expect(Blade::render('<x-aimtrack.target-rings />'))->toContain('aimtrack-target-rings');
+});
+
+test('ring-medaillon caps its width instead of hardcoding pixel dimensions', function (): void {
+    $html = Blade::render('<x-aimtrack.ring-medaillon size="160" />');
+
+    expect($html)
+        ->toContain('width: 100%')
+        ->toContain('max-width: 160px')
+        ->toContain('aspect-ratio: 1')
+        ->not->toContain('height: 160px');
+});
+
+test('design tokens stylesheet defines the shared fluid svg rule and overflow guard', function (): void {
+    $css = file_get_contents(resource_path('css/aimtrack-tokens.css'));
+
+    expect($css)
+        ->toContain('.aimtrack-sparkline,')
+        ->toContain('.aimtrack-reticle,')
+        ->toContain('.aimtrack-at-mark')
+        ->toContain('max-width: 100%')
+        ->toContain('height: auto')
+        ->toContain('html {')
+        ->toContain('overflow-x: hidden');
+});
+
+test('design tokens stylesheet exposes fluid data and display type tokens', function (): void {
+    $css = file_get_contents(resource_path('css/aimtrack-tokens.css'));
+
+    expect($css)
+        ->toContain('--at-data-lg: clamp(')
+        ->toContain('--at-data-xl: clamp(')
+        ->toContain('--at-display-lg-fluid: clamp(')
+        ->toContain('--at-display-md-fluid: clamp(');
+});
+
+test('design tokens stylesheet defines responsive grid and touch utilities with the 768/520 breakpoints', function (): void {
+    $css = file_get_contents(resource_path('css/aimtrack-tokens.css'));
+
+    expect($css)
+        ->toContain('.at-grid-main-aside')
+        ->toContain('.at-grid-aside-main')
+        ->toContain('.at-grid-stats')
+        ->toContain('.at-grid-triptych')
+        ->toContain('.at-touch')
+        ->toContain('@media (max-width: 768px)')
+        ->toContain('@media (max-width: 520px)');
+});
+
+test('landing page guards the html element against horizontal overflow', function (): void {
+    $this->get('/')
+        ->assertOk()
+        ->assertSee('html { scroll-behavior: smooth; overflow-x: hidden; }', escape: false);
+});
+
+test('landing page renders the chat drift sparkline as a fluid svg', function (): void {
+    $this->get('/')
+        ->assertOk()
+        ->assertSee('aimtrack-sparkline', escape: false)
+        ->assertSee('width: 100%', escape: false);
+});
+
+test('dashboard overview renders the fluid stat and main-aside grids', function (): void {
+    $user = User::factory()->create();
+    Weapon::factory()->for($user)->create();
+
+    $this->actingAs($user);
+
+    $this->get('/admin')
+        ->assertOk()
+        ->assertDontSee('data-testid="first-run-welcome"', escape: false)
+        ->assertSee('at-grid-main-aside', escape: false)
+        ->assertSee('at-grid-stats', escape: false);
+});


### PR DESCRIPTION
**Wat**

Maakt alle custom onderdelen (marketing-landing + gedeelde `x-aimtrack.*`
SVG-componenten + Filament-paneel) mobile-responsive volgens de op #104
gekozen aanpak: **custom CSS fluid maken, geen Tailwind-refactor**.

Kern is één gedeeld fluid-recept in `resources/css/aimtrack-tokens.css` — de
single source of truth die via `<x-aimtrack.head-assets>` (landing) én
`AdminPanelProvider::aimTrackDesignAssets()` (panel) wordt geïnjecteerd. Eén
centrale fix raakt daardoor beide contexten tegelijk.

- **Gedeelde SVG-rule**: `sparkline`, `target-rings`, `reticle`, `at-mark` en
  `icon` schalen via `max-width:100% / height:auto` nooit groter dan hun
  container (class toegevoegd aan `reticle`/`at-mark`/`icon`).
- **`fluid`-prop** op `sparkline` voor echte 100%-breedte (chat-, coach-,
  trend- en stat-card-sparklines); `ring-medaillon` krijgt een max-width-cap
  met `aspect-ratio`.
- **Fluid type-tokens** (`--at-data-*`, `--at-display-*-fluid` via `clamp`) zodat
  KPI-/stat-waarden en koppen niet meer uit hun kaart breken.
- **Responsive grid-utilities** (max-width 1024/768/520, aansluitend op de
  bestaande conventie in `welcome.blade.php`): stat-grids, hoofd/aside-layouts,
  coach-triptiek, label/waarde-lijsten, wapen-gebruik en wizard-numpad stacken
  nu correct.
- **Zijwaartse page-scroll weg**: `html { overflow-x: hidden }`-guard; hero-vizier
  en decoratief vizier fluid op mobiel.
- **view-weapon** sessietabel scrollt binnen de kaart i.p.v. de hele pagina.
- **Touch-targets (44px)** op numpad, schotenbord-knoppen en contact-CTA.

**Waarom**

Issue #104 (follow-up op epic #82, onderdeel mobile): de gedeelde SVG-componenten
zetten harde pixel-`width`/`height` zonder `max-width`, en inline grids met vaste
kolomaantallen vielen niet terug op mobiel — wat zijwaartse page-scroll en
afgesneden kolommen/kaarten gaf op 360/390/768px.

> Let op: er staat al een parallelle PR #107 (`feature/mobile-responsive`) voor
> hetzelfde issue open. Deze PR is de output van de KJ-ontwikkelorchestrator op
> branch `claude/issue-104` — kies bewust welke je merget.

**Hoe getest**

- Pint: groen op de gewijzigde bestanden.
- Pest: volledige suite **383 passed (1131 assertions)**. Nieuwe
  `tests/Feature/MobileResponsiveTest.php` borgt het fluid-recept (sparkline
  default vs. `fluid`, gedeelde hook-classes, ring-medaillon-cap, token-rules,
  landing overflow-guard, dashboard-grids). Bestaande component-tests bijgewerkt
  op de nieuwe markup.
- `composer audit`: één pre-existing low-severity advisory in transitieve
  dependency `symfony/yaml` (CVE-2026-45133) — niet door deze wijziging
  geïntroduceerd (geen dependency-wijzigingen), buiten scope van dit issue.
- `npm run build`: niet uitgevoerd in deze geïsoleerde omgeving (geen Node).
  De CSS-wijziging zit in `aimtrack-tokens.css`, die runtime via Blade wordt
  ingeladen (niet Vite-gebundeld); er zijn geen nieuwe Tailwind-utilities
  toegevoegd die purge-scanning vereisen.