### PR TITLE
feat(verenigingen): app-beheerder kan verenigingen aanmaken (#115)

### DIFF
--- a/app/Filament/Pages/VerenigingAanmaken.php
+++ b/app/Filament/Pages/VerenigingAanmaken.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\User;
+use App\Services\Vereniging\VerenigingException;
+use App\Services\Vereniging\VerenigingService;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+/**
+ * Aanmaak-pagina (BEHEER) voor verenigingen. Alleen app-beheerders
+ * (users.is_admin) mogen verenigingen provisionen en een beheerder toewijzen;
+ * die beheerder regelt daarna leden en de gedeelde key via "Mijn vereniging".
+ */
+class VerenigingAanmaken extends Page implements HasForms
+{
+    use InteractsWithForms;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-building-office-2';
+
+    protected static ?string $navigationLabel = 'Vereniging aanmaken';
+
+    protected static ?string $title = 'Vereniging aanmaken';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
+
+    protected static ?int $navigationSort = 80;
+
+    protected string $view = 'filament.pages.vereniging-aanmaken';
+
+    public ?array $data = [];
+
+    public static function canAccess(): bool
+    {
+        return (bool) (auth()->user()?->is_admin);
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return static::canAccess();
+    }
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Nieuwe vereniging')
+                    ->schema([
+                        TextInput::make('naam')
+                            ->label('Naam')
+                            ->required()
+                            ->maxLength(255),
+                        Select::make('beheerder_id')
+                            ->label('Beheerder')
+                            ->helperText('Deze gebruiker wordt admin van de vereniging en beheert de leden en de gedeelde key.')
+                            ->options(fn (): array => User::query()->orderBy('name')->pluck('name', 'id')->all())
+                            ->searchable()
+                            ->required(),
+                    ])
+                    ->columns(2),
+            ])
+            ->statePath('data');
+    }
+
+    public function aanmaken(): void
+    {
+        $state = $this->form->getState();
+
+        $beheerder = User::query()->find($state['beheerder_id'] ?? null);
+
+        if ($beheerder === null) {
+            Notification::make()->title('Kies een geldige beheerder')->warning()->send();
+
+            return;
+        }
+
+        try {
+            $vereniging = app(VerenigingService::class)->maakVereniging($state['naam'], $beheerder);
+        } catch (VerenigingException $exception) {
+            Notification::make()->title($exception->getMessage())->danger()->send();
+
+            return;
+        }
+
+        $this->form->fill();
+
+        Notification::make()
+            ->title("Vereniging '{$vereniging->naam}' aangemaakt")
+            ->body("{$beheerder->name} is als beheerder toegevoegd.")
+            ->success()
+            ->send();
+    }
+}

--- a/app/Services/Vereniging/VerenigingException.php
+++ b/app/Services/Vereniging/VerenigingException.php
@@ -25,4 +25,9 @@ class VerenigingException extends RuntimeException
     {
         return new self('De laatste beheerder kan niet verwijderd of gedegradeerd worden.');
     }
+
+    public static function naamVerplicht(): self
+    {
+        return new self('Vul een naam voor de vereniging in.');
+    }
 }

--- a/app/Services/Vereniging/VerenigingService.php
+++ b/app/Services/Vereniging/VerenigingService.php
@@ -6,9 +6,38 @@ use App\Enums\VerenigingRol;
 use App\Models\User;
 use App\Models\Vereniging;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 
 class VerenigingService
 {
+    /**
+     * Maak een nieuwe vereniging aan met $beheerder als admin. De maker wordt
+     * meteen als actieve vereniging gekoppeld en de slug wordt uniek gemaakt.
+     */
+    public function maakVereniging(string $naam, User $beheerder): Vereniging
+    {
+        $naam = trim($naam);
+
+        if ($naam === '') {
+            throw VerenigingException::naamVerplicht();
+        }
+
+        $vereniging = Vereniging::query()->create([
+            'naam' => $naam,
+            'slug' => $this->uniekeSlug($naam),
+            'created_by' => $beheerder->id,
+        ]);
+
+        $vereniging->members()->attach($beheerder, [
+            'role' => VerenigingRol::Admin->value,
+            'joined_at' => now(),
+        ]);
+
+        $beheerder->switchVereniging($vereniging);
+
+        return $vereniging;
+    }
+
     /**
      * Koppel een bestaande gebruiker (op e-mailadres) als lid aan de vereniging.
      * v1: alleen bestaande accounts; onbekende e-mails geven een nette fout.
@@ -125,6 +154,20 @@ class VerenigingService
         }
 
         return false;
+    }
+
+    private function uniekeSlug(string $naam): string
+    {
+        $basis = Str::slug($naam) ?: 'vereniging';
+        $slug = $basis;
+        $volgnummer = 2;
+
+        while (Vereniging::query()->where('slug', $slug)->exists()) {
+            $slug = "{$basis}-{$volgnummer}";
+            $volgnummer++;
+        }
+
+        return $slug;
     }
 
     private function rolVan(Vereniging $vereniging, User $user): ?VerenigingRol

--- a/resources/views/filament/pages/vereniging-aanmaken.blade.php
+++ b/resources/views/filament/pages/vereniging-aanmaken.blade.php
@@ -1,0 +1,18 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <p class="text-sm text-gray-600">
+            Maak een nieuwe vereniging aan en wijs een beheerder toe. De beheerder kan daarna
+            leden toevoegen en de gedeelde Claude-key instellen via "Mijn vereniging".
+        </p>
+
+        <div class="space-y-4">
+            {{ $this->form }}
+
+            <div class="flex justify-end">
+                <x-filament::button wire:click="aanmaken" icon="heroicon-m-plus">
+                    Vereniging aanmaken
+                </x-filament::button>
+            </div>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/tests/Feature/Verenigingen/VerenigingAanmakenPageTest.php
+++ b/tests/Feature/Verenigingen/VerenigingAanmakenPageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Enums\VerenigingRol;
+use App\Filament\Pages\VerenigingAanmaken;
+use App\Models\User;
+use App\Models\Vereniging;
+use Livewire\Livewire;
+
+it('is niet toegankelijk voor een niet-admin', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => false]));
+
+    expect(VerenigingAanmaken::canAccess())->toBeFalse();
+});
+
+it('is toegankelijk voor een app-beheerder', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => true]));
+
+    expect(VerenigingAanmaken::canAccess())->toBeTrue();
+});
+
+it('maakt een vereniging aan en wijst de gekozen beheerder toe', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => true]));
+    $beheerder = User::factory()->create();
+
+    Livewire::test(VerenigingAanmaken::class)
+        ->fillForm([
+            'naam' => 'Nieuwe Club',
+            'beheerder_id' => $beheerder->id,
+        ])
+        ->call('aanmaken')
+        ->assertNotified();
+
+    $vereniging = Vereniging::query()->where('naam', 'Nieuwe Club')->first();
+
+    expect($vereniging)->not->toBeNull()
+        ->and($beheerder->fresh()->active_vereniging_id)->toBe($vereniging->id)
+        ->and($beheerder->fresh()->rolInVereniging($vereniging))->toBe(VerenigingRol::Admin);
+});
+
+it('valideert dat naam en beheerder verplicht zijn', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => true]));
+
+    Livewire::test(VerenigingAanmaken::class)
+        ->fillForm(['naam' => null, 'beheerder_id' => null])
+        ->call('aanmaken')
+        ->assertHasFormErrors(['naam', 'beheerder_id']);
+
+    expect(Vereniging::query()->count())->toBe(0);
+});

--- a/tests/Feature/Verenigingen/VerenigingServiceTest.php
+++ b/tests/Feature/Verenigingen/VerenigingServiceTest.php
@@ -11,6 +11,31 @@ beforeEach(function (): void {
     $this->service = app(VerenigingService::class);
 });
 
+it('maakt een vereniging aan en zet de maker als actieve admin', function (): void {
+    $beheerder = User::factory()->create();
+
+    $vereniging = $this->service->maakVereniging('Test Club', $beheerder);
+
+    expect($vereniging->naam)->toBe('Test Club')
+        ->and($vereniging->slug)->toBe('test-club')
+        ->and($vereniging->created_by)->toBe($beheerder->id)
+        ->and($beheerder->fresh()->active_vereniging_id)->toBe($vereniging->id)
+        ->and($beheerder->fresh()->rolInVereniging($vereniging))->toBe(VerenigingRol::Admin);
+});
+
+it('genereert een unieke slug bij dezelfde verenigingsnaam', function (): void {
+    $a = $this->service->maakVereniging('Zelfde Naam', User::factory()->create());
+    $b = $this->service->maakVereniging('Zelfde Naam', User::factory()->create());
+
+    expect($a->slug)->toBe('zelfde-naam')
+        ->and($b->slug)->toBe('zelfde-naam-2');
+});
+
+it('weigert een lege verenigingsnaam', function (): void {
+    expect(fn () => $this->service->maakVereniging('   ', User::factory()->create()))
+        ->toThrow(VerenigingException::class);
+});
+
 it('voegt een bestaand lid toe op e-mailadres met een rol', function (): void {
     $vereniging = Vereniging::factory()->create();
     $user = User::factory()->create(['email' => 'lid@example.test']);


### PR DESCRIPTION
## Wat
Voegt een aanmaak-flow voor verenigingen toe, alleen zichtbaar voor **app-beheerders** (`users.is_admin`).

## Waarom
De v1 uit #106 leverde ledenbeheer + key-beheer *binnen* een bestaande vereniging, maar geen manier om er één aan te **maken**. Gevolg: op een verse omgeving (o.a. productie) is er geen vereniging, dus niemand heeft een actieve vereniging, dus de `VerenigingBeheer`-tab is by-design onzichtbaar — en er was geen weg om die eerste vereniging te bootstrappen behalve handmatig via tinker op de server. Deze PR maakt de feature zelfstandig bruikbaar.

Aanmaakmodel: **alleen app-beheerder** (bewuste keuze — controle bij de eigenaar, geen self-service wildgroei).

## Hoe
- `VerenigingService::maakVereniging(string $naam, User $beheerder): Vereniging` — maakt de vereniging met een **unieke slug**, koppelt de gekozen beheerder als `admin` (via de pivot) en zet die vereniging actief via `User::switchVereniging()` (de gehardde, niet-mass-assignable setter uit #106).
- `VerenigingException::naamVerplicht()` voor een lege naam.
- Filament-pagina **`VerenigingAanmaken`** (navigatiegroep BEHEER), afgeschermd met `canAccess() → is_admin` — spiegelt het patroon van `FailedJobsPage`. Form: naam + beheerder-select (zoekbaar).

## Getest (Pest)
- **Service**: aanmaak zet maker als actieve admin; unieke slug bij dezelfde naam (`zelfde-naam` → `zelfde-naam-2`); lege naam wordt geweigerd.
- **Pagina**: niet-admin heeft geen toegang, app-beheerder wel; aanmaak wijst de beheerder toe; naam + beheerder zijn verplicht.
- Volledige verenigingen-suite groen (45 tests / 89 assertions), Pint groen.

## Scope
Dit is het aanmaak-deel van #115. De **vereniging-switcher** (wisselen tussen meerdere actieve verenigingen) blijft in #115 open als vervolg.

Refs #115, #95.