### PR TITLE
fix(storage): productie-503 op /health — storage/app/private bij boot aanmaken

### DIFF
--- a/.ai/guidelines/parallel-worktrees.md
+++ b/.ai/guidelines/parallel-worktrees.md
@@ -87,18 +87,22 @@ Vergeet de registry hieronder niet bij te werken.
 
 ## Registry van actieve worktrees
 
+Alleen worktrees die op dit moment daadwerkelijk bestaan (`git worktree list`). Afgeronde
+worktrees horen hier niet meer in — zie *Cleanup* hierboven.
+
 | Feature | Branch | Pad | Web | DB | Mailpit | Python | Status |
 |---|---|---|---|---|---|---|---|
-| _hoofd-dev_ | _huidige_ | `aimtrack/` | 8080 | 5432 | 8025 | 8000 | actief |
-| copilot | feature/copilot | `aimtrack-copilot/` | 19080 | 15433 | 19025 | 19000 | actief (Filament Copilot migratie) |
-| design-foundation | feature/design-foundation | `aimtrack-design-foundation/` | 19084 | 15436 | 19029 | 19004 | actief (issue #82 · Fase 0 foundation) |
-| prod-backups | feature/prod-backups | `aimtrack-prod-backups/` | 19085 | 15437 | 19030 | 19005 | actief (issue #83 — prod backup-strategie in repo) |
-| empty-states | feature/empty-states | `aimtrack-empty-states/` | 19086 | 15438 | 19031 | 19006 | actief (issue #82 · Fase 2 empty-states) |
-| range-console | feature/range-console | `aimtrack-range-console/` | 19087 | 15439 | 19032 | 19007 | actief (issue #82 · Fase 1 Range Console — 5 kernschermen) |
-| marketing | feature/marketing | `aimtrack-marketing/` | 19088 | 15440 | 19033 | 19008 | actief (issue #82 · Fase 3 marketing landing) |
-| ai-byo-key | feature/ai-byo-key | `aimtrack-ai-byo-key/` | 19089 | 15441 | 19034 | 19009 | actief (issue #95 · Fase 1 BYO Claude-key per user) |
+| _hoofd-dev_ | main | `AimTrack/` | 8080 | 5432 | 8025 | 8000 | actief (alleen main-sync) |
+| 106-visual | feature/ai-verenigingen | `aimtrack-106-visual/` | 19091 | 15441 | 19036 | — | actief (issue #95 fase 2 · visuele controle) |
+| 55-vision-direct | feature/55-vision-direct | `aimtrack-55-vision-direct/` | 19082 | 15434 | 19027 | 19002 | actief (issue #55 · PR #114) |
+| prod-storage | feature/prod-storage | `aimtrack-prod-storage/` | 19090 | 15442 | 19035 | 19010 | actief (productie-503 `storage_unwritable`) |
 
 Update deze tabel bij setup en cleanup — zo weet iedereen direct welke poort bij welke stack hoort.
+
+**Poort-hoogtewatermerk**: `worktree-setup.sh` leidt de default-offset af uit het *aantal*
+bestaande worktrees, dus na een cleanup worden poorten hergebruikt terwijl een oudere stack
+ze nog bezet houdt. Geef daarom een expliciete offset mee die hoger ligt dan alles in deze
+tabel, of gebruik de high-water-mark-variant uit PR #118.
 
 ## Cross-machine borging
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,7 +24,16 @@ if [ -d /opt/aimtrack ]; then
     } 9>/var/www/html/.app-sync.lock
 fi
 
-mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views bootstrap/cache
+# storage/app/private is de root van de default filesystem-disk (FILESYSTEM_DISK=local)
+# en storage/app/public die van de publieke disk. Beide staan niet in git — storage/
+# bevat alleen .gitignore-bestanden — dus ze ontbreken in het image en daarmee in een
+# vers app_storage-volume. Laravel maakt ze bij de eerste write zelf aan, maar alléén
+# als de parent voor www-data schrijfbaar is. Door ze hier expliciet aan te maken vallen
+# ze onder de chown/chmod hieronder en faalt een niet-schrijfbaar volume hard bij boot,
+# in plaats van stil bij de eerste upload (dat gaf prod een 503 met storage_unwritable).
+mkdir -p storage/app/private storage/app/public \
+    storage/framework/cache storage/framework/sessions storage/framework/views \
+    bootstrap/cache
 chown -R www-data:www-data storage bootstrap/cache
 chmod -R 775 storage bootstrap/cache
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,12 @@
 <?php
 
+use App\Http\Controllers\HealthController;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/health', fn () => ['status' => 'ok']);
+/*
+ * Deze route gaf voorheen een vaste ['status' => 'ok'] terug, ongeacht de echte
+ * staat van de applicatie. Monitoring die op /api/health stond in plaats van op
+ * /health kreeg daardoor altijd een 200, ook toen productie op 503 stond met
+ * storage_unwritable. Beide paden delen nu dezelfde controller.
+ */
+Route::get('/health', HealthController::class)->name('api.health');

--- a/tests/Feature/HealthEndpointTest.php
+++ b/tests/Feature/HealthEndpointTest.php
@@ -57,6 +57,27 @@ test('health endpoint degrades to 503 when the database is unreachable', functio
         ->assertJsonPath('checks.database.error', 'database_unreachable');
 });
 
+test('api health route reports the real state instead of a fixed ok', function () {
+    Storage::shouldReceive('disk')
+        ->andThrow(new RuntimeException('Unable to create directory at storage/app/private'));
+
+    $this->getJson(route('api.health'))
+        ->assertServiceUnavailable()
+        ->assertJsonPath('status', 'degraded')
+        ->assertJsonPath('checks.storage.error', 'storage_unwritable');
+});
+
+test('api health route and web health route share one controller', function () {
+    Storage::fake(config('filesystems.default'));
+
+    $api = $this->getJson(route('api.health'));
+    $web = $this->getJson(route('health'));
+
+    $api->assertOk();
+    $web->assertOk();
+    expect($api->json('checks'))->toEqual($web->json('checks'));
+});
+
 test('health endpoint does not leak exception details', function () {
     Storage::shouldReceive('disk')
         ->andThrow(new RuntimeException('/var/www/html/storage/app/private is owned by root'));

--- a/tests/Feature/HealthEndpointTest.php
+++ b/tests/Feature/HealthEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+test('health endpoint reports ok when database, queue and storage all work', function () {
+    Storage::fake(config('filesystems.default'));
+
+    $response = $this->getJson(route('health'));
+
+    $response->assertOk()
+        ->assertJsonPath('status', 'ok')
+        ->assertJsonPath('checks.database.status', 'ok')
+        ->assertJsonPath('checks.queue.status', 'ok')
+        ->assertJsonPath('checks.storage.status', 'ok');
+});
+
+test('health endpoint reports the default disk it probed', function () {
+    Storage::fake(config('filesystems.default'));
+
+    $this->getJson(route('health'))
+        ->assertJsonPath('checks.storage.disk', config('filesystems.default'));
+});
+
+test('health endpoint leaves no probe file behind', function () {
+    $disk = config('filesystems.default');
+    Storage::fake($disk);
+
+    $this->getJson(route('health'))->assertOk();
+
+    Storage::disk($disk)->assertMissing('healthchecks/storage-check.txt');
+});
+
+test('health endpoint degrades to 503 when the storage disk is not writable', function () {
+    Storage::shouldReceive('disk')
+        ->andThrow(new RuntimeException('Unable to create directory at storage/app/private'));
+
+    $response = $this->getJson(route('health'));
+
+    $response->assertServiceUnavailable()
+        ->assertJsonPath('status', 'degraded')
+        ->assertJsonPath('checks.storage.status', 'failed')
+        ->assertJsonPath('checks.storage.error', 'storage_unwritable')
+        ->assertJsonPath('checks.database.status', 'ok');
+});
+
+test('health endpoint degrades to 503 when the database is unreachable', function () {
+    Storage::fake(config('filesystems.default'));
+
+    DB::shouldReceive('connection')
+        ->andThrow(new RuntimeException('could not connect to server'));
+
+    $this->getJson(route('health'))
+        ->assertServiceUnavailable()
+        ->assertJsonPath('status', 'degraded')
+        ->assertJsonPath('checks.database.status', 'failed')
+        ->assertJsonPath('checks.database.error', 'database_unreachable');
+});
+
+test('health endpoint does not leak exception details', function () {
+    Storage::shouldReceive('disk')
+        ->andThrow(new RuntimeException('/var/www/html/storage/app/private is owned by root'));
+
+    $response = $this->getJson(route('health'));
+
+    $response->assertServiceUnavailable();
+    expect($response->getContent())
+        ->not->toContain('owned by root')
+        ->not->toContain('/var/www/html');
+});


### PR DESCRIPTION
## Wat

`https://aimtrack.nl/health` gaf **503** met `storage_unwritable` (database en queue `ok`).
Omdat `storage/app/private` de root van de default disk is (`FILESYSTEM_DISK=local`,
`config/filesystems.php:16,35`), was daarmee ook de bijlage-upload in
`app/Filament/Resources/SessionResource.php` stuk voor gebruikers.

**De storing zelf is inmiddels operationeel verholpen** — zie de runbook-notitie in #120.
Deze PR maakt het gedrag testbaar en voorkomt herhaling.

## De oorzaak, gemeten

Nagebouwd in een lokale `compose.prod.yml`-stack met een verse `app_storage`-volume:

| Situatie | Uitkomst |
|---|---|
| Schone deploy van `main` | **HTTP 200** `{"status":"ok"}` |
| `storage/app` op prod's echte eigendom `1004:1003` mode `2775` | **HTTP 503** — byte-voor-byte dezelfde JSON als prod |
| Groep naar `33` (de gid die de container kent) | **HTTP 200**, en uid 1004 kan nog steeds schrijven |

**De code was dus niet stuk.** Op de host zit `www-data` in groep `webapps` (1003), maar
**binnen de container bestaat gid 1003 niet** — groepslidmaatschap komt uit de `/etc/group`
van de container. De php-fpm worker (`www-data`, uid 33) viel op `other` = `r-x` en kon
`storage/app/private` niet aanmaken.

## Hoe

- **`docker/entrypoint.sh`** — `storage/app/private` en `storage/app/public` expliciet in de
  `mkdir`, zodat ze onder de bestaande `chown`/`chmod` vallen. Een niet-schrijfbaar volume
  faalt daarmee hard bij boot in plaats van stil bij de eerste upload.
- **`routes/api.php`** — gaf een vaste `['status' => 'ok']` terug, ongeacht de werkelijkheid.
  Monitoring die daarop stond kreeg altijd een 200, ook tijdens de storing. Wijst nu naar
  dezelfde `HealthController`. Live aangetoond met kapotte storage:

  ```
  voor:  /health -> 503 degraded  |  /api/health -> 200 {"status":"ok"}
  na:    /health -> 503 degraded  |  /api/health -> 503 degraded
  ```

- **`tests/Feature/HealthEndpointTest.php`** — `HealthController` had geen enkele test. Nu 8:
  happy path, gerapporteerde disk-naam, probe-bestand wordt opgeruimd, degradatie naar 503
  bij onschrijfbare storage én bij onbereikbare database, geen lekkende exception-details,
  `/api/health` degradeert aantoonbaar mee, en de payload van beide routes is identiek zodat
  ze niet stil uiteen kunnen lopen.
- **`.ai/guidelines/parallel-worktrees.md`** — registry noemde 7 opgeruimde worktrees
  "actief"; teruggebracht naar de werkelijkheid, met een waarschuwing over het
  poort-hoogtewatermerk dat #118 fixt.

## Getest

- Lab-bewijs end-to-end: kapotte toestand → `503`; na deze wijziging + container recreëren
  → `storage/app/private` bestaat, `www-data`-owned, `775` → **`200`**, en
  `scripts/healthcheck.sh` slaagt.
- **471 tests groen** (1298 assertions) — was 463/1272, precies deze 8 erbij.
- `vendor/bin/pint` schoon.

## ⚠️ Deze PR bereikt de draaiende productie niet

Productie draait **niet** via `docker/compose.prod.yml` (waar `ci.yml:327` naartoe
deployt), maar via de root **`docker-compose.yml`** met `target: dev`. Het `dev`-target in
de `Dockerfile` (r. 60-63) heeft **geen `ENTRYPOINT`** — `COPY docker/entrypoint.sh` en
`ENTRYPOINT` staan pas in `production` (r. 83-89). `docker/entrypoint.sh` draait daar dus
nooit.

De wijziging in `routes/api.php` en de tests werken wél overal; alleen de
entrypoint-harding raakt de huidige productie niet. Die structurele vraag — welk
compose-bestand productie hóórt te draaien — staat in **#120**. De mailconfiguratie die in
hetzelfde compose-bestand naar Mailpit wijst, staat in **#121**.
