### PR TITLE
harden(sessie): Secure-vlag op de sessiecookie voorschrijven

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
+# Zonder deze vlag laat Laravel de Secure-attribuut op de sessiecookie weg, en gaat
+# de cookie ook over onversleuteld HTTP mee. Zet in productie altijd op true.
+SESSION_SECURE_COOKIE=true
 
 MAIL_MAILER=smtp
 MAIL_HOST=127.0.0.1

--- a/docs/PROD_HARDENING.md
+++ b/docs/PROD_HARDENING.md
@@ -16,7 +16,16 @@ Gebruik deze checklist voor productie-uitrol van AimTrack.
 ## Veiligheid & netwerk
 - [ ] TLS beëindigd op load balancer/reverse proxy; `X-Forwarded-*` headers doorgeven en proxies vertrouwd.
 - [ ] `AppServiceProvider` forceert HTTPS in productie; 4xx/5xx logging naar centraal logkanaal.
+- [ ] `SESSION_SECURE_COOKIE=true` in de productie-`.env`. Zonder deze vlag laat Laravel
+      `Secure` weg en gaat de sessiecookie ook over onversleuteld HTTP mee — relevant zodra de
+      origin naast de TLS-proxy óók direct bereikbaar is.
+- [ ] Geen enkele poort van de app-stack rechtstreeks bereikbaar naast de TLS-proxy. Controleer
+      met `docker ps` welke poorten op `0.0.0.0` publiceren en toets ze van buiten het netwerk;
+      alleen 80/443 (op de proxy) horen open te staan. Bind interne poorten aan de
+      docker-gateway of een LAN-adres, niet aan `0.0.0.0`.
 - [ ] Storage permissies gecontroleerd (`storage/`, `bootstrap/cache/` schrijfbaar door web user, geen world-writes).
+      Let op: een host-groep waar `www-data` op de host wel in zit, bestaat níet automatisch
+      binnen de container — groepslidmaatschap komt uit de `/etc/group` van de container.
 - [ ] Uploads op juiste disk (bij voorkeur S3/secure bucket) of lokale opslag afgeschermd via webserver.
 
 ## AI & externe diensten

--- a/tests/Feature/SessionCookieSecurityTest.php
+++ b/tests/Feature/SessionCookieSecurityTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+
+/**
+ * phpunit.xml zet SESSION_DRIVER=array, en bij die driver voegt StartSession
+ * geen sessiecookie aan de response toe. Voor deze tests is dus een persistente
+ * driver nodig; 'cookie' vraagt geen database of schrijfbare map.
+ */
+beforeEach(fn () => config()->set('session.driver', 'cookie'));
+
+function sessionCookie(TestResponse $response): ?Cookie
+{
+    return collect($response->headers->getCookies())
+        ->first(fn (Cookie $cookie): bool => $cookie->getName() === config('session.cookie'));
+}
+
+test('sessiecookie krijgt het Secure-attribuut wanneer SESSION_SECURE_COOKIE aanstaat', function () {
+    config()->set('session.secure', true);
+
+    $cookie = sessionCookie($this->get('/'));
+
+    expect($cookie)->not->toBeNull()
+        ->and($cookie->isSecure())->toBeTrue()
+        ->and($cookie->isHttpOnly())->toBeTrue();
+});
+
+test('sessiecookie mist Secure wanneer de vlag uit staat', function () {
+    config()->set('session.secure', false);
+
+    $cookie = sessionCookie($this->get('/'));
+
+    expect($cookie)->not->toBeNull()
+        ->and($cookie->isSecure())->toBeFalse();
+});
+
+test('env-voorbeeld schrijft een secure sessiecookie voor', function () {
+    expect(file_get_contents(base_path('.env.example')))
+        ->toContain('SESSION_SECURE_COOKIE=true');
+});
+
+test('session-config leest de secure-vlag uit de omgeving', function () {
+    expect(file_get_contents(config_path('session.php')))
+        ->toContain("env('SESSION_SECURE_COOKIE')");
+});
+
+test('hardening-checklist eist de secure cookie en dichte poorten', function () {
+    $checklist = file_get_contents(base_path('docs/PROD_HARDENING.md'));
+
+    expect($checklist)
+        ->toContain('SESSION_SECURE_COOKIE=true')
+        ->toContain('rechtstreeks bereikbaar naast de TLS-proxy');
+});


### PR DESCRIPTION
## Wat

`config/session.php:172` leest `env('SESSION_SECURE_COOKIE')`, maar die variabele stond
**nergens** gezet — niet in `.env.example`, niet in `docker-compose.yml`, niet in
`docker/compose.prod.yml`. Daardoor blijft `session.secure` `null` en laat Laravel het
`Secure`-attribuut van de sessiecookie weg. De cookie gaat dan ook over onversleuteld HTTP
mee.

## Waarom dit niet theoretisch is

De origin-nginx uit `docker-compose.yml` publiceert op `0.0.0.0:18080` en is naast de
TLS-proxy óók direct bereikbaar. Over die weg kwam de sessiecookie terug als:

```
Set-Cookie: aimtrack-session=…; expires=…; path=/; httponly; samesite=lax
```

Geen `secure`. `APP_FORCE_HTTPS=true` helpt hier niet: dat beïnvloedt gegenereerde URL's,
niet het cookie-attribuut, en de plain-HTTP-request kreeg een `200` zonder redirect.

## Hoe

- **`.env.example`** — `SESSION_SECURE_COOKIE=true` toegevoegd, met uitleg waarom.
- **`docs/PROD_HARDENING.md`** — drie aanvullingen in *Veiligheid & netwerk*:
  - de cookie-vlag als expliciet checklist-punt;
  - dat geen poort van de app-stack naast de TLS-proxy bereikbaar mag zijn, te toetsen
    **van buiten het netwerk** en niet alleen met `docker ps`;
  - bij de bestaande storage-regel de valkuil dat een host-groep waar `www-data` op de host
    wel in zit, níet automatisch binnen de container bestaat — groepslidmaatschap komt uit de
    `/etc/group` van de container.
- **`tests/Feature/SessionCookieSecurityTest.php`** — 5 tests: `Secure` en `HttpOnly` worden
  aantoonbaar gezet met de vlag aan en gemist met de vlag uit, en `.env.example`,
  `config/session.php` en de checklist worden op inhoud getoetst zodat de afspraak niet stil
  wegzakt.

## Getest

- **468 tests groen** (1281 assertions) — was 463/1272, precies deze 5 erbij.
- `vendor/bin/pint` schoon.

## Voor de reviewer

`phpunit.xml:28` zet `SESSION_DRIVER=array`, en bij die driver voegt `StartSession` geen
sessiecookie aan de response toe (`sessionIsPersistent()` sluit `array` uit). Daarom
schakelt een `beforeEach` naar de `cookie`-driver — die vraagt geen database of schrijfbare
map.

## Nog te doen buiten deze PR

`SESSION_SECURE_COOKIE=true` moet ook in de **productie-`.env` op de host** landen; deze PR
zet alleen het voorbeeld en de afspraak vast. En de bereikbaarheid van poort 18080 zelf is
een aparte wijziging in `docker-compose.yml`.
