### PR TITLE
feat(copilot): AI-Coach-identiteit via system prompt (vervangt #105)

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -113,6 +113,10 @@ class AdminPanelProvider extends PanelProvider
                 FilamentCopilotPlugin::make()
                     ->provider('anthropic')
                     ->model('claude-haiku-4-5-20251001')
+                    // De system prompt staat in config/filament-copilot.php. Met een lege
+                    // "extra" prompt voorkomen we dat het package diezelfde config-prompt
+                    // nog een tweede keer als "## Additional Instructions" toevoegt.
+                    ->systemPrompt('')
                     ->rateLimitEnabled()
                     ->memoryEnabled()
                     ->authorizeUsing(fn (): bool => app(AimtrackFeatureToggle::class)->aiEnabled()),

--- a/config/filament-copilot.php
+++ b/config/filament-copilot.php
@@ -121,9 +121,42 @@ return [
     |--------------------------------------------------------------------------
     | System Prompt
     |--------------------------------------------------------------------------
+    | Basis-identiteit van de copilot. Vervangt de generieke "Filament admin
+    | panel assistant"-prompt van het package, zodat de assistent zich als de
+    | AimTrack AI-Coach voorstelt. De operationele richtlijnen (tools,
+    | bevestiging, geheugen) zijn behouden zodat de copilot blijft werken.
     */
 
-    'system_prompt' => null,
+    'system_prompt' => <<<'PROMPT'
+        Je bent de AimTrack AI-Coach: een behulpzame coach-assistent voor schutters en coaches binnen AimTrack. Je helpt gebruikers hun trainingsdata begrijpen, doelen stellen en gerichte feedback krijgen over hun sessies, wapens en techniek.
+
+        Stel jezelf altijd voor als "AimTrack AI-Coach" — nooit als een admin panel-assistent. Antwoord standaard in het Nederlands.
+
+        ## Richtlijnen
+        - Respecteer altijd de rechten van de gebruiker. Voer nooit acties uit waarvoor de gebruiker geen autorisatie heeft.
+        - Bevestig wijzigingen voordat je opslaat, tenzij de gebruiker expliciet vraagt om direct op te slaan.
+        - Geef duidelijke, beknopte en coachende antwoorden.
+        - Als een actie mislukt, leg uit waarom en stel alternatieven voor.
+
+        ## Werken met resources, pagina's en widgets
+        Je hebt globale tools voor ontdekking en uitvoering:
+        - **list_resources** / **list_pages** / **list_widgets** — bekijk wat beschikbaar is
+        - **get_tools** — ontdek de copilot-tools voor een specifieke resource, pagina of widget
+        - **run_tool** — voer een ontdekte tool uit met de vereiste argumenten
+
+        ### Werkwijze
+        1. De context hieronder somt de beschikbare resources, pagina's en widgets met hun beschrijving op.
+        2. Wil je een actie op een resource uitvoeren, gebruik dan **get_tools** met de resource-class om beschikbare tools te ontdekken.
+        3. Gebruik **run_tool** om de specifieke tool met de vereiste argumenten uit te voeren.
+        4. Vereist een tool bevestiging (needToAsk), vraag dit dan altijd eerst aan de gebruiker.
+
+        ## Bevestigingsregels
+        - Tools die "CONFIRMATION REQUIRED" teruggeven, vereisen expliciete bevestiging van de gebruiker voordat je ze opnieuw uitvoert.
+        - Vraag de gebruiker altijd om bevestiging vóór destructieve acties (verwijderen, definitief verwijderen).
+
+        ## Geheugen
+        - Gebruik **remember** / **recall** om voorkeuren van de gebruiker op te slaan en op te halen tussen gesprekken.
+        PROMPT,
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/Filament/Copilot/CopilotSystemPromptTest.php
+++ b/tests/Feature/Filament/Copilot/CopilotSystemPromptTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use EslamRedaDiv\FilamentCopilot\Agent\ContextBuilder;
+use Filament\Facades\Filament;
+
+it('configures the copilot to introduce itself as the AimTrack AI-Coach', function () {
+    $prompt = config('filament-copilot.system_prompt');
+
+    expect($prompt)->toBeString()
+        ->toContain('AimTrack AI-Coach')
+        ->not->toContain('admin panel assistent')
+        ->not->toContain('Filament admin panel assistant');
+});
+
+it('uses the configured coach prompt as the copilot base prompt', function () {
+    $builder = app(ContextBuilder::class);
+
+    $buildBasePrompt = new ReflectionMethod($builder, 'buildBasePrompt');
+    $buildBasePrompt->setAccessible(true);
+
+    expect($buildBasePrompt->invoke($builder))
+        ->toBe(config('filament-copilot.system_prompt'));
+});
+
+it('does not append the config prompt a second time as additional instructions', function () {
+    $plugin = Filament::getPanel('admin')->getPlugin('filament-copilot');
+
+    expect($plugin->getSystemPrompt())->toBe('');
+});


### PR DESCRIPTION
Vervangt #105. Sluit issue niet automatisch — #105 kan handmatig gesloten worden zodra dit gemerged is.

## Wat

`config/filament-copilot.php:126` staat op `'system_prompt' => null`. Het package valt dan
terug op zijn eigen Engelse default in
`vendor/eslam-reda-div/filament-copilot/src/Agent/ContextBuilder.php:83`:

> You are a helpful Filament admin panel assistant. You help users manage their data and
> navigate the admin panel efficiently.

## Wat dit wél en niet is

**Niet** een zichtbaar defect. In de praktijk gedraagt de assistent zich al als coach en
antwoordt hij in het Nederlands, omdat `ContextBuilder::build()` naast de basisprompt de
volledige domeincontext meegeeft — `## Available Resources` met Sessies, Wapens en
Verenigingen, plus de `copilotTools()` uit `app/Filament/Resources/SessionResource.php:531`,
`WeaponResource.php:327` en `app/Filament/Pages/CoachPage.php:60`. Een model dat die context
ziet, leidt de rol zelf af.

**Wel** een afspraak die niet is vastgelegd. De coach-identiteit hangt nu volledig aan die
gevolgtrekking: ze verandert mee met de resourcelabels, het model en de
package-versie, en er is niets dat het tegenhoudt als het package zijn default aanpast. Deze
PR maakt de identiteit expliciet, Nederlands en getest, in plaats van emergent.

Het package gebruikt `config('app.name')` nergens, dus zonder deze wijziging staat het woord
"AimTrack" nergens in de prompt.

## Hoe

- **`config/filament-copilot.php`** — Nederlandse AimTrack AI-Coach-prompt als
  basis-identiteit. De operationele richtlijnen van het package (tool-ontdekking via
  `get_tools`/`run_tool`, bevestigingsregels, `remember`/`recall`) zijn overgenomen, zodat de
  copilot functioneel blijft werken zoals hij deed.
- **`app/Providers/Filament/AdminPanelProvider.php`** — `->systemPrompt('')` op de plugin.
  Dit is nodig, niet cosmetisch: `FilamentCopilotPlugin::getSystemPrompt()` (r. 123-126)
  doet `$this->systemPrompt ?? config('filament-copilot.system_prompt')`. Zonder de lege
  string levert die dus dezelfde config-prompt, die `ContextBuilder` (r. 67-69) er een
  tweede keer achter plakt als `## Additional Instructions`.
- **`tests/Feature/Filament/Copilot/CopilotSystemPromptTest.php`** — 3 tests: de prompt noemt
  zichzelf AimTrack AI-Coach en niet de package-default, `buildBasePrompt()` levert exact de
  config-prompt, en de plugin injecteert hem niet nog een keer.

## Verhouding tot #105

De inhoudelijke wijziging komt ongewijzigd uit #105. Die PR is `DIRTY` omdat hij daarnaast
een import-herschikking in `AdminPanelProvider` meenam die `main` inmiddels zelf heeft
doorgevoerd (`862fcb6`) — puur conflict-ruis. Deze PR zet dezelfde wijziging op een verse
basis, zonder die herschikking.

## Getest

- **466 tests groen** (1278 assertions) — was 463/1272, precies deze 3 erbij.
- `vendor/bin/pint` schoon.

Niet automatisch te toetsen: hoe de coach zich in een echt gesprek voorstelt. Eén handmatige
check in het paneel na merge — hij moet zich als *AimTrack AI-Coach* aandienen.

## Opmerking voor later

`ContextBuilder.php:78` doet `if ($prompt)`, een truthy-check. Een prompt van `''` of `'0'`
valt daardoor stil terug op de package-default. Voor deze PR niet relevant (we zetten een
echte string), maar het is een valkuil als iemand de prompt ooit leeg wil zetten.
