### PR TITLE
feat(gebruikers): gebruikersbeheer + eerste user automatisch admin

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\UserResource\Pages\ListUsers;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * Gebruikersbeheer (BEHEER), uitsluitend voor app-beheerders (users.is_admin).
+ * Lijst van gebruikers met de mogelijkheid om beheerderrechten toe te kennen of
+ * in te trekken. De laatste beheerder kan zichzelf/anderen niet degraderen.
+ */
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-users';
+
+    protected static ?string $navigationLabel = 'Gebruikers';
+
+    protected static ?string $modelLabel = 'Gebruiker';
+
+    protected static ?string $pluralModelLabel = 'Gebruikers';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'BEHEER';
+
+    protected static ?int $navigationSort = 70;
+
+    public static function canViewAny(): bool
+    {
+        return (bool) (auth()->user()?->is_admin);
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return (bool) (auth()->user()?->is_admin);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Naam')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->label('E-mail')
+                    ->searchable()
+                    ->sortable(),
+                IconColumn::make('is_admin')
+                    ->label('Beheerder')
+                    ->boolean()
+                    ->sortable(),
+                TextColumn::make('created_at')
+                    ->label('Geregistreerd')
+                    ->dateTime('d-m-Y')
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->recordActions([
+                Action::make('toggleAdmin')
+                    ->label(fn (User $record): string => $record->is_admin ? 'Beheerder intrekken' : 'Maak beheerder')
+                    ->icon(fn (User $record): string => $record->is_admin ? 'heroicon-m-shield-exclamation' : 'heroicon-m-shield-check')
+                    ->color(fn (User $record): string => $record->is_admin ? 'danger' : 'primary')
+                    ->requiresConfirmation()
+                    ->action(function (User $record): void {
+                        if ($record->is_admin && User::query()->where('is_admin', true)->count() <= 1) {
+                            Notification::make()
+                                ->title('Er moet minstens één beheerder blijven.')
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
+
+                        $record->update(['is_admin' => ! $record->is_admin]);
+
+                        Notification::make()
+                            ->title($record->is_admin ? 'Gebruiker is nu beheerder.' : 'Beheerderrechten ingetrokken.')
+                            ->success()
+                            ->send();
+                    }),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUsers::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Listeners/PromoteFirstUserToAdmin.php
+++ b/app/Listeners/PromoteFirstUserToAdmin.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+
+/**
+ * Maakt uitsluitend de allereerste geregistreerde gebruiker automatisch
+ * app-beheerder (users.is_admin). Zo heeft een self-hosted install (Docker e.d.)
+ * meteen een beheerder, zonder dat elke latere registratie admin-rechten krijgt.
+ *
+ * Bewust gekoppeld aan het Registered-event (echte registratie), niet aan een
+ * model-event: seeders/factories mogen geen users promoveren.
+ */
+class PromoteFirstUserToAdmin
+{
+    public function handle(Registered $event): void
+    {
+        $user = $event->user;
+
+        if (! $user instanceof User) {
+            return;
+        }
+
+        if ($user->is_admin) {
+            return;
+        }
+
+        if (User::query()->count() === 1) {
+            $user->forceFill(['is_admin' => true])->save();
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,12 +2,16 @@
 
 namespace App\Providers;
 
+use App\Listeners\PromoteFirstUserToAdmin;
+use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
 {
     protected $listen = [
-        //
+        Registered::class => [
+            PromoteFirstUserToAdmin::class,
+        ],
     ];
 
     public function boot(): void

--- a/tests/Feature/Users/FirstUserBecomesAdminTest.php
+++ b/tests/Feature/Users/FirstUserBecomesAdminTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Events\Registered;
+
+it('maakt de eerste geregistreerde gebruiker automatisch app-beheerder', function (): void {
+    $eerste = User::factory()->create(['is_admin' => false]);
+
+    event(new Registered($eerste));
+
+    expect($eerste->fresh()->is_admin)->toBeTrue();
+});
+
+it('maakt een latere geregistreerde gebruiker geen beheerder', function (): void {
+    User::factory()->create();
+    $tweede = User::factory()->create(['is_admin' => false]);
+
+    event(new Registered($tweede));
+
+    expect($tweede->fresh()->is_admin)->toBeFalse();
+});
+
+it('promoveert de eerste gebruiker niet nogmaals als die al beheerder is', function (): void {
+    $eerste = User::factory()->create(['is_admin' => true]);
+
+    event(new Registered($eerste));
+
+    expect($eerste->fresh()->is_admin)->toBeTrue()
+        ->and(User::query()->where('is_admin', true)->count())->toBe(1);
+});

--- a/tests/Feature/Users/UserResourceTest.php
+++ b/tests/Feature/Users/UserResourceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Filament\Resources\UserResource;
+use App\Filament\Resources\UserResource\Pages\ListUsers;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Livewire\Livewire;
+
+it('is niet zichtbaar voor een niet-admin', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => false]));
+
+    expect(UserResource::canViewAny())->toBeFalse()
+        ->and(UserResource::shouldRegisterNavigation())->toBeFalse();
+});
+
+it('is zichtbaar voor een app-beheerder', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => true]));
+
+    expect(UserResource::canViewAny())->toBeTrue();
+});
+
+it('promoveert een gebruiker tot beheerder via de actie', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => true]));
+    $doel = User::factory()->create(['is_admin' => false]);
+
+    Livewire::test(ListUsers::class)
+        ->callAction(TestAction::make('toggleAdmin')->table($doel))
+        ->assertNotified();
+
+    expect($doel->fresh()->is_admin)->toBeTrue();
+});
+
+it('trekt beheerderrechten in zolang er nog een andere beheerder is', function (): void {
+    $this->actingAs(User::factory()->create(['is_admin' => true]));
+    $andere = User::factory()->create(['is_admin' => true]);
+
+    Livewire::test(ListUsers::class)
+        ->callAction(TestAction::make('toggleAdmin')->table($andere));
+
+    expect($andere->fresh()->is_admin)->toBeFalse();
+});
+
+it('weigert het intrekken van de laatste beheerder', function (): void {
+    $enige = User::factory()->create(['is_admin' => true]);
+    $this->actingAs($enige);
+
+    Livewire::test(ListUsers::class)
+        ->callAction(TestAction::make('toggleAdmin')->table($enige));
+
+    expect($enige->fresh()->is_admin)->toBeTrue();
+});


### PR DESCRIPTION
## Wat
Voegt gebruikersbeheer toe (admin-only) én een bootstrap zodat een verse (self-hosted) install meteen een beheerder heeft.

## Waarom
Om de BEHEER-schermen (o.a. `VerenigingAanmaken` uit #116) te gebruiken moet je `is_admin` zijn — maar er was geen UI om dat te wórden, en geen manier om de eerste beheerder te krijgen behalve handmatig via tinker/seeder. Deze PR sluit dat gat aan beide kanten.

## Hoe
**1. Eerste user = admin (bootstrap)**
- `PromoteFirstUserToAdmin` luistert op `Illuminate\\Auth\\Events\\Registered` en promoveert **alleen de allereerste** geregistreerde gebruiker tot `is_admin`. Latere registraties niet.
- Bewust op het **registratie-event** (Filament-registratie staat aan) i.p.v. een model-event, zodat seeders/factories niemand per ongeluk admin maken. `DatabaseSeeder` is leeg, dus op een self-hosted `migrate --seed` wordt de eerste échte registrant de beheerder.

**2. Gebruikersbeheer (`UserResource`, BEHEER)**
- Afgeschermd met `canViewAny()/shouldRegisterNavigation() → is_admin`.
- Lijst (naam, e-mail, beheerder-icoon, registratiedatum) + actie **"Maak beheerder" / "Beheerder intrekken"** met bevestiging.
- **Guard**: de laatste beheerder kan niet worden gedegradeerd ("er moet minstens één beheerder blijven").
- Geen create/edit/delete in v1 (users registreren zelf; wachtwoord-reset/impersonation bewust buiten scope).

## Getest (Pest)
- Bootstrap: eerste user wordt admin; latere niet; geen dubbele promotie.
- Resource: onzichtbaar voor niet-admins, zichtbaar voor admins; promoveren via de actie; intrekken zolang er een andere admin is; laatste-admin-guard blokkeert.
- 8 tests groen, Pint groen.

## Let op (deploy)
Zoals eerder besproken: dit wordt pas zichtbaar in prod zodra de `deploy-production.yml` de container daadwerkelijk vervangt.