### PR TITLE
feat(55): kalibratie loskoppelen (vision-direct fallback) + eval-metrics

### DIFF
--- a/.ai/guidelines/parallel-worktrees.md
+++ b/.ai/guidelines/parallel-worktrees.md
@@ -97,6 +97,7 @@ Vergeet de registry hieronder niet bij te werken.
 | range-console | feature/range-console | `aimtrack-range-console/` | 19087 | 15439 | 19032 | 19007 | actief (issue #82 · Fase 1 Range Console — 5 kernschermen) |
 | marketing | feature/marketing | `aimtrack-marketing/` | 19088 | 15440 | 19033 | 19008 | actief (issue #82 · Fase 3 marketing landing) |
 | ai-byo-key | feature/ai-byo-key | `aimtrack-ai-byo-key/` | 19089 | 15441 | 19034 | 19009 | actief (issue #95 · Fase 1 BYO Claude-key per user) |
+| 55-vision-direct | feature/55-vision-direct | `aimtrack-55-vision-direct/` | 19082 | 15434 | 19027 | 19002 | actief (issue #55 · kalibratie loskoppelen + eval-harness, op basis van feature/55) |
 
 Update deze tabel bij setup en cleanup — zo weet iedereen direct welke poort bij welke stack hoort.
 

--- a/python-service/app/calibration/target_intrinsic.py
+++ b/python-service/app/calibration/target_intrinsic.py
@@ -24,6 +24,10 @@ CANONICAL_SIZE: int = 1000
 CANONICAL_MARGIN: float = 0.05  # 5% margin around ring-1 in canonical image
 CANONICAL_RING1_RADIUS: float = CANONICAL_SIZE / 2 * (1.0 - CANONICAL_MARGIN)
 MIN_RINGS_REQUIRED: int = 2
+# Cap input resolution before calibration. HoughCircles/findContours/fitEllipse work
+# is roughly quadratic in pixel count; the canonical target is only 1000px, so running
+# calibration on a full ~12MP phone photo costs minutes of latency for no accuracy gain.
+MAX_CALIBRATION_DIM: int = 1600
 
 
 class CalibrationError(Exception):
@@ -87,6 +91,7 @@ def calibrate(image: np.ndarray, spec: TargetSpec) -> CalibrationResult:
     Raises:
         CalibrationError: when fewer than MIN_RINGS_REQUIRED rings are detected.
     """
+    image = _downscale_for_calibration(image)
     gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
     enhanced = _apply_clahe(gray)
 
@@ -148,6 +153,19 @@ def homography_to_list(H: np.ndarray) -> list[list[float]]:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _downscale_for_calibration(image: np.ndarray, max_dim: int = MAX_CALIBRATION_DIM) -> np.ndarray:
+    """Downscale an oversized photo before calibration. Every detection threshold is
+    relative to the image dimensions and the homography maps into the fixed 1000px
+    canonical space, so results are equivalent while latency drops sharply on large
+    phone photos. Aspect ratio is preserved."""
+    h, w = image.shape[:2]
+    longest = max(h, w)
+    if longest <= max_dim:
+        return image
+    scale = max_dim / float(longest)
+    return cv2.resize(image, (int(round(w * scale)), int(round(h * scale))), interpolation=cv2.INTER_AREA)
 
 
 def _apply_clahe(gray: np.ndarray) -> np.ndarray:
@@ -268,23 +286,11 @@ def _detect_black_area(
         cx, cy, radius = best
         return (cx, cy), radius
 
-    # Fallback: use Hough circles
-    edges = cv2.Canny(gray, 30, 100)
-    circles = cv2.HoughCircles(
-        edges,
-        cv2.HOUGH_GRADIENT,
-        dp=1,
-        minDist=h // 2,
-        param1=50,
-        param2=30,
-        minRadius=int(min(h, w) * 0.15),
-        maxRadius=int(min(h, w) * 0.65),
-    )
-    if circles is not None and len(circles[0]) > 0:
-        cx, cy, r = circles[0][0]
-        return (float(cx), float(cy)), float(r)
-
-    # Last resort: image centre
+    # No clean circular black contour — typical on cluttered, sticker-covered photos.
+    # The former cv2.HoughCircles fallback was pathologically slow here (a dense Canny
+    # edge map plus a wide radius search runs for minutes) and unreliable on exactly
+    # these targets, so we return a fast image-centre estimate instead. A resulting
+    # poor calibration is caught downstream (high RMS -> vision-direct path).
     return (w / 2.0, h / 2.0), min(h, w) * 0.40
 
 

--- a/python-service/app/pipeline.py
+++ b/python-service/app/pipeline.py
@@ -66,15 +66,27 @@ def _build_review_reason_direct(
     detected: int,
     expected: int | None,
     overall_conf: float,
+    cal_rms: float | None,
+    cal_failed: bool,
 ) -> str:
     """Reason for the vision-direct path (calibration failed/weak, so positions are
-    approximate but the rings were read directly)."""
+    approximate but the rings were read directly). A high RMS with a converged
+    calibration is a strong signal the chosen discipline does not match the target
+    (e.g. a rifle target scored as pistol-25m), so we say so explicitly."""
     if not vision_ok:
         return _NO_KEY_REASON
-    reasons = [
-        "De roos kon niet nauwkeurig worden uitgelijnd; de schoten zijn via directe "
-        "ring-aflezing geplaatst — controleer de posities."
-    ]
+    if cal_failed:
+        lead = (
+            "De roos kon niet worden uitgelijnd — maak een rechtere, scherpere foto van de "
+            "hele roos. De schoten zijn via directe ring-aflezing geplaatst; controleer de posities."
+        )
+    else:
+        mm = f" ({round(cal_rms)} mm afwijking)" if cal_rms is not None else ""
+        lead = (
+            f"De roos past slecht bij de gekozen discipline{mm} — controleer of het roostype "
+            "(discipline) klopt. De schoten zijn via directe ring-aflezing geplaatst; controleer de posities."
+        )
+    reasons = [lead]
     if not count_ok and expected is not None:
         reasons.append(
             f"Aantal gedetecteerd ({detected}) wijkt af van het ingevulde aantal ({expected})."
@@ -231,6 +243,8 @@ def _analyze_vision_direct(
         detected=detected,
         expected=expected_shot_count,
         overall_conf=overall_conf,
+        cal_rms=(cal.rms_error_mm if cal is not None else None),
+        cal_failed=(cal is None),
     )
 
     if cal_error is not None:

--- a/python-service/app/pipeline.py
+++ b/python-service/app/pipeline.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from app.calibration.target_intrinsic import CalibrationError, calibrate
+from app.calibration.target_intrinsic import CalibrationError, CalibrationResult, calibrate
 from app.config import TargetSpec
 from app.detection.candidates import detect_candidates
 from app.detection.reconcile import Hole, reconcile
-from app.scoring import score_shot
+from app.scoring import score_from_vision, score_shot
 from app.settings import settings
-from app.vision.claude_detector import VisionError, detect_holes
+from app.vision.claude_detector import VisionError, detect_holes, detect_holes_direct
 
 
 @dataclass
@@ -28,6 +28,13 @@ class AnalysisResult:
     calibration: dict
 
 
+_NO_KEY_REASON = (
+    "AI-herkenning niet beschikbaar (geen geldige Claude-key) — stel je Claude-key "
+    "in bij AI-instellingen. Er draaide alleen ruwe detectie; stickers en gedrukte "
+    "cijfers zijn NIET uitgefilterd. Controleer de schoten handmatig."
+)
+
+
 def _build_review_reason(
     *,
     vision_ok: bool,
@@ -37,13 +44,9 @@ def _build_review_reason(
     overall_conf: float,
     rms: float,
 ) -> str:
-    """Concrete Dutch reason why a turn was flagged for review (empty if it wasn't)."""
+    """Concrete Dutch reason why a canonical-path turn was flagged for review."""
     if not vision_ok:
-        return (
-            "AI-herkenning niet beschikbaar (geen geldige Claude-key) — stel je Claude-key "
-            "in bij AI-instellingen. Er draaide alleen ruwe detectie; stickers en gedrukte "
-            "cijfers zijn NIET uitgefilterd. Controleer de schoten handmatig."
-        )
+        return _NO_KEY_REASON
     reasons: list[str] = []
     if not count_ok and expected is not None:
         reasons.append(
@@ -56,32 +59,72 @@ def _build_review_reason(
     return " ".join(reasons) or "Controleer de gedetecteerde schoten."
 
 
+def _build_review_reason_direct(
+    *,
+    vision_ok: bool,
+    count_ok: bool,
+    detected: int,
+    expected: int | None,
+    overall_conf: float,
+) -> str:
+    """Reason for the vision-direct path (calibration failed/weak, so positions are
+    approximate but the rings were read directly)."""
+    if not vision_ok:
+        return _NO_KEY_REASON
+    reasons = [
+        "De roos kon niet nauwkeurig worden uitgelijnd; de schoten zijn via directe "
+        "ring-aflezing geplaatst — controleer de posities."
+    ]
+    if not count_ok and expected is not None:
+        reasons.append(
+            f"Aantal gedetecteerd ({detected}) wijkt af van het ingevulde aantal ({expected})."
+        )
+    if overall_conf < settings.review_confidence_threshold:
+        reasons.append(f"Lage zekerheid ({round(overall_conf * 100)}%).")
+    return " ".join(reasons)
+
+
+def _cap_vision_shots(shots: list[dict], expected_shot_count: int | None) -> list[dict]:
+    """Drop sub-confidence vision-direct shots, then cap any surplus to the expected
+    count (dropping the lowest-confidence extras). Mirrors ``reconcile`` for the path
+    that has no CV candidates to snap to: fewer confident shots + needs_review beats
+    padding up to the count with dubious markers."""
+    kept = [s for s in shots if s["confidence"] >= settings.min_shot_confidence]
+    if expected_shot_count is not None and len(kept) > expected_shot_count:
+        kept = sorted(kept, key=lambda s: s["confidence"], reverse=True)[:expected_shot_count]
+    return kept
+
+
 def analyze_target_v2(image: np.ndarray, spec: TargetSpec, expected_shot_count: int | None, api_key: str | None = None) -> AnalysisResult:
-    """5-stage pipeline: calibrate -> CV candidates -> Claude discrimination ->
-    reconcile -> discipline-correct scoring. Never raises for normal failure modes;
-    degrades to needs_review so the user's photo is never lost."""
+    """Detect shots on a target photo and score them discipline-correctly.
+
+    Calibration is a non-blocking hint, not a hard gate: when the intrinsic homography
+    converges accurately (RMS within ``cal_rms_fallback_mm``) the canonical path runs
+    (CV candidates -> Claude discrimination -> reconcile -> pixel scoring). When
+    calibration fails or is too weak, the vision-direct path takes over — the model
+    reads the ring straight off the raw photo — so a bad homography never loses the
+    turn. Never raises for normal failure modes; degrades to needs_review."""
+    cal: CalibrationResult | None = None
+    cal_error: CalibrationError | None = None
     try:
         cal = calibrate(image, spec)
     except CalibrationError as exc:
-        return AnalysisResult(
-            shots=[],
-            expected_shot_count=expected_shot_count,
-            detected_count=0,
-            count_matches_expected=False,
-            overall_confidence=0.0,
-            needs_review=True,
-            review_reason="Kalibratie mislukt — de roos kon niet worden uitgelijnd. Maak een rechtere, scherpere foto van het hele schietbord.",
-            orientation_note="",
-            vision_model=settings.vision_model,
-            calibration={
-                "ok": False,
-                "error": str(exc),
-                "rms_error_mm": None,
-                "confidence": None,
-                "rings_detected": exc.rings_detected,
-            },
-        )
+        cal_error = exc
 
+    if cal is not None and cal.rms_error_mm <= settings.cal_rms_fallback_mm:
+        return _analyze_canonical(image, spec, expected_shot_count, api_key, cal)
+    return _analyze_vision_direct(image, spec, expected_shot_count, api_key, cal, cal_error)
+
+
+def _analyze_canonical(
+    image: np.ndarray,
+    spec: TargetSpec,
+    expected_shot_count: int | None,
+    api_key: str | None,
+    cal: CalibrationResult,
+) -> AnalysisResult:
+    """Homography-corrected path: CV candidates -> Claude discrimination -> reconcile
+    -> ISSF pixel scoring on the canonical 1000x1000 image."""
     candidates = detect_candidates(cal.canonical_image, spec)
 
     try:
@@ -143,5 +186,76 @@ def analyze_target_v2(image: np.ndarray, spec: TargetSpec, expected_shot_count: 
             "rms_error_mm": cal.rms_error_mm,
             "confidence": cal.confidence,
             "rings_detected": cal.rings_detected,
+            "method": "canonical",
+        },
+    )
+
+
+def _analyze_vision_direct(
+    image: np.ndarray,
+    spec: TargetSpec,
+    expected_shot_count: int | None,
+    api_key: str | None,
+    cal: CalibrationResult | None,
+    cal_error: CalibrationError | None,
+) -> AnalysisResult:
+    """Fallback path when calibration failed or is too weak: the model reads the ring
+    directly off the raw photo and reports target-normalized positions. The turn is
+    still flagged needs_review because absolute placement is approximate without a
+    homography, but the shots are never discarded."""
+    try:
+        vision = detect_holes_direct(image, spec, expected_shot_count, api_key)
+        kept = _cap_vision_shots(vision["shots"], expected_shot_count)
+        overall_conf = vision["overall_confidence"]
+        orientation = vision["orientation_note"]
+        vision_ok = True
+    except VisionError:
+        kept = []
+        overall_conf = 0.0
+        orientation = ""
+        vision_ok = False
+
+    shots: list[dict] = []
+    for s in kept:
+        sc = score_from_vision(s["x_norm"], s["y_norm"], s["ring"])
+        shots.append(
+            {"x": sc.x, "y": sc.y, "ring": sc.ring, "score": sc.score,
+             "confidence": round(s["confidence"], 3), "kind": s["kind"]}
+        )
+
+    detected = len(shots)
+    count_ok = expected_shot_count is None or detected == expected_shot_count
+    review_reason = _build_review_reason_direct(
+        vision_ok=vision_ok,
+        count_ok=count_ok,
+        detected=detected,
+        expected=expected_shot_count,
+        overall_conf=overall_conf,
+    )
+
+    if cal_error is not None:
+        cal_err_msg = str(cal_error)
+        rings = cal_error.rings_detected
+    else:
+        cal_err_msg = f"RMS te hoog ({round(cal.rms_error_mm)} mm) — homografie onbetrouwbaar" if cal is not None else "kalibratie niet uitgevoerd"
+        rings = cal.rings_detected if cal is not None else 0
+
+    return AnalysisResult(
+        shots=shots,
+        expected_shot_count=expected_shot_count,
+        detected_count=detected,
+        count_matches_expected=count_ok,
+        overall_confidence=round(overall_conf, 3),
+        needs_review=True,
+        review_reason=review_reason,
+        orientation_note=orientation,
+        vision_model=settings.vision_model,
+        calibration={
+            "ok": False,
+            "error": cal_err_msg,
+            "rms_error_mm": (cal.rms_error_mm if cal is not None else None),
+            "confidence": (cal.confidence if cal is not None else None),
+            "rings_detected": rings,
+            "method": "vision_direct",
         },
     )

--- a/python-service/app/scoring.py
+++ b/python-service/app/scoring.py
@@ -50,3 +50,21 @@ def score_shot(x_px: float, y_px: float, spec: TargetSpec, center: float = CANON
         score=ring,
         distance_norm=round(dist_norm, 4),
     )
+
+
+def score_from_vision(x_norm: float, y_norm: float, ring: int) -> ScoredShot:
+    """Score a shot from the vision-direct path (no homography available).
+
+    The model reports the ring it read straight off the printed rings plus a
+    target-normalized position (centre=(0,0), ring-1 outer edge=1.0). We trust the
+    directly-read ring rather than re-deriving it from ``x_norm``/``y_norm``: on an
+    uncalibrated, perspective-skewed photo the radial distance is not a reliable ring
+    proxy, whereas the printed rings are legible regardless of skew."""
+    r = max(0, min(10, int(ring)))
+    return ScoredShot(
+        x=round(x_norm, 4),
+        y=round(y_norm, 4),
+        ring=r,
+        score=r,
+        distance_norm=round(hypot(x_norm, y_norm), 4),
+    )

--- a/python-service/app/settings.py
+++ b/python-service/app/settings.py
@@ -14,6 +14,10 @@ class Settings:
         self.vision_effort: str = os.getenv("AIMTRACK_VISION_EFFORT", "high")
         self.review_confidence_threshold: float = float(os.getenv("AIMTRACK_REVIEW_CONFIDENCE", "0.6"))
         self.cal_rms_review_mm: float = float(os.getenv("AIMTRACK_CAL_RMS_REVIEW_MM", "20.0"))
+        # Above this RMS the intrinsic homography is too inaccurate to score pixels
+        # against; the pipeline falls back to the vision-direct path (the model reads
+        # the ring straight off the printed rings) instead of losing the turn.
+        self.cal_rms_fallback_mm: float = float(os.getenv("AIMTRACK_CAL_RMS_FALLBACK_MM", "30.0"))
         self.min_shot_confidence: float = float(os.getenv("AIMTRACK_MIN_SHOT_CONFIDENCE", "0.4"))
 
 

--- a/python-service/app/validation/metrics.py
+++ b/python-service/app/validation/metrics.py
@@ -6,17 +6,50 @@ def compare_turn(truth: list[dict], pred: list[dict]) -> dict:
     """Compare ground-truth shots to predicted shots for one turn.
 
     Pairs shots by sorted (ring desc) order — a coarse but stable proxy when the
-    harness lacks per-shot correspondence. ``count_correct`` tracks the count
-    dimension separately; ``ring_accuracy`` is measured over the shots actually
-    compared (hits / pairs)."""
+    harness lacks per-shot correspondence.
+
+    Returns:
+        count_correct: predicted count equals truth count.
+        count_delta:   pred - truth (positive = over-counting, the paster failure mode).
+        ring_accuracy: exact-ring hits / paired shots.
+        ring_mae:      mean absolute ring error over paired shots (None when no pairs).
+    """
     count_correct = len(truth) == len(pred)
+    count_delta = len(pred) - len(truth)
     if not truth:
-        return {"count_correct": count_correct, "ring_accuracy": 1.0 if not pred else 0.0}
+        return {
+            "count_correct": count_correct,
+            "count_delta": count_delta,
+            "ring_accuracy": 1.0 if not pred else 0.0,
+            "ring_mae": 0.0 if not pred else None,
+        }
     if not pred:
-        return {"count_correct": False, "ring_accuracy": 0.0}
+        return {"count_correct": False, "count_delta": count_delta, "ring_accuracy": 0.0, "ring_mae": None}
 
     t_sorted = sorted((s["ring"] for s in truth), reverse=True)
     p_sorted = sorted((s["ring"] for s in pred), reverse=True)
     pairs = min(len(t_sorted), len(p_sorted))
     hits = sum(1 for i in range(pairs) if t_sorted[i] == p_sorted[i])
-    return {"count_correct": count_correct, "ring_accuracy": hits / pairs}
+    mae = sum(abs(t_sorted[i] - p_sorted[i]) for i in range(pairs)) / pairs
+    return {
+        "count_correct": count_correct,
+        "count_delta": count_delta,
+        "ring_accuracy": hits / pairs,
+        "ring_mae": mae,
+    }
+
+
+def aggregate(results: list[dict]) -> dict:
+    """Roll per-turn ``compare_turn`` dicts up into headline validation metrics."""
+    n = len(results)
+    if n == 0:
+        return {"turns": 0}
+    maes = [r["ring_mae"] for r in results if r.get("ring_mae") is not None]
+    return {
+        "turns": n,
+        "count_accuracy": sum(1 for r in results if r["count_correct"]) / n,
+        "mean_ring_accuracy": sum(r["ring_accuracy"] for r in results) / n,
+        "mean_ring_mae": (sum(maes) / len(maes)) if maes else None,
+        "over_count_turns": sum(1 for r in results if r["count_delta"] > 0),
+        "under_count_turns": sum(1 for r in results if r["count_delta"] < 0),
+    }

--- a/python-service/app/vision/claude_detector.py
+++ b/python-service/app/vision/claude_detector.py
@@ -65,12 +65,14 @@ def _system_prompt(spec: TargetSpec, expected_shot_count: int | None) -> str:
     )
 
 
-def _call_claude(canonical_b64: str, system: str, api_key: str | None = None) -> str:
+def _call_claude(canonical_b64: str, system: str, api_key: str | None = None, schema: dict | None = None) -> str:
     """Single network call. Isolated so tests can monkeypatch it. Returns the raw
     JSON text the model produced under the structured-output format constraint.
 
     ``api_key`` is the per-user BYO Claude key (resolved by Laravel, forwarded per
-    request); it takes precedence over the optional service-level env key."""
+    request); it takes precedence over the optional service-level env key.
+    ``schema`` is the JSON schema the structured output must satisfy; it defaults to
+    the canonical-pixel ``_SHOT_SCHEMA`` so existing callers are unchanged."""
     from anthropic import Anthropic
 
     client = Anthropic(api_key=api_key or settings.anthropic_api_key or None)
@@ -81,7 +83,7 @@ def _call_claude(canonical_b64: str, system: str, api_key: str | None = None) ->
         thinking={"type": "adaptive"},
         output_config={
             "effort": settings.vision_effort,
-            "format": {"type": "json_schema", "schema": _SHOT_SCHEMA},
+            "format": {"type": "json_schema", "schema": schema or _SHOT_SCHEMA},
         },
         messages=[
             {
@@ -131,6 +133,124 @@ def detect_holes(canonical: np.ndarray, spec: TargetSpec, expected_shot_count: i
             {
                 "x_px": int(s["x_px"]),
                 "y_px": int(s["y_px"]),
+                "confidence": max(0.0, min(1.0, float(s.get("confidence", 0.0)))),
+                "kind": s.get("kind", "hole"),
+            }
+        )
+    return {
+        "shots": shots,
+        "orientation_note": str(data.get("orientation_note", "")),
+        "overall_confidence": max(0.0, min(1.0, float(data.get("overall_confidence", 0.0)))),
+        "count_matches_expected": bool(data.get("count_matches_expected", False)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Vision-direct — fallback when calibration failed or is too weak for a reliable
+# homography. The model analyses the RAW (uncalibrated) photo and reports each shot
+# as a target-normalized position plus the ring it reads directly off the printed
+# rings, so a failed homography no longer loses the turn.
+# ---------------------------------------------------------------------------
+
+_DIRECT_SHOT_SCHEMA: dict = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "shots": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "x_norm": {"type": "number"},
+                    "y_norm": {"type": "number"},
+                    "ring": {"type": "integer"},
+                    "confidence": {"type": "number"},
+                    "kind": {"type": "string", "enum": ["hole", "uncertain"]},
+                },
+                "required": ["x_norm", "y_norm", "ring", "confidence", "kind"],
+            },
+        },
+        "orientation_note": {"type": "string"},
+        "overall_confidence": {"type": "number"},
+        "count_matches_expected": {"type": "boolean"},
+    },
+    "required": ["shots", "orientation_note", "overall_confidence", "count_matches_expected"],
+}
+
+_VISION_MAX_DIM: int = 1500
+
+
+def _direct_system_prompt(spec: TargetSpec, expected_shot_count: int | None) -> str:
+    count_line = (
+        f"Er zijn precies {expected_shot_count} schoten gelost in deze beurt; rapporteer er bij "
+        f"voorkeur exact {expected_shot_count} schoten, maar rapporteer NOOIT iets wat geen vers "
+        f"kogelgat is alleen om dat aantal te halen."
+        if expected_shot_count is not None
+        else "Het aantal schoten is onbekend; rapporteer elk vers kogelgat waar je zeker van bent."
+    )
+    return (
+        f"Je analyseert een ONBEWERKTE foto van een {spec.name} schietkaart; het perspectief is "
+        f"NIET gecorrigeerd, dus de kaart kan schuin of gedraaid in beeld staan. "
+        f"Bepaal zelf het centrum van het zwarte richtvlak en lees de concentrische ringen af. "
+        f"Rapporteer per VERS kogelgat: (1) de positie GENORMALISEERD t.o.v. het roos-centrum, waarbij "
+        f"(0,0) het centrum is en straal 1.0 de BUITENrand van ring 1 (rechts = +x_norm, omlaag = "
+        f"+y_norm); (2) de RING (1-10, of 0 als het schot buiten ring 1 valt) die je DIRECT van de "
+        f"gedrukte ringen afleest — NIET uit de afstand berekent, want door het perspectief is de "
+        f"afstand geen betrouwbare ringmaat. "
+        f"Oude treffers zijn dichtgeplakt met lichte (witte/lichtblauwe) plakkers op het papier of "
+        f"ZWARTE plakkers op het zwarte vlak — dat zijn GEEN schoten. Rapporteer UITSLUITEND verse "
+        f"kogelgaten: donkere perforaties op licht papier, of lichte/gescheurde kraters waar VERS door "
+        f"het zwart is geschoten. Negeer expliciet: gladde plakkers/pasters, gedrukte ringcijfers "
+        f"(zoals 8, 9, 10), ringlijnen, kartonscheuren en tape. "
+        f"Liever minder gaten rapporteren waar je zeker van bent dan twijfelgevallen meetellen — zet "
+        f"de confidence laag (onder 0.4) bij twijfel. {count_line}"
+    )
+
+
+def _prepare_for_vision(image: np.ndarray, max_dim: int = _VISION_MAX_DIM) -> np.ndarray:
+    """Downscale an oversized photo so the token cost of the vision call stays bounded.
+    Aspect ratio is preserved, so fractional/normalized coordinates are unaffected."""
+    h, w = image.shape[:2]
+    longest = max(h, w)
+    if longest <= max_dim:
+        return image
+    scale = max_dim / float(longest)
+    return cv2.resize(image, (int(round(w * scale)), int(round(h * scale))), interpolation=cv2.INTER_AREA)
+
+
+def detect_holes_direct(image: np.ndarray, spec: TargetSpec, expected_shot_count: int | None, api_key: str | None = None) -> dict:
+    """Vision-direct fallback: analyse the RAW photo and return shots with a
+    target-normalized position (centre=(0,0), ring-1 edge=1.0) plus the directly-read
+    ring. Used when intrinsic calibration failed or is too weak for a reliable
+    homography. Returns: {shots: [{x_norm,y_norm,ring,confidence,kind}], orientation_note,
+    overall_confidence, count_matches_expected}. Raises VisionError on any failure."""
+    ok, buf = cv2.imencode(".png", _prepare_for_vision(image))
+    if not ok:
+        raise VisionError("PNG-codering mislukt")
+    b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+
+    try:
+        raw = _call_claude(
+            b64, _direct_system_prompt(spec, expected_shot_count), api_key, schema=_DIRECT_SHOT_SCHEMA
+        )
+    except VisionError:
+        raise
+    except Exception as exc:  # anthropic.APIError, network, etc.
+        raise VisionError(str(exc)) from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise VisionError("Ongeldige JSON van vision-model") from exc
+
+    shots: list[dict] = []
+    for s in data.get("shots", []):
+        shots.append(
+            {
+                "x_norm": float(s["x_norm"]),
+                "y_norm": float(s["y_norm"]),
+                "ring": max(0, min(10, int(s.get("ring", 0)))),
                 "confidence": max(0.0, min(1.0, float(s.get("confidence", 0.0)))),
                 "kind": s.get("kind", "hole"),
             }

--- a/python-service/fixtures/.gitignore
+++ b/python-service/fixtures/.gitignore
@@ -1,0 +1,4 @@
+*.jpg
+*.jpeg
+*.png
+manifest.json

--- a/python-service/fixtures/LABELS-REVIEW.md
+++ b/python-service/fixtures/LABELS-REVIEW.md
@@ -1,0 +1,21 @@
+# Eval-labels — PROVISIONEEL (corrigeer wat fout is)
+
+Deze labels zijn automatisch voor-ingevuld door Claude-vision op de rúwe foto's.
+**Ze zijn NIET geverifieerd tegen de werkelijkheid.** Jij weet de echte schoten — corrigeer per foto:
+
+1. **`target_type`** — bevestig de discipline (jij weet welke roos je schoot). Geldig: `kkp_25m`, `gkp_25m`, `kkg_50m`, `kkg_100m`, `gkg_100m`.
+2. **`expected_shot_count`** — het echte aantal schoten van die beurt.
+3. **`truth`** — de echte ringwaarde per schot.
+
+Pas daarna `fixtures/manifest.provisional.json` aan en hernoem naar `fixtures/manifest.json`.
+
+| Foto | discipline (GOK — check) | aantal (prov.) | ringen (prov.) |
+|---|---|---|---|
+| IMG_5672.jpg | `kkp_25m` | 5 | 8, 8, 7, 7, 6 |
+| IMG_5700.jpg | `gkg_100m` | 0 |  |
+| IMG_6277.jpg | `kkg_100m` | 4 | 9, 8, 6, 6 |
+| IMG_6415.jpg | `kkp_25m` | 15 | 9, 9, 8, 8, 8, 7, 7, 7, 7, 6, 6, 6, 6, 6, 3 |
+| IMG_6826.jpg | `kkp_25m` | 5 | 8, 7, 7, 6, 5 |
+| IMG_7381.jpg | `kkp_25m` | 6 | 8, 8, 8, 7, 6, 6 |
+
+> Tip: begin met deze 6 en breid uit met 2-3 foto's per discipline voor een gebalanceerde eval-set.

--- a/python-service/fixtures/README.md
+++ b/python-service/fixtures/README.md
@@ -1,0 +1,23 @@
+# Eval-fixtures (GH-55)
+
+De harness (`tools/validate_detection.py`) leest foto's uit deze map.
+
+## Foto's hierheen kopieren (niet in git)
+
+```bash
+# vanuit de repo-root, kopieer de eval-foto's uit IMAGES/ hierheen:
+cp ../IMAGES/IMG_5672.jpg ../IMAGES/IMG_6277.jpg ../IMAGES/IMG_6826.jpg \
+   ../IMAGES/IMG_5700.jpg ../IMAGES/IMG_6415.jpg ../IMAGES/IMG_7381.jpg \
+   python-service/fixtures/
+```
+
+## Labelen + draaien
+
+1. Corrigeer `LABELS-REVIEW.md` -> pas `manifest.provisional.json` aan -> hernoem naar `manifest.json`.
+2. Zet `ANTHROPIC_API_KEY` in de omgeving van de python-service.
+3. Draai in de container:
+   ```bash
+   python tools/validate_detection.py fixtures/manifest.json
+   ```
+
+De foto's zelf staan in `.gitignore` (te groot / niet nodig in git); alleen manifest + labels worden gecommit.

--- a/python-service/fixtures/manifest.provisional.json
+++ b/python-service/fixtures/manifest.provisional.json
@@ -1,0 +1,160 @@
+[
+  {
+    "photo": "fixtures/IMG_5672.jpg",
+    "target_type": "kkp_25m",
+    "expected_shot_count": 5,
+    "truth": [
+      {
+        "ring": 8
+      },
+      {
+        "ring": 8
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 6
+      }
+    ],
+    "_provisional": true,
+    "_discipline_guess_raw": "Pistool/geweer precisie op Nederlandse schietroos (zwaar hergebruikte kaart, bul"
+  },
+  {
+    "photo": "fixtures/IMG_5700.jpg",
+    "target_type": "gkg_100m",
+    "expected_shot_count": 0,
+    "truth": [],
+    "_provisional": true,
+    "_discipline_guess_raw": "Krale-schietsport precisieroos (KKG/luchtgeweer of pistool), staand formaat, zwa"
+  },
+  {
+    "photo": "fixtures/IMG_6277.jpg",
+    "target_type": "kkg_100m",
+    "expected_shot_count": 4,
+    "truth": [
+      {
+        "ring": 9
+      },
+      {
+        "ring": 8
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 6
+      }
+    ],
+    "_provisional": true,
+    "_discipline_guess_raw": "Pistool/geweer precisie op Nederlandse schietroos (zwaar hergebruikte, geplakte "
+  },
+  {
+    "photo": "fixtures/IMG_6415.jpg",
+    "target_type": "kkp_25m",
+    "expected_shot_count": 15,
+    "truth": [
+      {
+        "ring": 9
+      },
+      {
+        "ring": 9
+      },
+      {
+        "ring": 8
+      },
+      {
+        "ring": 8
+      },
+      {
+        "ring": 8
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 3
+      }
+    ],
+    "_provisional": true,
+    "_discipline_guess_raw": "Nederlandse ISSF-trainingsroos (krale.shop / \"training only\"), waarschijnlijk lu"
+  },
+  {
+    "photo": "fixtures/IMG_6826.jpg",
+    "target_type": "kkp_25m",
+    "expected_shot_count": 5,
+    "truth": [
+      {
+        "ring": 8
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 5
+      }
+    ],
+    "_provisional": true,
+    "_discipline_guess_raw": "Nederlandse ISSF-trainingsroos (klein kaliber / luchtdruk), zwaar hergebruikt en"
+  },
+  {
+    "photo": "fixtures/IMG_7381.jpg",
+    "target_type": "kkp_25m",
+    "expected_shot_count": 6,
+    "truth": [
+      {
+        "ring": 8
+      },
+      {
+        "ring": 8
+      },
+      {
+        "ring": 8
+      },
+      {
+        "ring": 7
+      },
+      {
+        "ring": 6
+      },
+      {
+        "ring": 6
+      }
+    ],
+    "_provisional": true,
+    "_discipline_guess_raw": "Pistool 25m/50m (ISSF, kop \"Pistool 25 m, 50 m\") - opgeplakte binnenroos over gr"
+  }
+]

--- a/python-service/tests/test_calibration.py
+++ b/python-service/tests/test_calibration.py
@@ -249,3 +249,19 @@ class TestCalibrateIntegration:
         result = calibrate(img, GKG_100M)
         assert result.rings_detected >= MIN_RINGS_REQUIRED
         assert result.canonical_image.shape == (CANONICAL_SIZE, CANONICAL_SIZE, 3)
+
+
+class TestDownscaleForCalibration:
+    def test_downscales_oversized_preserving_aspect(self) -> None:
+        from app.calibration.target_intrinsic import MAX_CALIBRATION_DIM, _downscale_for_calibration
+
+        big = np.zeros((4032, 3024, 3), dtype=np.uint8)  # 12MP portrait phone photo
+        out = _downscale_for_calibration(big)
+        assert max(out.shape[:2]) == MAX_CALIBRATION_DIM
+        assert out.shape[0] > out.shape[1]  # portrait aspect preserved
+
+    def test_leaves_small_image_untouched(self) -> None:
+        from app.calibration.target_intrinsic import _downscale_for_calibration
+
+        small = np.zeros((800, 600, 3), dtype=np.uint8)
+        assert _downscale_for_calibration(small).shape == (800, 600, 3)

--- a/python-service/tests/test_claude_detector.py
+++ b/python-service/tests/test_claude_detector.py
@@ -8,11 +8,22 @@ import pytest
 
 from app.config import KKP_25M
 from app.vision import claude_detector
-from app.vision.claude_detector import VisionError, _system_prompt, detect_holes
+from app.vision.claude_detector import (
+    VisionError,
+    _direct_system_prompt,
+    _prepare_for_vision,
+    _system_prompt,
+    detect_holes,
+    detect_holes_direct,
+)
 
 
 def _canonical() -> np.ndarray:
     return np.full((1000, 1000, 3), 255, np.uint8)
+
+
+def _raw_photo() -> np.ndarray:
+    return np.full((4032, 3024, 3), 200, np.uint8)
 
 
 class TestDetectHoles:
@@ -54,3 +65,64 @@ class TestSystemPrompt:
         assert "vers" in prompt             # only fresh holes
         assert "ringcijfers" in prompt      # ignore printed numbers
         assert "5 schoten" in prompt        # count guidance present
+
+
+class TestDetectHolesDirect:
+    def test_parses_normalized_and_clamps(self, monkeypatch):
+        payload = {
+            "shots": [
+                {"x_norm": 0.1, "y_norm": -0.2, "ring": 9, "confidence": 1.3, "kind": "hole"},
+                {"x_norm": 0.5, "y_norm": 0.4, "ring": 15, "confidence": 0.3, "kind": "uncertain"},
+            ],
+            "orientation_note": "kaart staat schuin",
+            "overall_confidence": 0.8,
+            "count_matches_expected": True,
+        }
+        monkeypatch.setattr(
+            claude_detector, "_call_claude",
+            lambda b64, system, api_key=None, schema=None: json.dumps(payload),
+        )
+        result = detect_holes_direct(_raw_photo(), KKP_25M, expected_shot_count=2)
+        assert len(result["shots"]) == 2
+        assert result["shots"][0]["x_norm"] == 0.1 and result["shots"][0]["y_norm"] == -0.2
+        assert result["shots"][0]["confidence"] == 1.0   # clamped
+        assert result["shots"][1]["ring"] == 10          # ring clamped to 0..10
+        assert result["overall_confidence"] == 0.8
+
+    def test_uses_direct_schema(self, monkeypatch):
+        seen: dict = {}
+        def capture(b64, system, api_key=None, schema=None):
+            seen["schema"] = schema
+            return json.dumps({"shots": [], "orientation_note": "", "overall_confidence": 0.0, "count_matches_expected": False})
+        monkeypatch.setattr(claude_detector, "_call_claude", capture)
+        detect_holes_direct(_raw_photo(), KKP_25M, expected_shot_count=None)
+        assert seen["schema"] is claude_detector._DIRECT_SHOT_SCHEMA
+
+    def test_raises_vision_error_on_bad_json(self, monkeypatch):
+        monkeypatch.setattr(
+            claude_detector, "_call_claude",
+            lambda b64, system, api_key=None, schema=None: "not json",
+        )
+        with pytest.raises(VisionError):
+            detect_holes_direct(_raw_photo(), KKP_25M, expected_shot_count=2)
+
+
+class TestPrepareForVision:
+    def test_downscales_oversized_preserving_aspect(self):
+        out = _prepare_for_vision(_raw_photo(), max_dim=1500)
+        assert max(out.shape[:2]) == 1500
+        # 4032x3024 -> longest side 4032 scaled to 1500; aspect preserved
+        assert out.shape[0] == 1500 and out.shape[1] == 1125
+
+    def test_leaves_small_image_untouched(self):
+        small = np.zeros((800, 600, 3), np.uint8)
+        assert _prepare_for_vision(small, max_dim=1500).shape == (800, 600, 3)
+
+
+class TestDirectSystemPrompt:
+    def test_asks_for_normalized_and_directly_read_ring(self):
+        prompt = _direct_system_prompt(KKP_25M, expected_shot_count=None).lower()
+        assert "onbewerkte" in prompt        # raw photo, not calibrated
+        assert "genormaliseerd" in prompt    # normalized position requested
+        assert "direct" in prompt            # read the ring directly
+        assert "plakker" in prompt           # ignore pasters

--- a/python-service/tests/test_metrics.py
+++ b/python-service/tests/test_metrics.py
@@ -1,7 +1,7 @@
 # python-service/tests/test_metrics.py
 from __future__ import annotations
 
-from app.validation.metrics import compare_turn
+from app.validation.metrics import aggregate, compare_turn
 
 
 class TestCompareTurn:
@@ -11,6 +11,8 @@ class TestCompareTurn:
         m = compare_turn(truth, pred)
         assert m["count_correct"] is True
         assert m["ring_accuracy"] == 1.0
+        assert m["ring_mae"] == 0.0
+        assert m["count_delta"] == 0
 
     def test_count_mismatch_and_partial_rings(self):
         truth = [{"ring": 10}, {"ring": 9}, {"ring": 8}]
@@ -18,9 +20,33 @@ class TestCompareTurn:
         m = compare_turn(truth, pred)
         assert m["count_correct"] is False
         assert m["ring_accuracy"] == 0.5
+        # paired (10,10) and (9,7) -> abs errors 0 and 2 -> mae 1.0
+        assert m["ring_mae"] == 1.0
+        assert m["count_delta"] == -1
+
+    def test_over_count_positive_delta(self):
+        m = compare_turn([{"ring": 10}], [{"ring": 10}, {"ring": 6}])
+        assert m["count_delta"] == 1
 
     def test_empty_prediction(self):
         truth = [{"ring": 10}]
         m = compare_turn(truth, [])
         assert m["count_correct"] is False
         assert m["ring_accuracy"] == 0.0
+        assert m["ring_mae"] is None
+
+
+class TestAggregate:
+    def test_rolls_up_headline_metrics(self):
+        results = [
+            compare_turn([{"ring": 10}, {"ring": 9}], [{"ring": 10}, {"ring": 9}]),  # perfect
+            compare_turn([{"ring": 8}], [{"ring": 8}, {"ring": 5}]),                 # over-count
+        ]
+        agg = aggregate(results)
+        assert agg["turns"] == 2
+        assert agg["count_accuracy"] == 0.5
+        assert agg["over_count_turns"] == 1
+        assert agg["under_count_turns"] == 0
+
+    def test_empty(self):
+        assert aggregate([]) == {"turns": 0}

--- a/python-service/tests/test_pipeline.py
+++ b/python-service/tests/test_pipeline.py
@@ -130,3 +130,26 @@ class TestVisionDirectFallback:
         result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=2)
         assert result.detected_count == 2                      # 0.2 dropped, 2 kept
         assert sorted(s["ring"] for s in result.shots) == [9, 10]
+
+    def test_high_rms_hints_at_wrong_discipline(self, monkeypatch):
+        # A converged-but-poor fit (RMS well above fallback) usually means the chosen
+        # discipline doesn't match the target -> the reason must say so, with the mm.
+        monkeypatch.setattr(pipeline, "calibrate", lambda img, spec: _fake_cal(rms=40.0))
+        monkeypatch.setattr(pipeline, "detect_holes_direct", _fake_direct([
+            {"x_norm": 0.0, "y_norm": 0.0, "ring": 10, "confidence": 0.7, "kind": "hole"},
+        ]))
+        result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=1)
+        assert "discipline" in result.review_reason.lower()
+        assert "40 mm" in result.review_reason
+
+    def test_calibration_failure_reason_is_not_discipline(self, monkeypatch):
+        # A hard CalibrationError is a photo problem, not a discipline mismatch.
+        def boom(img, spec):
+            raise CalibrationError("te weinig ringen", rings_detected=1)
+        monkeypatch.setattr(pipeline, "calibrate", boom)
+        monkeypatch.setattr(pipeline, "detect_holes_direct", _fake_direct([
+            {"x_norm": 0.0, "y_norm": 0.0, "ring": 10, "confidence": 0.7, "kind": "hole"},
+        ]))
+        result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=1)
+        assert "discipline" not in result.review_reason.lower()
+        assert "rechtere" in result.review_reason.lower()

--- a/python-service/tests/test_pipeline.py
+++ b/python-service/tests/test_pipeline.py
@@ -10,15 +10,27 @@ from app.pipeline import analyze_target_v2
 from app.vision.claude_detector import VisionError
 
 
-def _fake_cal() -> CalibrationResult:
+def _fake_cal(rms: float = 8.0) -> CalibrationResult:
     return CalibrationResult(
         canonical_image=np.full((1000, 1000, 3), 255, np.uint8),
         homography=np.eye(3),
-        rms_error_mm=8.0,
+        rms_error_mm=rms,
         confidence=0.18,
         rings_detected=7,
         target_spec=KKP_25M,
     )
+
+
+def _fake_direct(shots: list[dict], overall: float = 0.9):
+    """Build a detect_holes_direct stub returning the given vision-direct shots."""
+    def _impl(image, spec, n, api_key=None):
+        return {
+            "shots": shots,
+            "orientation_note": "raw",
+            "overall_confidence": overall,
+            "count_matches_expected": True,
+        }
+    return _impl
 
 
 class TestPipeline:
@@ -35,6 +47,7 @@ class TestPipeline:
         assert result.count_matches_expected is True
         assert result.needs_review is False
         assert result.review_reason == ""
+        assert result.calibration["method"] == "canonical"
 
     def test_count_mismatch_flags_review(self, monkeypatch):
         monkeypatch.setattr(pipeline, "calibrate", lambda img, spec: _fake_cal())
@@ -61,12 +74,59 @@ class TestPipeline:
         assert result.needs_review is True
         assert "Claude-key" in result.review_reason
 
-    def test_calibration_failure_returns_empty_review(self, monkeypatch):
+
+class TestVisionDirectFallback:
+    """Calibration is a hint, not a gate: a failed/weak homography falls back to the
+    vision-direct path so the turn's shots are never discarded."""
+
+    def test_calibration_failure_falls_back_to_vision_direct(self, monkeypatch):
         def boom(img, spec):
             raise CalibrationError("te weinig ringen", rings_detected=1)
         monkeypatch.setattr(pipeline, "calibrate", boom)
-        result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=5)
+        monkeypatch.setattr(pipeline, "detect_holes_direct", _fake_direct([
+            {"x_norm": 0.0, "y_norm": 0.0, "ring": 10, "confidence": 0.9, "kind": "hole"},
+            {"x_norm": 0.3, "y_norm": -0.1, "ring": 8, "confidence": 0.8, "kind": "hole"},
+        ]))
+        result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=2)
+        assert result.detected_count == 2                     # NOT empty anymore
+        assert [s["ring"] for s in result.shots] == [10, 8]   # directly-read rings
+        assert result.calibration["ok"] is False
+        assert result.calibration["method"] == "vision_direct"
+        assert result.needs_review is True
+        assert "directe ring-aflezing" in result.review_reason
+
+    def test_weak_calibration_uses_vision_direct(self, monkeypatch):
+        # RMS above the fallback threshold -> homography unreliable -> vision-direct.
+        monkeypatch.setattr(pipeline, "calibrate", lambda img, spec: _fake_cal(rms=35.0))
+        called = {"canonical": False}
+        monkeypatch.setattr(pipeline, "detect_holes", lambda *a, **k: called.__setitem__("canonical", True))
+        monkeypatch.setattr(pipeline, "detect_holes_direct", _fake_direct([
+            {"x_norm": -0.2, "y_norm": 0.2, "ring": 7, "confidence": 0.7, "kind": "hole"},
+        ]))
+        result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=1)
+        assert called["canonical"] is False                   # canonical path skipped
+        assert result.detected_count == 1
+        assert result.calibration["method"] == "vision_direct"
+        assert result.calibration["rms_error_mm"] == 35.0
+
+    def test_vision_direct_no_key_degrades_to_empty(self, monkeypatch):
+        monkeypatch.setattr(pipeline, "calibrate", lambda img, spec: _fake_cal(rms=40.0))
+        def boom(image, spec, n, api_key=None):
+            raise VisionError("no key")
+        monkeypatch.setattr(pipeline, "detect_holes_direct", boom)
+        result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=3)
         assert result.shots == []
         assert result.needs_review is True
-        assert result.calibration["ok"] is False
-        assert "Kalibratie mislukt" in result.review_reason
+        assert "Claude-key" in result.review_reason
+
+    def test_vision_direct_filters_and_caps(self, monkeypatch):
+        # One sub-confidence shot dropped; surplus over expected capped to the top-N.
+        monkeypatch.setattr(pipeline, "calibrate", lambda img, spec: _fake_cal(rms=50.0))
+        monkeypatch.setattr(pipeline, "detect_holes_direct", _fake_direct([
+            {"x_norm": 0.0, "y_norm": 0.0, "ring": 10, "confidence": 0.9, "kind": "hole"},
+            {"x_norm": 0.1, "y_norm": 0.1, "ring": 9, "confidence": 0.8, "kind": "hole"},
+            {"x_norm": 0.9, "y_norm": 0.0, "ring": 1, "confidence": 0.2, "kind": "uncertain"},
+        ]))
+        result = analyze_target_v2(np.zeros((10, 10, 3), np.uint8), KKP_25M, expected_shot_count=2)
+        assert result.detected_count == 2                      # 0.2 dropped, 2 kept
+        assert sorted(s["ring"] for s in result.shots) == [9, 10]

--- a/python-service/tests/test_scoring.py
+++ b/python-service/tests/test_scoring.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from app.config import KKG_50M, KKP_25M
-from app.scoring import ScoredShot, score_shot
+from app.scoring import ScoredShot, score_from_vision, score_shot
 
 RING1_RADIUS_PX = 475.0
 
@@ -57,3 +57,26 @@ class TestScoreShot:
         assert center.ring == 10
         edge = score_shot(_norm_to_px(0.99), 500.0, KKG_50M)
         assert edge.ring == 1
+
+
+class TestScoreFromVision:
+    def test_trusts_directly_read_ring(self):
+        # Position says near-centre, but the model read ring 8: we trust the ring.
+        s = score_from_vision(0.1, -0.05, 8)
+        assert isinstance(s, ScoredShot)
+        assert s.ring == 8
+        assert s.score == 8
+        assert s.x == 0.1 and s.y == -0.05
+
+    def test_passes_normalized_position_through(self):
+        s = score_from_vision(0.42, 0.37, 9)
+        assert s.x == 0.42 and s.y == 0.37
+        assert round(s.distance_norm, 4) == round((0.42 ** 2 + 0.37 ** 2) ** 0.5, 4)
+
+    def test_clamps_ring_out_of_range(self):
+        assert score_from_vision(0.0, 0.0, 11).ring == 10
+        assert score_from_vision(2.0, 0.0, -3).ring == 0
+
+    def test_miss_ring_zero(self):
+        s = score_from_vision(1.3, 0.0, 0)
+        assert s.ring == 0 and s.score == 0

--- a/python-service/tools/validate_detection.py
+++ b/python-service/tools/validate_detection.py
@@ -4,59 +4,80 @@ NOT part of the API surface and NOT run in CI — it makes real Claude calls.
 
 Usage (inside the python-service container, with ANTHROPIC_API_KEY set):
     python tools/validate_detection.py manifest.json
+(Run from the python-service root; the script adds that root to sys.path itself.)
 
 manifest.json format:
     [
       {
-        "photo": "/app/fixtures/kkp_25m_turn1.jpg",
+        "photo": "fixtures/kkp_25m_turn1.jpg",
         "target_type": "kkp_25m",
         "expected_shot_count": 5,
         "truth": [{"ring": 10}, {"ring": 9}, {"ring": 9}, {"ring": 8}, {"ring": 7}]
       }
     ]
 
-Prints per-photo and aggregate count-accuracy and ring-accuracy.
+Prints per-photo count/ring metrics plus the calibration method + RMS (so a
+discipline mismatch is visible), and an aggregate rollup.
 """
 from __future__ import annotations
 
 import json
+import os
 import sys
+
+# Allow `python tools/validate_detection.py` from the python-service root without
+# requiring PYTHONPATH: add that root (the script's parent's parent) to sys.path.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import cv2
 
 from app.config import TARGET_SPECS
 from app.pipeline import analyze_target_v2
-from app.validation.metrics import compare_turn
+from app.validation.metrics import aggregate, compare_turn
 
 
 def main(manifest_path: str) -> None:
     with open(manifest_path, encoding="utf-8") as fh:
         cases = json.load(fh)
 
-    total = 0
-    count_ok = 0
-    ring_acc_sum = 0.0
+    results: list[dict] = []
+    header = f"{'photo':22s} {'discipline':10s} {'det/exp':>8s} {'cnt':>4s} {'ringMAE':>8s} {'method':13s} {'rms':>5s}  review"
+    print(header)
+    print("-" * len(header))
     for case in cases:
+        name = case["photo"].split("/")[-1]
         image = cv2.imread(case["photo"])
         if image is None:
-            print(f"SKIP (cannot read): {case['photo']}")
+            print(f"{name:22s} SKIP (cannot read: {case['photo']})")
             continue
         spec = TARGET_SPECS[case["target_type"]]
         result = analyze_target_v2(image, spec, case.get("expected_shot_count"))
-        pred = [{"ring": s["ring"]} for s in result.shots]
-        m = compare_turn(case.get("truth", []), pred)
-        total += 1
-        count_ok += 1 if m["count_correct"] else 0
-        ring_acc_sum += m["ring_accuracy"]
+        m = compare_turn(case.get("truth", []), [{"ring": s["ring"]} for s in result.shots])
+        results.append(m)
+
+        exp = case.get("expected_shot_count")
+        mae = m["ring_mae"]
+        rms = result.calibration.get("rms_error_mm")
+        cnt = "OK" if m["count_correct"] else f"{m['count_delta']:+d}"
         print(
-            f"{case['photo']}: count_correct={m['count_correct']} "
-            f"ring_accuracy={m['ring_accuracy']:.2f} needs_review={result.needs_review}"
+            f"{name:22s} {case['target_type']:10s} "
+            f"{result.detected_count}/{exp if exp is not None else '?'!s:>3} "
+            f"{cnt:>4s} "
+            f"{(f'{mae:.2f}' if mae is not None else '-'):>8s} "
+            f"{result.calibration.get('method', ''):13s} "
+            f"{(f'{rms:.0f}' if rms is not None else '-'):>5s}  "
+            f"{'REVIEW' if result.needs_review else 'ok'}"
         )
 
-    if total:
+    agg = aggregate(results)
+    if agg["turns"]:
+        mae = agg["mean_ring_mae"]
         print(
-            f"\nAGGREGATE over {total}: count_accuracy={count_ok / total:.2f} "
-            f"mean_ring_accuracy={ring_acc_sum / total:.2f}"
+            f"\nAGGREGATE over {agg['turns']}: "
+            f"count_accuracy={agg['count_accuracy']:.2f}  "
+            f"mean_ring_accuracy={agg['mean_ring_accuracy']:.2f}  "
+            f"mean_ring_mae={(f'{mae:.2f}' if mae is not None else '-')}  "
+            f"over/under-count={agg['over_count_turns']}/{agg['under_count_turns']}"
         )
 
 


### PR DESCRIPTION
## Wat

Kalibratie is niet langer een **harde eis** in de foto→schoten-pipeline, en de eval-harness krijgt bruikbare metrics + een provisionele label-set.

### Fase 2a — kalibratie loskoppelen (vision-direct fallback)
Voorheen: `analyze_target_v2` gooide bij `CalibrationError` of hoge RMS de schoten van de beurt wég (`shots=[]`). Op zwaar-geplakte rozen (~30 mm RMS) was dat de terugkerende faalmodus uit #55.

Nu: kalibratie is een **niet-blokkerende hint**.
- Slaagt de homografie (RMS ≤ `AIMTRACK_CAL_RMS_FALLBACK_MM`, default 30 mm) → bestaand canonical-pad, ongewijzigd.
- Faalt of te zwak → **vision-direct pad**: `detect_holes_direct` laat het model de ring **direct van de rúwe foto** aflezen + een genormaliseerde positie geven (centrum=(0,0), ring1-rand=1.0); `score_from_vision` scoort. **Schoten gaan nooit meer verloren**; de beurt wordt `needs_review` (positie is benaderend zonder homografie).
- `calibration.method` = `canonical` | `vision_direct`. Laravel-kant ongewijzigd (zelfde 0.5-conventie).

### Fase 2b — eval-metrics + provisionele labels
- `metrics.compare_turn`: extra `count_delta` (proxy voor plakker-overtelling) en `ring_mae`; nieuwe `aggregate()`.
- `python-service/fixtures/`: provisioneel, met vision voor-ingevuld `manifest.provisional.json` + `LABELS-REVIEW.md`. **De labels moeten nog gecorrigeerd worden** (echte `target_type`/aantal/ringen) vóór de harness zinvol meet. Foto's zijn ge-gitignore'd.

## Waarom
De empirische validatie op 49 echte foto's (zie #55) toonde: vision-lokalisatie is betrouwbaar op de rúwe foto, terwijl de klassieke kalibratie de zwakke schakel is. Deze PR haalt die zwakke schakel uit het kritieke pad.

## Hoe getest
- **110 python-tests groen** (94 baseline + 16 nieuwe: vision-direct fallback, `score_from_vision`, `detect_holes_direct`, uitgebreide metrics).
- Ruff-schoon op alle gewijzigde bestanden.

> ⚠️ **Let op:** de tests draaiden in een tijdelijke venv met **nieuwere deps dan de pins** (cv2 5.0 vs 4.8, numpy 2.5 vs <2) omdat er geen Docker in de omgeving was. Draai de suite nog even in de Docker-`python-service` (gepinde versies) vóór merge. 2 ruff-meldingen in `test_reconcile.py`/`test_v2_endpoint.py` zijn **pre-existing** (buiten scope).

## Nog te doen (na merge-review)
- [ ] Labels in `fixtures/LABELS-REVIEW.md` corrigeren → `manifest.json`.
- [ ] `ANTHROPIC_API_KEY` in de python-service → `tools/validate_detection.py fixtures/manifest.json` draaien om vision-direct vs canonical écht te meten en de drempels te ijken.

Onderdeel van #55.
