### PR TITLE
harden(security): eigenaarschap van records serverside vastzetten

### DIFF
--- a/app/Filament/Concerns/AssignsOwnerOnCreate.php
+++ b/app/Filament/Concerns/AssignsOwnerOnCreate.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Concerns;
+
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Zet de eigenaar van een nieuw record serverside vast op de ingelogde
+ * gebruiker.
+ *
+ * De vier persoonlijke resources (sessies, wapens, locaties, munitietypes)
+ * haalden user_id eerder uit een Hidden-veld met ->default(auth()->id()).
+ * Een default is echter geen dwang: Filament neemt aan wat er uit het
+ * formulier terugkomt, dus een aangepaste request kon een record op naam van
+ * een ander account wegschrijven.
+ *
+ * Deze hook draait ná de formulierafhandeling en overschrijft user_id
+ * onvoorwaardelijk, dus ook wanneer er onverhoopt weer een invulbaar veld
+ * met die naam in een schema belandt.
+ *
+ * Zie GHSA-w8rm-7p6x-jrrr.
+ */
+trait AssignsOwnerOnCreate
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['user_id'] = Auth::id();
+
+        return $data;
+    }
+}

--- a/app/Filament/Concerns/PreservesOwnerOnSave.php
+++ b/app/Filament/Concerns/PreservesOwnerOnSave.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Concerns;
+
+/**
+ * Houdt de eigenaar van een bestaand record ongewijzigd bij het bewerken.
+ *
+ * SessionPolicy::update() en de zusterpolicies toetsen het eigenaarschap op
+ * het record zoals dat in de database staat. Een wijziging van user_id in
+ * dezelfde request glipt daar dus langs: de controle slaagt op de oude
+ * eigenaar, waarna het record naar een ander account wordt doorgeschoven en
+ * uit het overzicht van de bewerker verdwijnt.
+ *
+ * Door user_id uit de opslagdata te halen blijft de kolom staan zoals hij is.
+ *
+ * Zie GHSA-w8rm-7p6x-jrrr.
+ */
+trait PreservesOwnerOnSave
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        unset($data['user_id']);
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/AmmoTypeResource.php
+++ b/app/Filament/Resources/AmmoTypeResource.php
@@ -6,7 +6,6 @@ use App\Filament\Resources\AmmoTypeResource\Pages\CreateAmmoType;
 use App\Filament\Resources\AmmoTypeResource\Pages\EditAmmoType;
 use App\Filament\Resources\AmmoTypeResource\Pages\ListAmmoTypes;
 use App\Models\AmmoType;
-use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
@@ -34,11 +33,6 @@ class AmmoTypeResource extends Resource
     {
         return $schema
             ->components([
-                Hidden::make('user_id')
-                    ->default(fn () => auth()->id())
-                    ->required()
-                    ->dehydrated(fn ($state) => filled($state)),
-
                 InfoSection::make('Munitietype')
                     ->schema([
                         TextInput::make('name')

--- a/app/Filament/Resources/AmmoTypeResource/Pages/CreateAmmoType.php
+++ b/app/Filament/Resources/AmmoTypeResource/Pages/CreateAmmoType.php
@@ -2,10 +2,13 @@
 
 namespace App\Filament\Resources\AmmoTypeResource\Pages;
 
+use App\Filament\Concerns\AssignsOwnerOnCreate;
 use App\Filament\Resources\AmmoTypeResource;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateAmmoType extends CreateRecord
 {
+    use AssignsOwnerOnCreate;
+
     protected static string $resource = AmmoTypeResource::class;
 }

--- a/app/Filament/Resources/AmmoTypeResource/Pages/EditAmmoType.php
+++ b/app/Filament/Resources/AmmoTypeResource/Pages/EditAmmoType.php
@@ -2,12 +2,15 @@
 
 namespace App\Filament\Resources\AmmoTypeResource\Pages;
 
+use App\Filament\Concerns\PreservesOwnerOnSave;
 use App\Filament\Resources\AmmoTypeResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditAmmoType extends EditRecord
 {
+    use PreservesOwnerOnSave;
+
     protected static string $resource = AmmoTypeResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/LocationResource.php
+++ b/app/Filament/Resources/LocationResource.php
@@ -6,7 +6,6 @@ use App\Filament\Resources\LocationResource\Pages\CreateLocation;
 use App\Filament\Resources\LocationResource\Pages\EditLocation;
 use App\Filament\Resources\LocationResource\Pages\ListLocations;
 use App\Models\Location;
-use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -37,11 +36,6 @@ class LocationResource extends Resource
     {
         return $schema
             ->components([
-                Hidden::make('user_id')
-                    ->default(fn () => auth()->id())
-                    ->required()
-                    ->dehydrated(fn ($state) => filled($state)),
-
                 InfoSection::make('Locatie')
                     ->schema([
                         TextInput::make('name')

--- a/app/Filament/Resources/LocationResource/Pages/CreateLocation.php
+++ b/app/Filament/Resources/LocationResource/Pages/CreateLocation.php
@@ -2,10 +2,13 @@
 
 namespace App\Filament\Resources\LocationResource\Pages;
 
+use App\Filament\Concerns\AssignsOwnerOnCreate;
 use App\Filament\Resources\LocationResource;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateLocation extends CreateRecord
 {
+    use AssignsOwnerOnCreate;
+
     protected static string $resource = LocationResource::class;
 }

--- a/app/Filament/Resources/LocationResource/Pages/EditLocation.php
+++ b/app/Filament/Resources/LocationResource/Pages/EditLocation.php
@@ -2,12 +2,15 @@
 
 namespace App\Filament\Resources\LocationResource\Pages;
 
+use App\Filament\Concerns\PreservesOwnerOnSave;
 use App\Filament\Resources\LocationResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditLocation extends EditRecord
 {
+    use PreservesOwnerOnSave;
+
     protected static string $resource = LocationResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/SessionResource.php
+++ b/app/Filament/Resources/SessionResource.php
@@ -69,7 +69,6 @@ class SessionResource extends Resource implements CopilotResourceContract
         return $schema
             ->columns(1)
             ->components([
-                static::userIdField(),
 
                 InfoSection::make('Sessie')
                     ->description('Basisgegevens van de sessie')
@@ -94,14 +93,6 @@ class SessionResource extends Resource implements CopilotResourceContract
             ]);
     }
 
-    public static function userIdField(): Hidden
-    {
-        return Hidden::make('user_id')
-            ->default(fn () => auth()->id())
-            ->required()
-            ->dehydrated(fn ($state) => filled($state));
-    }
-
     /**
      * Basisvelden van de sessie (zonder notities), herbruikt door de
      * Edit-form en de Range Console nieuwe-sessie wizard (stap Sessie).
@@ -114,6 +105,9 @@ class SessionResource extends Resource implements CopilotResourceContract
             DatePicker::make('date')
                 ->label('Datum')
                 ->native(false)
+                // Een sessie ligt per definitie in het verleden; zonder deze
+                // grens kon een willekeurige datum worden weggeschreven.
+                ->maxDate(fn () => now())
                 ->required(),
             Select::make('range_location_id')
                 ->label('Baan/vereniging')

--- a/app/Filament/Resources/SessionResource/Pages/CreateSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/CreateSession.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SessionResource\Pages;
 
+use App\Filament\Concerns\AssignsOwnerOnCreate;
 use App\Filament\Resources\SessionResource;
 use App\Models\User;
 use Filament\Resources\Pages\CreateRecord;
@@ -14,6 +15,7 @@ use Filament\Support\Icons\Heroicon;
 
 class CreateSession extends CreateRecord
 {
+    use AssignsOwnerOnCreate;
     use HasWizard;
 
     protected static string $resource = SessionResource::class;
@@ -75,7 +77,6 @@ class CreateSession extends CreateRecord
                 ->icon(Heroicon::OutlinedBolt)
                 ->description('Welke wapens gebruik je?')
                 ->schema([
-                    SessionResource::userIdField(),
                     SessionResource::sessionWeaponsRepeater(),
                 ]),
 

--- a/app/Filament/Resources/SessionResource/Pages/EditSession.php
+++ b/app/Filament/Resources/SessionResource/Pages/EditSession.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\SessionResource\Pages;
 
+use App\Filament\Concerns\PreservesOwnerOnSave;
 use App\Filament\Resources\SessionResource;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
@@ -9,6 +10,8 @@ use Filament\Resources\Pages\EditRecord;
 
 class EditSession extends EditRecord
 {
+    use PreservesOwnerOnSave;
+
     protected static string $resource = SessionResource::class;
 
     protected function getHeaderActions(): array

--- a/app/Filament/Resources/WeaponResource.php
+++ b/app/Filament/Resources/WeaponResource.php
@@ -22,7 +22,6 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -63,11 +62,6 @@ class WeaponResource extends Resource implements CopilotResourceContract
     {
         return $schema
             ->components([
-                Hidden::make('user_id')
-                    ->default(fn () => auth()->id())
-                    ->required()
-                    ->dehydrated(fn ($state) => filled($state)),
-
                 InfoSection::make('Basisgegevens')
                     ->columns(2)
                     ->schema([

--- a/app/Filament/Resources/WeaponResource/Pages/CreateWeapon.php
+++ b/app/Filament/Resources/WeaponResource/Pages/CreateWeapon.php
@@ -2,12 +2,15 @@
 
 namespace App\Filament\Resources\WeaponResource\Pages;
 
+use App\Filament\Concerns\AssignsOwnerOnCreate;
 use App\Filament\Resources\WeaponResource;
 use App\Services\WeaponStarterTemplateService;
 use Filament\Resources\Pages\CreateRecord;
 
 class CreateWeapon extends CreateRecord
 {
+    use AssignsOwnerOnCreate;
+
     protected static string $resource = WeaponResource::class;
 
     public function mount(): void

--- a/app/Filament/Resources/WeaponResource/Pages/EditWeapon.php
+++ b/app/Filament/Resources/WeaponResource/Pages/EditWeapon.php
@@ -2,12 +2,15 @@
 
 namespace App\Filament\Resources\WeaponResource\Pages;
 
+use App\Filament\Concerns\PreservesOwnerOnSave;
 use App\Filament\Resources\WeaponResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 
 class EditWeapon extends EditRecord
 {
+    use PreservesOwnerOnSave;
+
     protected static string $resource = WeaponResource::class;
 
     protected function getHeaderActions(): array

--- a/tests/Feature/Filament/RecordOwnershipTest.php
+++ b/tests/Feature/Filament/RecordOwnershipTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use App\Filament\Resources\AmmoTypeResource\Pages\CreateAmmoType;
+use App\Filament\Resources\LocationResource\Pages\CreateLocation;
+use App\Filament\Resources\SessionResource\Pages\CreateSession;
+use App\Filament\Resources\SessionResource\Pages\EditSession;
+use App\Filament\Resources\WeaponResource\Pages\CreateWeapon;
+use App\Filament\Resources\WeaponResource\Pages\EditWeapon;
+use App\Models\AmmoType;
+use App\Models\Location;
+use App\Models\Session;
+use App\Models\User;
+use App\Models\Weapon;
+use Livewire\Livewire;
+
+/*
+ * Regressietests bij GHSA-w8rm-7p6x-jrrr.
+ *
+ * user_id kwam uit een Hidden-veld met ->default(auth()->id()). Een default is
+ * geen dwang: een aangepaste request kon records op naam van een ander account
+ * wegschrijven (aanmaken) of een bestaand record naar een ander account
+ * doorschuiven (bewerken).
+ */
+
+beforeEach(function () {
+    $this->ik = User::factory()->create();
+    $this->slachtoffer = User::factory()->create();
+
+    $this->actingAs($this->ik);
+});
+
+it('negeert een meegestuurd user_id bij het aanmaken van een sessie', function () {
+    Livewire::test(CreateSession::class)
+        ->fillForm([
+            'user_id' => $this->slachtoffer->id,
+            'date' => now()->subDay()->format('Y-m-d'),
+            'sessionWeapons' => [],
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $session = Session::query()->latest('id')->first();
+
+    expect($session->user_id)->toBe($this->ik->id)
+        ->and(Session::query()->where('user_id', $this->slachtoffer->id)->count())->toBe(0);
+});
+
+it('schuift een sessie niet door naar een ander account bij het bewerken', function () {
+    $session = Session::factory()->create([
+        'user_id' => $this->ik->id,
+        'date' => now()->subDay(),
+    ]);
+
+    Livewire::test(EditSession::class, ['record' => $session->getKey()])
+        ->fillForm(['user_id' => $this->slachtoffer->id])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($session->refresh()->user_id)->toBe($this->ik->id);
+});
+
+it('weigert een sessiedatum in de toekomst', function () {
+    Livewire::test(CreateSession::class)
+        ->fillForm([
+            'date' => now()->addYears(4)->format('Y-m-d'),
+            'sessionWeapons' => [],
+            'attachments' => [],
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['date']);
+});
+
+it('negeert een meegestuurd user_id bij het aanmaken van een wapen', function () {
+    Livewire::test(CreateWeapon::class)
+        ->fillForm([
+            'user_id' => $this->slachtoffer->id,
+            'name' => 'Testwapen',
+            'weapon_type' => 'pistool',
+            'caliber' => '9×19 mm',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    expect(Weapon::query()->latest('id')->first()->user_id)->toBe($this->ik->id);
+});
+
+it('schuift een wapen niet door naar een ander account bij het bewerken', function () {
+    $weapon = Weapon::factory()->create([
+        'user_id' => $this->ik->id,
+        'caliber' => '9×19 mm',
+    ]);
+
+    Livewire::test(EditWeapon::class, ['record' => $weapon->getKey()])
+        ->fillForm(['user_id' => $this->slachtoffer->id])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($weapon->refresh()->user_id)->toBe($this->ik->id);
+});
+
+it('negeert een meegestuurd user_id bij het aanmaken van een locatie', function () {
+    Livewire::test(CreateLocation::class)
+        ->fillForm([
+            'user_id' => $this->slachtoffer->id,
+            'name' => 'Testbaan',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    expect(Location::query()->latest('id')->first()->user_id)->toBe($this->ik->id);
+});
+
+it('negeert een meegestuurd user_id bij het aanmaken van een munitietype', function () {
+    Livewire::test(CreateAmmoType::class)
+        ->fillForm([
+            'user_id' => $this->slachtoffer->id,
+            'name' => 'Testmunitie',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    expect(AmmoType::query()->latest('id')->first()->user_id)->toBe($this->ik->id);
+});
+
+it('biedt user_id niet langer als formulierveld aan', function () {
+    $schemas = [
+        App\Filament\Resources\WeaponResource::class,
+        App\Filament\Resources\LocationResource::class,
+        App\Filament\Resources\AmmoTypeResource::class,
+    ];
+
+    foreach ($schemas as $resource) {
+        expect(file_get_contents((new ReflectionClass($resource))->getFileName()))
+            ->not->toContain("Hidden::make('user_id')");
+    }
+});


### PR DESCRIPTION
## Wat

`user_id` kwam bij sessies, wapens, locaties en munitietypes uit een `Hidden`-formulierveld met `->default(auth()->id())`. Een default is geen dwang — Filament nam over wat er uit het formulier terugkwam, dus de waarde was client-stuurbaar.

Bij het bewerken speelde hetzelfde langs een andere weg: de policy toetst het eigenaarschap op het record zoals dat in de database staat, dus een wijziging van `user_id` binnen diezelfde request glipte er ongezien langs.

## Hoe

- Twee concerns in `app/Filament/Concerns/`:
  - `AssignsOwnerOnCreate` zet `user_id` bij het aanmaken onvoorwaardelijk op de ingelogde gebruiker.
  - `PreservesOwnerOnSave` haalt `user_id` uit de opslagdata bij het bewerken, zodat de kolom blijft staan zoals hij is.

  Toegepast op de acht Create/Edit-pagina's van `SessionResource`, `WeaponResource`, `LocationResource` en `AmmoTypeResource`.
- Het `Hidden`-veld `user_id` is uit alle vier de formulieren verdwenen, dus de waarde komt niet langer uit clientinvoer. `SessionResource::userIdField()` werd daarmee overbodig en is verwijderd.
- De sessiedatum is begrensd met `->maxDate(now())`. Een sessie ligt per definitie in het verleden.

De hooks staan bewust **náást** het weghalen van het veld. Mocht er ooit weer een invulbaar `user_id` in een schema belanden, dan blijft het eigenaarschap kloppen.

## Getest

8 nieuwe tests in `tests/Feature/Filament/RecordOwnershipTest.php`:

| Scenario | Resources |
|---|---|
| Aanmaken met een vreemd `user_id` → record is van de ingelogde gebruiker | sessie, wapen, locatie, munitietype |
| Bewerken met een vreemd `user_id` → eigenaar blijft ongewijzigd | sessie, wapen |
| Datum in de toekomst → validatiefout | sessie |
| `Hidden::make('user_id')` staat niet meer in de schema's | wapen, locatie, munitietype |

- Volledige suite: **471 passed** (1305 assertions), was 463. Geen regressies.
- Pint schoon.

## Uitrol

Geen handmatige stappen — puur applicatiecode, geen configuratie of migratie.

### Controleer wel of bestaande data vervuild is

Deze fix sluit het gat, maar ruimt niets op. Draai na de deploy op productie:

```bash
php artisan tinker --execute="
  \App\Models\Session::query()
    ->whereDate('date', '>', now())
    ->get(['id','user_id','date','created_at'])
    ->each(fn(\$s) => print(\"sessie {\$s->id} · user {\$s->user_id} · datum {\$s->date} · aangemaakt {\$s->created_at}\n\"));
"
```

Sessies met een datum in de toekomst zijn het duidelijkste signaal; die konden vóór deze PR gewoon worden weggeschreven. Vind je niets, dan is er geen aanwijzing dat het gat is gebruikt.

Achtergrond en reproductie staan in de bijbehorende private security advisory.